### PR TITLE
ci: cancel in-progress integration tests

### DIFF
--- a/.github/workflows/autoware-integration.yml
+++ b/.github/workflows/autoware-integration.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/autoware-integration.yml
+++ b/.github/workflows/autoware-integration.yml
@@ -4,8 +4,11 @@ on:
   push:
     branches: [devel]
   pull_request:
-    branches: [devel]
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   integration:


### PR DESCRIPTION
## Summary
- Add `concurrency` group to Autoware integration workflow so new pushes cancel previous runs (saves ~1h of CI time)
- Remove `branches: [devel]` restriction on `pull_request` trigger so integration tests run for PRs targeting any branch

## Test plan
- [x] Verify workflow triggers on this PR
- [x] Push a follow-up commit to confirm the previous run gets cancelled

🤖 Generated with [Claude Code](https://claude.com/claude-code)