### PR TITLE
fix: harden build workflow and resolve pipeline

### DIFF
--- a/crates/launch-plus-cli/src/main.rs
+++ b/crates/launch-plus-cli/src/main.rs
@@ -389,6 +389,10 @@ enum Commands {
         #[arg(long, default_value = "install")]
         install_base: String,
 
+        /// Colcon log directory
+        #[arg(long, default_value = "log")]
+        log_base: String,
+
         /// Path to a colcon flagfile (one token per line, # comments allowed).
         ///
         /// The file contents are inserted verbatim into `colcon build` before
@@ -459,6 +463,10 @@ enum Commands {
         /// Colcon install prefix
         #[arg(long, default_value = "install")]
         install_base: String,
+
+        /// Colcon log directory
+        #[arg(long, default_value = "log")]
+        log_base: String,
 
         /// Path to a colcon flagfile (one token per line, # comments allowed).
         /// See `build --colcon-flagfile` for details.
@@ -545,6 +553,10 @@ enum Commands {
         /// Colcon install prefix
         #[arg(long, default_value = "install")]
         install_base: String,
+
+        /// Colcon log directory
+        #[arg(long, default_value = "log")]
+        log_base: String,
 
         /// Path to a colcon flagfile (one token per line, # comments allowed).
         /// See `build --colcon-flagfile` for details.
@@ -789,6 +801,7 @@ fn main() -> Result<()> {
             rosdep,
             build_base,
             install_base,
+            log_base,
             colcon_flagfile,
             dry_run,
         } => {
@@ -818,6 +831,7 @@ fn main() -> Result<()> {
                 workflow_options,
                 &build_base,
                 &install_base,
+                &log_base,
                 BuildOptions {
                     dry_run,
                     extra_colcon_args,
@@ -836,6 +850,7 @@ fn main() -> Result<()> {
             shallow,
             build_base,
             install_base,
+            log_base,
             colcon_flagfile,
             rosdep,
             dry_run,
@@ -870,6 +885,7 @@ fn main() -> Result<()> {
                 src_path,
                 std::path::Path::new(&build_base),
                 std::path::Path::new(&install_base),
+                std::path::Path::new(&log_base),
                 &fetch_options,
                 false, // test_mode
             )?;
@@ -921,6 +937,7 @@ fn main() -> Result<()> {
             rosdep,
             build_base,
             install_base,
+            log_base,
             colcon_flagfile,
             dry_run,
         } => {
@@ -950,6 +967,7 @@ fn main() -> Result<()> {
                 workflow_options,
                 &build_base,
                 &install_base,
+                &log_base,
                 BuildOptions {
                     dry_run,
                     extra_colcon_args,
@@ -1444,7 +1462,7 @@ fn parse_workspace_state(clean: bool, dirty: bool) -> Result<WorkspaceState> {
 /// The following flags are always managed by launch-plus and must **not** appear
 /// in the flagfile (an error is returned if they do):
 /// - `--packages-*` (e.g. `--packages-select`, `--packages-up-to`, `--packages-skip`)
-/// - `--base-paths`, `--build-base`, `--install-base`
+/// - `--base-paths`, `--build-base`, `--install-base`, `--log-base`
 ///
 /// Example file:
 /// ```text
@@ -1473,6 +1491,7 @@ fn read_colcon_flagfile(path: &str) -> Result<Vec<String>> {
             || token == "--base-paths"
             || token == "--build-base"
             || token == "--install-base"
+            || token == "--log-base"
         {
             anyhow::bail!(
                 "colcon flagfile {path:?}: '{}' conflicts with a launch-plus-managed \
@@ -1497,6 +1516,7 @@ fn run_build(
     workflow_options: ResolveWorkflowOptions,
     build_base: &str,
     install_base: &str,
+    log_base: &str,
     build_options: BuildOptions,
     test_mode: bool,
     verbose: bool,
@@ -1538,6 +1558,7 @@ fn run_build(
         fetch_path,
         Path::new(build_base),
         Path::new(install_base),
+        Path::new(log_base),
         &fetch_options,
         test_mode,
     )

--- a/crates/launch-plus-core/src/builder.rs
+++ b/crates/launch-plus-core/src/builder.rs
@@ -49,6 +49,8 @@ pub struct BuildPlan {
     pub build_base: PathBuf,
     /// Colcon install prefix (`--install-base`).
     pub install_base: PathBuf,
+    /// Colcon log directory (`--log-base`).
+    pub log_base: PathBuf,
 }
 
 /// Options controlling how the build is executed.
@@ -85,6 +87,7 @@ pub fn plan_build_from_packages(
     src_dir: &Path,
     build_base: &Path,
     install_base: &Path,
+    log_base: &Path,
     fetch_options: &FetchOptions,
     test_mode: bool,
 ) -> crate::Result<BuildPlan> {
@@ -127,6 +130,7 @@ pub fn plan_build_from_packages(
         src_dir: src_dir.to_path_buf(),
         build_base: build_base.to_path_buf(),
         install_base: install_base.to_path_buf(),
+        log_base: log_base.to_path_buf(),
     })
 }
 
@@ -140,7 +144,12 @@ pub fn execute_build(plan: &BuildPlan, options: &BuildOptions) -> crate::Result<
         return Ok(());
     }
 
-    let mut args: Vec<String> = vec!["build".to_string()];
+    // --log-base is a colcon global argument (before the verb).
+    let mut args: Vec<String> = vec![
+        "--log-base".to_string(),
+        plan.log_base.to_string_lossy().into_owned(),
+        "build".to_string(),
+    ];
 
     args.push("--base-paths".to_string());
     args.push(plan.src_dir.to_string_lossy().into_owned());

--- a/crates/launch-plus-core/src/indexer.rs
+++ b/crates/launch-plus-core/src/indexer.rs
@@ -461,24 +461,28 @@ mod condition {
         Ok(tokens)
     }
 
-    /// Resolve a term token to its string value.
-    fn resolve_term(token: &Token) -> Result<String, String> {
-        match token {
-            Token::Var(name) => Ok(std::env::var(name).unwrap_or_default()),
-            Token::Literal(s) => Ok(s.clone()),
-            other => Err(format!("expected term, got {other:?}")),
-        }
-    }
-
     /// Recursive-descent parser and evaluator.
-    struct Parser {
+    struct Parser<F: Fn(&str) -> String> {
         tokens: Vec<Token>,
         pos: usize,
+        env_lookup: F,
     }
 
-    impl Parser {
-        fn new(tokens: Vec<Token>) -> Self {
-            Self { tokens, pos: 0 }
+    impl<F: Fn(&str) -> String> Parser<F> {
+        fn new(tokens: Vec<Token>, env_lookup: F) -> Self {
+            Self {
+                tokens,
+                pos: 0,
+                env_lookup,
+            }
+        }
+
+        fn resolve_term(&self, token: &Token) -> Result<String, String> {
+            match token {
+                Token::Var(name) => Ok((self.env_lookup)(name)),
+                Token::Literal(s) => Ok(s.clone()),
+                other => Err(format!("expected term, got {other:?}")),
+            }
         }
 
         fn peek(&self) -> Option<&Token> {
@@ -536,7 +540,7 @@ mod condition {
         /// comparison = term cmp_op term
         fn parse_comparison(&mut self) -> Result<bool, String> {
             let lhs_token = self.next().cloned().ok_or("expected term")?;
-            let lhs = resolve_term(&lhs_token)?;
+            let lhs = self.resolve_term(&lhs_token)?;
 
             let op = match self.next() {
                 Some(Token::CmpOp(op)) => *op,
@@ -546,19 +550,18 @@ mod condition {
             };
 
             let rhs_token = self.next().cloned().ok_or("expected term after operator")?;
-            let rhs = resolve_term(&rhs_token)?;
+            let rhs = self.resolve_term(&rhs_token)?;
 
             Ok(op.eval(&lhs, &rhs))
         }
     }
 
-    /// Evaluate a REP-149 condition expression against the current environment.
-    pub fn evaluate(condition: &str) -> Result<bool, String> {
+    fn evaluate_impl(condition: &str, env_lookup: impl Fn(&str) -> String) -> Result<bool, String> {
         let tokens = tokenize(condition)?;
         if tokens.is_empty() {
             return Ok(true);
         }
-        let mut parser = Parser::new(tokens);
+        let mut parser = Parser::new(tokens, env_lookup);
         let result = parser.parse_expr()?;
         if parser.pos != parser.tokens.len() {
             return Err(format!(
@@ -569,13 +572,20 @@ mod condition {
         Ok(result)
     }
 
+    /// Evaluate a REP-149 condition expression against the current environment.
+    pub fn evaluate(condition: &str) -> Result<bool, String> {
+        evaluate_impl(condition, |name| std::env::var(name).unwrap_or_default())
+    }
+
     #[cfg(test)]
     mod tests {
         use super::*;
+        use std::collections::HashMap;
 
-        /// Helper: evaluate with known env.  We can't set env vars safely,
-        /// so we test tokenizer + parser logic using literals only, plus
-        /// a few tests that rely on unset vars (→ empty string).
+        /// Evaluate with an injected env map — no dependence on real env vars.
+        fn eval_with(condition: &str, env: &HashMap<&str, &str>) -> Result<bool, String> {
+            evaluate_impl(condition, |name| env.get(name).unwrap_or(&"").to_string())
+        }
         #[test]
         fn simple_eq_true() {
             assert!(evaluate("1 == 1").unwrap());
@@ -646,9 +656,9 @@ mod condition {
 
         #[test]
         fn unset_var_is_empty_string() {
-            // _LAUNCH_PLUS_UNSET_VAR_ should not exist
-            assert!(evaluate("$_LAUNCH_PLUS_UNSET_VAR_ == ''").unwrap());
-            assert!(!evaluate("$_LAUNCH_PLUS_UNSET_VAR_ == 1").unwrap());
+            let env = HashMap::new(); // no vars set
+            assert!(eval_with("$MISSING_VAR == ''", &env).unwrap());
+            assert!(!eval_with("$MISSING_VAR == 1", &env).unwrap());
         }
 
         #[test]
@@ -1675,30 +1685,29 @@ repositories:
 
     #[test]
     fn test_parse_package_xml_condition_filters_deps() {
-        // Use a test-specific env var that won't collide.
-        // In CI/test env, LAUNCH_PLUS_TEST_COND is unset → "" != "yes" is true,
-        // "" == "yes" is false.
+        // Use literal-only conditions to avoid env-var dependence.
+        // Env-var resolution is tested in the condition module via eval_with().
         let content = r#"<?xml version="1.0"?>
 <package format="3">
   <name>test_pkg</name>
-  <buildtool_depend condition="$LAUNCH_PLUS_TEST_COND == yes">conditional_dep</buildtool_depend>
-  <buildtool_depend condition="$LAUNCH_PLUS_TEST_COND != yes">fallback_dep</buildtool_depend>
+  <buildtool_depend condition="1 == 2">excluded_dep</buildtool_depend>
+  <buildtool_depend condition="1 == 1">included_dep</buildtool_depend>
   <depend>unconditional_dep</depend>
 </package>
 "#;
         let info = parse_package_xml(content, "test").unwrap();
-        // LAUNCH_PLUS_TEST_COND is unset → "" == "yes" is false → excluded
+        // 1 == 2 is false → excluded
         assert!(
             !info
                 .dependencies
                 .buildtool
-                .contains(&"conditional_dep".to_string())
+                .contains(&"excluded_dep".to_string())
         );
-        // "" != "yes" is true → included
+        // 1 == 1 is true → included
         assert!(
             info.dependencies
                 .buildtool
-                .contains(&"fallback_dep".to_string())
+                .contains(&"included_dep".to_string())
         );
         // Unconditional deps always included
         assert!(

--- a/crates/launch-plus-core/src/indexer.rs
+++ b/crates/launch-plus-core/src/indexer.rs
@@ -274,7 +274,10 @@ fn evaluate_condition(element: &quick_xml::events::BytesStart) -> bool {
         .flatten()
         .find(|a| a.key.as_ref() == b"condition")
     {
-        Some(attr) => String::from_utf8_lossy(&attr.value).to_string(),
+        Some(attr) => match attr.unescape_value() {
+            Ok(val) => val.into_owned(),
+            Err(_) => String::from_utf8_lossy(&attr.value).into_owned(),
+        },
         None => return true, // no condition → always include
     };
 

--- a/crates/launch-plus-core/src/indexer.rs
+++ b/crates/launch-plus-core/src/indexer.rs
@@ -256,6 +256,420 @@ pub struct PackageInfo {
     pub dependencies: Dependencies,
 }
 
+/// Evaluate a REP-149 `condition` attribute on a dependency element.
+///
+/// Returns `true` if the dependency should be included (no condition, or
+/// condition evaluates to true).
+///
+/// Implements the full REP-149 condition grammar:
+/// - Comparison operators: `==`, `!=`, `<`, `<=`, `>`, `>=` (string comparison)
+/// - Logical operators: `and`, `or` (left-associative, `and` binds tighter)
+/// - Parentheses for grouping
+/// - Terms: `$VAR` (env variable), bare words (alphanums/`_`/`-`), quoted strings
+///
+/// Reference: <https://ros.org/reps/rep-0149.html#condition>
+fn evaluate_condition(element: &quick_xml::events::BytesStart) -> bool {
+    let condition = match element
+        .attributes()
+        .flatten()
+        .find(|a| a.key.as_ref() == b"condition")
+    {
+        Some(attr) => String::from_utf8_lossy(&attr.value).to_string(),
+        None => return true, // no condition → always include
+    };
+
+    match condition::evaluate(&condition) {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::warn!("failed to evaluate condition '{condition}': {e}; including dependency");
+            true
+        }
+    }
+}
+
+/// REP-149 condition expression evaluator.
+///
+/// Grammar (informal):
+/// ```text
+/// expr       = or_expr
+/// or_expr    = and_expr ('or' and_expr)*
+/// and_expr   = atom ('and' atom)*
+/// atom       = '(' expr ')' | comparison
+/// comparison = term cmp_op term
+/// cmp_op     = '==' | '!=' | '<=' | '>=' | '<' | '>'
+/// term       = variable | quoted_string | bare_word
+/// variable   = '$' [A-Za-z0-9_]+
+/// bare_word  = [A-Za-z0-9_-]+
+/// ```
+mod condition {
+    /// Tokens produced by the lexer.
+    #[derive(Debug, Clone, PartialEq)]
+    enum Token {
+        /// `$VAR` — resolved to env value at eval time
+        Var(String),
+        /// Bare word or quoted string literal
+        Literal(String),
+        /// Comparison operator
+        CmpOp(CmpOp),
+        And,
+        Or,
+        LParen,
+        RParen,
+    }
+
+    #[derive(Debug, Clone, Copy, PartialEq)]
+    enum CmpOp {
+        Eq,
+        Ne,
+        Lt,
+        Le,
+        Gt,
+        Ge,
+    }
+
+    impl CmpOp {
+        fn eval(self, lhs: &str, rhs: &str) -> bool {
+            match self {
+                CmpOp::Eq => lhs == rhs,
+                CmpOp::Ne => lhs != rhs,
+                CmpOp::Lt => lhs < rhs,
+                CmpOp::Le => lhs <= rhs,
+                CmpOp::Gt => lhs > rhs,
+                CmpOp::Ge => lhs >= rhs,
+            }
+        }
+    }
+
+    /// Tokenize a condition string.
+    fn tokenize(input: &str) -> Result<Vec<Token>, String> {
+        let mut tokens = Vec::new();
+        let chars: Vec<char> = input.chars().collect();
+        let mut i = 0;
+
+        while i < chars.len() {
+            // Skip whitespace
+            if chars[i].is_ascii_whitespace() {
+                i += 1;
+                continue;
+            }
+
+            // Parentheses
+            if chars[i] == '(' {
+                tokens.push(Token::LParen);
+                i += 1;
+                continue;
+            }
+            if chars[i] == ')' {
+                tokens.push(Token::RParen);
+                i += 1;
+                continue;
+            }
+
+            // Comparison operators (check two-char first)
+            if i + 1 < chars.len() {
+                let two: String = chars[i..=i + 1].iter().collect();
+                match two.as_str() {
+                    "==" => {
+                        tokens.push(Token::CmpOp(CmpOp::Eq));
+                        i += 2;
+                        continue;
+                    }
+                    "!=" => {
+                        tokens.push(Token::CmpOp(CmpOp::Ne));
+                        i += 2;
+                        continue;
+                    }
+                    "<=" => {
+                        tokens.push(Token::CmpOp(CmpOp::Le));
+                        i += 2;
+                        continue;
+                    }
+                    ">=" => {
+                        tokens.push(Token::CmpOp(CmpOp::Ge));
+                        i += 2;
+                        continue;
+                    }
+                    _ => {}
+                }
+            }
+            if chars[i] == '<' {
+                tokens.push(Token::CmpOp(CmpOp::Lt));
+                i += 1;
+                continue;
+            }
+            if chars[i] == '>' {
+                tokens.push(Token::CmpOp(CmpOp::Gt));
+                i += 1;
+                continue;
+            }
+
+            // Variable: $[A-Za-z0-9_]+
+            if chars[i] == '$' {
+                let start = i + 1;
+                i += 1;
+                while i < chars.len() && (chars[i].is_ascii_alphanumeric() || chars[i] == '_') {
+                    i += 1;
+                }
+                if i == start {
+                    return Err("empty variable name after '$'".to_string());
+                }
+                let name: String = chars[start..i].iter().collect();
+                tokens.push(Token::Var(name));
+                continue;
+            }
+
+            // Quoted string
+            if chars[i] == '"' || chars[i] == '\'' {
+                let quote = chars[i];
+                i += 1;
+                let start = i;
+                while i < chars.len() && chars[i] != quote {
+                    i += 1;
+                }
+                if i >= chars.len() {
+                    return Err(format!("unterminated {quote}-quoted string"));
+                }
+                let s: String = chars[start..i].iter().collect();
+                tokens.push(Token::Literal(s));
+                i += 1; // skip closing quote
+                continue;
+            }
+
+            // Bare word: alphanums, underscore, dash
+            if chars[i].is_ascii_alphanumeric() || chars[i] == '_' || chars[i] == '-' {
+                let start = i;
+                while i < chars.len()
+                    && (chars[i].is_ascii_alphanumeric() || chars[i] == '_' || chars[i] == '-')
+                {
+                    i += 1;
+                }
+                let word: String = chars[start..i].iter().collect();
+                match word.as_str() {
+                    "and" => tokens.push(Token::And),
+                    "or" => tokens.push(Token::Or),
+                    _ => tokens.push(Token::Literal(word)),
+                }
+                continue;
+            }
+
+            return Err(format!("unexpected character '{}'", chars[i]));
+        }
+
+        Ok(tokens)
+    }
+
+    /// Resolve a term token to its string value.
+    fn resolve_term(token: &Token) -> Result<String, String> {
+        match token {
+            Token::Var(name) => Ok(std::env::var(name).unwrap_or_default()),
+            Token::Literal(s) => Ok(s.clone()),
+            other => Err(format!("expected term, got {other:?}")),
+        }
+    }
+
+    /// Recursive-descent parser and evaluator.
+    struct Parser {
+        tokens: Vec<Token>,
+        pos: usize,
+    }
+
+    impl Parser {
+        fn new(tokens: Vec<Token>) -> Self {
+            Self { tokens, pos: 0 }
+        }
+
+        fn peek(&self) -> Option<&Token> {
+            self.tokens.get(self.pos)
+        }
+
+        fn next(&mut self) -> Option<&Token> {
+            let t = self.tokens.get(self.pos);
+            if t.is_some() {
+                self.pos += 1;
+            }
+            t
+        }
+
+        /// expr = or_expr
+        fn parse_expr(&mut self) -> Result<bool, String> {
+            self.parse_or()
+        }
+
+        /// or_expr = and_expr ('or' and_expr)*
+        fn parse_or(&mut self) -> Result<bool, String> {
+            let mut result = self.parse_and()?;
+            while self.peek() == Some(&Token::Or) {
+                self.next();
+                let rhs = self.parse_and()?;
+                result = result || rhs;
+            }
+            Ok(result)
+        }
+
+        /// and_expr = atom ('and' atom)*
+        fn parse_and(&mut self) -> Result<bool, String> {
+            let mut result = self.parse_atom()?;
+            while self.peek() == Some(&Token::And) {
+                self.next();
+                let rhs = self.parse_atom()?;
+                result = result && rhs;
+            }
+            Ok(result)
+        }
+
+        /// atom = '(' expr ')' | comparison
+        fn parse_atom(&mut self) -> Result<bool, String> {
+            if self.peek() == Some(&Token::LParen) {
+                self.next(); // consume '('
+                let result = self.parse_expr()?;
+                if self.next() != Some(&Token::RParen) {
+                    return Err("expected ')'".to_string());
+                }
+                return Ok(result);
+            }
+            self.parse_comparison()
+        }
+
+        /// comparison = term cmp_op term
+        fn parse_comparison(&mut self) -> Result<bool, String> {
+            let lhs_token = self.next().cloned().ok_or("expected term")?;
+            let lhs = resolve_term(&lhs_token)?;
+
+            let op = match self.next() {
+                Some(Token::CmpOp(op)) => *op,
+                other => {
+                    return Err(format!("expected comparison operator, got {other:?}"));
+                }
+            };
+
+            let rhs_token = self.next().cloned().ok_or("expected term after operator")?;
+            let rhs = resolve_term(&rhs_token)?;
+
+            Ok(op.eval(&lhs, &rhs))
+        }
+    }
+
+    /// Evaluate a REP-149 condition expression against the current environment.
+    pub fn evaluate(condition: &str) -> Result<bool, String> {
+        let tokens = tokenize(condition)?;
+        if tokens.is_empty() {
+            return Ok(true);
+        }
+        let mut parser = Parser::new(tokens);
+        let result = parser.parse_expr()?;
+        if parser.pos != parser.tokens.len() {
+            return Err(format!(
+                "unexpected token at position {}: {:?}",
+                parser.pos, parser.tokens[parser.pos]
+            ));
+        }
+        Ok(result)
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        /// Helper: evaluate with known env.  We can't set env vars safely,
+        /// so we test tokenizer + parser logic using literals only, plus
+        /// a few tests that rely on unset vars (→ empty string).
+        #[test]
+        fn simple_eq_true() {
+            assert!(evaluate("1 == 1").unwrap());
+        }
+
+        #[test]
+        fn simple_eq_false() {
+            assert!(!evaluate("1 == 2").unwrap());
+        }
+
+        #[test]
+        fn simple_ne() {
+            assert!(evaluate("1 != 2").unwrap());
+            assert!(!evaluate("1 != 1").unwrap());
+        }
+
+        #[test]
+        fn string_comparison_operators() {
+            // String comparison: "a" < "b"
+            assert!(evaluate("a < b").unwrap());
+            assert!(evaluate("a <= b").unwrap());
+            assert!(evaluate("a <= a").unwrap());
+            assert!(evaluate("b > a").unwrap());
+            assert!(evaluate("b >= a").unwrap());
+            assert!(evaluate("b >= b").unwrap());
+            assert!(!evaluate("b < a").unwrap());
+        }
+
+        #[test]
+        fn logical_and() {
+            assert!(evaluate("1 == 1 and 2 == 2").unwrap());
+            assert!(!evaluate("1 == 1 and 1 == 2").unwrap());
+        }
+
+        #[test]
+        fn logical_or() {
+            assert!(evaluate("1 == 2 or 2 == 2").unwrap());
+            assert!(!evaluate("1 == 2 or 3 == 4").unwrap());
+        }
+
+        #[test]
+        fn and_binds_tighter_than_or() {
+            // "1==2 and 1==1 or 2==2" → (false and true) or true → true
+            assert!(evaluate("1 == 2 and 1 == 1 or 2 == 2").unwrap());
+            // "1==1 or 1==2 and 1==2" → true or (false and false) → true
+            assert!(evaluate("1 == 1 or 1 == 2 and 1 == 2").unwrap());
+        }
+
+        #[test]
+        fn parentheses() {
+            // Without parens: "1==1 or 1==2 and 1==2" → true (or short-circuits)
+            // With parens: "(1==1 or 1==2) and 1==2" → true and false → false
+            assert!(!evaluate("(1 == 1 or 1 == 2) and 1 == 2").unwrap());
+        }
+
+        #[test]
+        fn quoted_strings() {
+            assert!(evaluate(r#""hello" == "hello""#).unwrap());
+            assert!(!evaluate(r#""hello" == "world""#).unwrap());
+            assert!(evaluate("'foo' == 'foo'").unwrap());
+        }
+
+        #[test]
+        fn bare_word_with_dash() {
+            assert!(evaluate("my-value == my-value").unwrap());
+            assert!(!evaluate("my-value == other-value").unwrap());
+        }
+
+        #[test]
+        fn unset_var_is_empty_string() {
+            // _LAUNCH_PLUS_UNSET_VAR_ should not exist
+            assert!(evaluate("$_LAUNCH_PLUS_UNSET_VAR_ == ''").unwrap());
+            assert!(!evaluate("$_LAUNCH_PLUS_UNSET_VAR_ == 1").unwrap());
+        }
+
+        #[test]
+        fn nested_parentheses() {
+            assert!(evaluate("((1 == 1))").unwrap());
+        }
+
+        #[test]
+        fn empty_condition() {
+            assert!(evaluate("").unwrap());
+        }
+
+        #[test]
+        fn error_on_garbage() {
+            assert!(evaluate("@#!").is_err());
+        }
+
+        #[test]
+        fn error_on_unbalanced_paren() {
+            assert!(evaluate("(1 == 1").is_err());
+        }
+    }
+}
+
 /// Parse package.xml content to extract package information
 ///
 /// # Arguments
@@ -271,12 +685,19 @@ pub fn parse_package_xml(content: &str, path: &str) -> crate::Result<PackageInfo
     let mut name = String::new();
     let mut dependencies = Dependencies::default();
     let mut current_tag = String::new();
+    let mut skip_current = false;
     let mut buf = Vec::new();
 
     loop {
         match reader.read_event_into(&mut buf) {
             Ok(Event::Start(e)) => {
                 current_tag = String::from_utf8_lossy(e.name().as_ref()).to_string();
+                // REP-149 §3: evaluate condition="$VAR == value" attributes.
+                // Dependencies whose condition evaluates to false are skipped.
+                skip_current = !evaluate_condition(&e);
+            }
+            Ok(Event::Text(_)) if skip_current => {
+                // Condition evaluated to false — skip this dependency.
             }
             Ok(Event::Text(e)) => {
                 let text = e.unescape().map_err(|err| {
@@ -1247,5 +1668,60 @@ repositories:
 "#;
         let result = parse_package_xml(content, "test");
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_parse_package_xml_condition_filters_deps() {
+        // Use a test-specific env var that won't collide.
+        // In CI/test env, LAUNCH_PLUS_TEST_COND is unset → "" != "yes" is true,
+        // "" == "yes" is false.
+        let content = r#"<?xml version="1.0"?>
+<package format="3">
+  <name>test_pkg</name>
+  <buildtool_depend condition="$LAUNCH_PLUS_TEST_COND == yes">conditional_dep</buildtool_depend>
+  <buildtool_depend condition="$LAUNCH_PLUS_TEST_COND != yes">fallback_dep</buildtool_depend>
+  <depend>unconditional_dep</depend>
+</package>
+"#;
+        let info = parse_package_xml(content, "test").unwrap();
+        // LAUNCH_PLUS_TEST_COND is unset → "" == "yes" is false → excluded
+        assert!(
+            !info
+                .dependencies
+                .buildtool
+                .contains(&"conditional_dep".to_string())
+        );
+        // "" != "yes" is true → included
+        assert!(
+            info.dependencies
+                .buildtool
+                .contains(&"fallback_dep".to_string())
+        );
+        // Unconditional deps always included
+        assert!(
+            info.dependencies
+                .build
+                .contains(&"unconditional_dep".to_string())
+        );
+    }
+
+    #[test]
+    fn test_parse_package_xml_no_condition_includes_all() {
+        let content = r#"<?xml version="1.0"?>
+<package format="3">
+  <name>test_pkg</name>
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <build_depend>rclcpp</build_depend>
+  <exec_depend>std_msgs</exec_depend>
+</package>
+"#;
+        let info = parse_package_xml(content, "test").unwrap();
+        assert!(
+            info.dependencies
+                .buildtool
+                .contains(&"ament_cmake".to_string())
+        );
+        assert!(info.dependencies.build.contains(&"rclcpp".to_string()));
+        assert!(info.dependencies.exec.contains(&"std_msgs".to_string()));
     }
 }

--- a/crates/launch-plus-core/src/rosdep.rs
+++ b/crates/launch-plus-core/src/rosdep.rs
@@ -11,8 +11,10 @@
 //! use case of installing an explicit set of rosdep keys extracted from the
 //! dependency graph.
 //!
-//! Only `#apt` and `#pip` installers are supported.  Keys that resolve to
-//! other installers (e.g. `#brew`) are treated as unresolved.
+//! Only `#apt` and `#pip` installers are supported.  Keys that resolve
+//! *exclusively* to unsupported installers (e.g. `#brew`) are treated as
+//! unresolved.  If a key has both supported and unsupported installers,
+//! the supported packages are installed and the key is considered resolved.
 
 use std::collections::{BTreeSet, HashSet};
 use std::process::Command;

--- a/crates/launch-plus-core/src/rosdep.rs
+++ b/crates/launch-plus-core/src/rosdep.rs
@@ -14,13 +14,14 @@
 //! Only `#apt` and `#pip` installers are supported.  Keys that resolve to
 //! other installers (e.g. `#brew`) are treated as unresolved.
 
-use std::collections::HashSet;
+use std::collections::{BTreeSet, HashSet};
 use std::process::Command;
-use std::sync::Once;
+use std::sync::{Once, OnceLock};
 
 use tracing::info;
 
 static ROSDEP_UPDATE: Once = Once::new();
+static INSTALLED_PACKAGES: OnceLock<HashSet<String>> = OnceLock::new();
 
 /// Run `rosdep update` once per process (best-effort, non-fatal).
 pub fn ensure_rosdep_updated() {
@@ -280,7 +281,8 @@ pub fn rosdep_install(keys: &[&str]) -> crate::Result<()> {
     }
 
     // Filter out keys that are already installed as ROS packages.
-    let installed = installed_packages();
+    // Cached per-process: the orchestrator may call rosdep_install() many times.
+    let installed = INSTALLED_PACKAGES.get_or_init(installed_packages);
     let mut filtered: Vec<&str> = keys
         .iter()
         .copied()
@@ -314,17 +316,17 @@ pub fn rosdep_install(keys: &[&str]) -> crate::Result<()> {
         )));
     }
 
-    // Deduplicate
+    // Deduplicate — BTreeSet gives sorted, deterministic install order.
     let apt_pkgs: Vec<String> = resolved
         .apt
         .into_iter()
-        .collect::<HashSet<_>>()
+        .collect::<BTreeSet<_>>()
         .into_iter()
         .collect();
     let pip_pkgs: Vec<String> = resolved
         .pip
         .into_iter()
-        .collect::<HashSet<_>>()
+        .collect::<BTreeSet<_>>()
         .into_iter()
         .collect();
 

--- a/crates/launch-plus-core/src/rosdep.rs
+++ b/crates/launch-plus-core/src/rosdep.rs
@@ -1,11 +1,18 @@
 //! Shared helpers for invoking `rosdep` from both the resolver and builder.
 //!
-//! Uses `rosdep resolve` to map rosdep keys to system package names,
-//! then installs via `apt` or `pip` directly.  This avoids `rosdep install`
-//! entirely — callers control exactly which packages are installed.
+//! Uses `rosdep resolve` to map rosdep keys → system package names, then
+//! installs via `apt-get`/`pip` directly.
 //!
-//! Only `#apt` and `#pip` installers are supported for now.  Keys that
-//! resolve to other installers (e.g. `#brew`) are treated as unresolved.
+//! **Why not `rosdep install`?**  Without `--from-paths`, `rosdep install`
+//! treats arguments as ROS **package names** (via `rospkg.expand_to_packages`)
+//! and fails on pure system keys like `asio` with `ResourceNotFound`.
+//! With `--from-paths`, it scans every `package.xml` under the source tree and
+//! pulls in unresolvable test-only dependencies.  Neither mode works for our
+//! use case of installing an explicit set of rosdep keys extracted from the
+//! dependency graph.
+//!
+//! Only `#apt` and `#pip` installers are supported.  Keys that resolve to
+//! other installers (e.g. `#brew`) are treated as unresolved.
 
 use std::collections::HashSet;
 use std::process::Command;

--- a/crates/launch-plus-core/src/rosdep.rs
+++ b/crates/launch-plus-core/src/rosdep.rs
@@ -129,14 +129,18 @@ fn parse_rosdep_resolve(stdout: &str, keys: &[&str]) -> crate::Result<ResolvedDe
     // Single-key format: no #ROSDEP[...] headers
     if keys.len() == 1 && !lines[0].starts_with("#ROSDEP[") {
         let mut installer: Option<&str> = None;
+        let mut has_supported = false;
         for line in &lines {
             if let Some(inst) = line.strip_prefix('#') {
                 installer = Some(inst);
+                if is_supported_installer(inst) {
+                    has_supported = true;
+                }
             } else if let Some(inst) = installer {
                 collect_packages(&mut result, inst, line);
             }
         }
-        if installer.is_none() {
+        if !has_supported {
             result.unresolved.push(keys[0].to_string());
         }
         return Ok(result);
@@ -163,7 +167,9 @@ fn parse_rosdep_resolve(stdout: &str, keys: &[&str]) -> crate::Result<ResolvedDe
             installer = None;
         } else if let Some(inst) = line.strip_prefix('#') {
             installer = Some(inst);
-            current_key_has_installer = true;
+            if is_supported_installer(inst) {
+                current_key_has_installer = true;
+            }
         } else if let Some(inst) = installer {
             collect_packages(&mut result, inst, line);
         }
@@ -185,15 +191,21 @@ fn parse_rosdep_resolve(stdout: &str, keys: &[&str]) -> crate::Result<ResolvedDe
     Ok(result)
 }
 
+/// Returns `true` if the installer is supported (`apt` or `pip`).
+fn is_supported_installer(installer: &str) -> bool {
+    matches!(installer, "apt" | "pip")
+}
+
 /// Add space-separated package names to the appropriate installer bucket.
 ///
-/// Only `apt` and `pip` are supported.  Other installers cause an error
-/// in `rosdep_install` (the key ends up in `unresolved`).
+/// Only `apt` and `pip` are supported.  Other installers are silently
+/// skipped here; callers use [`is_supported_installer`] to decide whether
+/// to mark the key as resolved.
 fn collect_packages(result: &mut ResolvedDeps, installer: &str, packages_line: &str) {
     let target = match installer {
         "apt" => &mut result.apt,
         "pip" => &mut result.pip,
-        _other => return, // unsupported installer — key stays in `unresolved`
+        _other => return,
     };
     for pkg in packages_line.split_whitespace() {
         if !pkg.is_empty() {
@@ -414,5 +426,29 @@ libnl-3-dev libnl-genl-3-dev libnl-route-3-dev
     fn parse_empty_output() {
         let result = parse_rosdep_resolve("", &["foo", "bar"]).unwrap();
         assert_eq!(result.unresolved, vec!["foo", "bar"]);
+    }
+
+    #[test]
+    fn parse_unsupported_installer_single_key() {
+        let stdout = "#brew\nhomebrew-pkg\n";
+        let result = parse_rosdep_resolve(stdout, &["some_key"]).unwrap();
+        assert!(result.apt.is_empty());
+        assert!(result.pip.is_empty());
+        assert_eq!(result.unresolved, vec!["some_key"]);
+    }
+
+    #[test]
+    fn parse_unsupported_installer_multi_key() {
+        let stdout = "\
+#ROSDEP[rclcpp]
+#apt
+ros-jazzy-rclcpp
+#ROSDEP[brew_only]
+#brew
+homebrew-pkg
+";
+        let result = parse_rosdep_resolve(stdout, &["rclcpp", "brew_only"]).unwrap();
+        assert_eq!(result.apt, vec!["ros-jazzy-rclcpp"]);
+        assert_eq!(result.unresolved, vec!["brew_only"]);
     }
 }

--- a/crates/launch-plus-core/src/rosdep.rs
+++ b/crates/launch-plus-core/src/rosdep.rs
@@ -11,7 +11,7 @@ use std::collections::HashSet;
 use std::process::Command;
 use std::sync::Once;
 
-use tracing::{info, warn};
+use tracing::info;
 
 static ROSDEP_UPDATE: Once = Once::new();
 
@@ -180,16 +180,13 @@ fn parse_rosdep_resolve(stdout: &str, keys: &[&str]) -> crate::Result<ResolvedDe
 
 /// Add space-separated package names to the appropriate installer bucket.
 ///
-/// Only `apt` and `pip` are supported.  Other installers are logged and
-/// skipped (the key ends up in `unresolved`).
+/// Only `apt` and `pip` are supported.  Other installers cause an error
+/// in `rosdep_install` (the key ends up in `unresolved`).
 fn collect_packages(result: &mut ResolvedDeps, installer: &str, packages_line: &str) {
     let target = match installer {
         "apt" => &mut result.apt,
         "pip" => &mut result.pip,
-        other => {
-            warn!("rosdep: unsupported installer '{other}', skipping");
-            return;
-        }
+        _other => return, // unsupported installer — key stays in `unresolved`
     };
     for pkg in packages_line.split_whitespace() {
         if !pkg.is_empty() {
@@ -198,11 +195,64 @@ fn collect_packages(result: &mut ResolvedDeps, installer: &str, packages_line: &
     }
 }
 
+/// Collect package names available in `AMENT_PREFIX_PATH` and `ROS_PACKAGE_PATH`.
+///
+/// Mirrors `rosdep install --ignore-src`: any key that corresponds to an
+/// already-installed ament/catkin package is skipped.
+fn installed_packages() -> HashSet<String> {
+    let mut pkgs = HashSet::new();
+
+    // AMENT_PREFIX_PATH: each entry is an install prefix like
+    // /opt/ros/jazzy or <ws>/install/<pkg>.  Packages are at
+    // <prefix>/share/<pkg_name>/package.xml.
+    if let Ok(ament_path) = std::env::var("AMENT_PREFIX_PATH") {
+        for prefix in ament_path.split(':').filter(|s| !s.is_empty()) {
+            let share = std::path::Path::new(prefix).join("share");
+            if let Ok(entries) = std::fs::read_dir(&share) {
+                for entry in entries.flatten() {
+                    if entry.path().join("package.xml").exists() {
+                        if let Some(name) = entry.file_name().to_str() {
+                            pkgs.insert(name.to_string());
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // ROS_PACKAGE_PATH: each entry is a directory containing packages
+    // (catkin-style).  Walk one level and look for package.xml.
+    if let Ok(ros_path) = std::env::var("ROS_PACKAGE_PATH") {
+        for dir in ros_path.split(':').filter(|s| !s.is_empty()) {
+            let path = std::path::Path::new(dir);
+            if path.join("package.xml").exists() {
+                if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
+                    pkgs.insert(name.to_string());
+                }
+            }
+            if let Ok(entries) = std::fs::read_dir(path) {
+                for entry in entries.flatten() {
+                    if entry.path().join("package.xml").exists() {
+                        if let Some(name) = entry.file_name().to_str() {
+                            pkgs.insert(name.to_string());
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    pkgs
+}
+
 /// Resolve rosdep keys and install the resulting system packages.
 ///
-/// 1. `rosdep resolve` maps keys → system package names
-/// 2. `apt-get install` for `#apt` packages
-/// 3. `pip install` for `#pip` packages
+/// 1. Filter out keys already available as installed ROS packages
+///    (checks `AMENT_PREFIX_PATH` and `ROS_PACKAGE_PATH`, like
+///    `rosdep install --ignore-src`)
+/// 2. `rosdep resolve` maps remaining keys → system package names
+/// 3. `apt-get install` for `#apt` packages
+/// 4. `pip install` for `#pip` packages
 ///
 /// Returns an error if any keys could not be resolved.
 pub fn rosdep_install(keys: &[&str]) -> crate::Result<()> {
@@ -210,8 +260,32 @@ pub fn rosdep_install(keys: &[&str]) -> crate::Result<()> {
         return Ok(());
     }
 
-    info!("Resolving {} rosdep keys", keys.len());
-    let resolved = rosdep_resolve(keys)?;
+    // Filter out keys that are already installed as ROS packages.
+    let installed = installed_packages();
+    let mut filtered: Vec<&str> = keys
+        .iter()
+        .copied()
+        .filter(|k| !installed.contains(*k))
+        .collect();
+
+    // Sort for deterministic ordering — callers often pass keys from a HashSet
+    // whose iteration order varies between runs.
+    filtered.sort_unstable();
+
+    if filtered.len() < keys.len() {
+        info!(
+            "Skipped {} keys already installed as ROS packages ({} remaining)",
+            keys.len() - filtered.len(),
+            filtered.len()
+        );
+    }
+
+    if filtered.is_empty() {
+        return Ok(());
+    }
+
+    info!("Resolving {} rosdep keys", filtered.len());
+    let resolved = rosdep_resolve(&filtered)?;
 
     if !resolved.unresolved.is_empty() {
         return Err(crate::Error::ProcessExecution(format!(

--- a/python/launch_plus/py_resolver.py
+++ b/python/launch_plus/py_resolver.py
@@ -2125,9 +2125,21 @@ class _PatchingFinder(importlib.abc.MetaPathFinder):
 
 # ─── Main ─────────────────────────────────────────────────────────────────────
 
+def _emit(obj):
+    """Write JSON to the real stdout (saved before redirect)."""
+    _emit._fd.write(json.dumps(obj))
+    _emit._fd.write("\n")
+    _emit._fd.flush()
+
+
 def main():
+    # Redirect stdout → stderr so that print() calls inside user launch files
+    # (e.g. OpaqueFunction bodies) don't contaminate our JSON output.
+    _emit._fd = sys.stdout
+    sys.stdout = sys.stderr
+
     if len(sys.argv) < 3:
-        print(json.dumps({"error": "usage: py_resolver.py <launch_file> <args_json> [package_shares_json]"}))
+        _emit({"error": "usage: py_resolver.py <launch_file> <args_json> [package_shares_json]"})
         sys.exit(1)
 
     launch_file = sys.argv[1]
@@ -2174,7 +2186,7 @@ def main():
     # Load the launch file as a module
     spec = importlib.util.spec_from_file_location("_target_launch", launch_file)
     if spec is None:
-        print(json.dumps({"error": f"cannot load {launch_file}"}))
+        _emit({"error": f"cannot load {launch_file}"})
         sys.exit(1)
 
     mod = importlib.util.module_from_spec(spec)
@@ -2184,17 +2196,17 @@ def main():
         # Module-level get_package_share_directory() call failed: source not on disk.
         # Output with packages_to_fetch set so Rust fetches and retries.
         _tracked["packages_to_fetch"] = sorted(_packages_to_fetch)
-        print(json.dumps(_tracked))
+        _emit(_tracked)
         return
     except Exception as e:
         _error(f"Error loading launch file: {e}")
-        print(json.dumps(_tracked))
+        _emit(_tracked)
         return
 
     # Call generate_launch_description()
     if not hasattr(mod, "generate_launch_description"):
         _error("No generate_launch_description() function found")
-        print(json.dumps(_tracked))
+        _emit(_tracked)
         return
 
     # Pre-populate global_params from the orchestrator's persisted context so that
@@ -2220,11 +2232,11 @@ def main():
         ld = mod.generate_launch_description()
     except _PackageNotFetchedError:
         _tracked["packages_to_fetch"] = sorted(_packages_to_fetch)
-        print(json.dumps(_tracked))
+        _emit(_tracked)
         return
     except Exception as e:
         _error(f"generate_launch_description() failed: {e}")
-        print(json.dumps(_tracked))
+        _emit(_tracked)
         return
 
     # Walk the LaunchDescription tree — two passes, mirroring the XML resolver's behaviour:
@@ -2248,7 +2260,7 @@ def main():
 
     if _packages_to_fetch:
         _tracked["packages_to_fetch"] = sorted(_packages_to_fetch)
-    print(json.dumps(_tracked))
+    _emit(_tracked)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary

- **`--log-base` flag**: Add `--log-base` to `build`, `build-pkg`, and `test` subcommands. Placed before the `build` verb in colcon invocation (global arg, not subcommand arg).
- **Rosdep hardening**: Fix non-deterministic resolution caused by `HashSet` iteration order (sort keys before passing to `rosdep resolve`). Harden error handling: unresolved keys are now a hard error, unsupported installers (exclusively) mark keys as unresolved. Cache `installed_packages()` with `OnceLock` and use `BTreeSet` for deterministic dedup.
- **REP-149 condition attributes**: Implement a full recursive-descent parser for `condition` attributes on `package.xml` dependency tags (comparisons, `and`/`or` operators, `$VAR` env var expansion, parentheses). Dependencies whose condition evaluates to false are excluded from the dependency graph. XML entity escaping (`&lt;` etc.) handled via `unescape_value()`. Condition evaluator accepts injected env lookup for testability.
- **Document rosdep design**: Explain why we use `rosdep resolve` + manual `apt-get`/`pip` instead of `rosdep install` (which treats bare args as ROS package names via `rospkg.expand_to_packages` and fails on system keys like `asio`; `--from-paths` pulls in unresolvable test dependencies).
- **Fix py_resolver stdout corruption**: Redirect `sys.stdout` to `sys.stderr` at startup so that `print()` calls inside OpaqueFunction bodies don't corrupt the JSON output that Rust parses.

## Test plan

- [x] All 188 unit tests pass
- [x] Autoware integration test (sample_sensor_kit / sample_vehicle) — preview resolve, build, post-build resolve
- [x] Verified with additional vehicle/sensor configurations

🤖 Generated with [Claude Code](https://claude.com/claude-code)