### PR TITLE
docs: add public release documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ variables substituted — invaluable for debugging and CI validation.
 
 - **Lazy fetching** — packages are sparse-checked out on demand; no full clone required
 - **Minimal builds** — only the transitive dependencies of your launch target are built
-- **Static analysis** — resolve launch files without building or executing anything
+- **Static analysis** — resolve launch files without building packages or running ROS nodes
 - **Python launch support** — executes `generate_launch_description()` with shimmed
   `launch`/`launch_ros` imports; no ROS 2 Python packages needed on the resolver host
 - **OpaqueFunction handling** — executes arbitrary Python callables with patched
@@ -71,7 +71,7 @@ variables substituted — invaluable for debugging and CI validation.
 ### Prerequisites
 
 - **Rust toolchain** — [rustup.rs](https://rustup.rs) (edition 2024, MSRV 1.85)
-- **Python 3** in `PATH` — used to evaluate Python launch files
+- **Python 3** in `PATH` — used to evaluate Python launch files and `$(eval ...)` substitutions in XML
 - **Git** — for sparse-checkout operations
 - **ROS 2** — source your ROS 2 environment (`source /opt/ros/<distro>/setup.bash`)
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ variables substituted — invaluable for debugging and CI validation.
 ### Prerequisites
 
 - **Rust toolchain** — [rustup.rs](https://rustup.rs) (edition 2024, MSRV 1.85)
-- **Python 3** in `PATH` — used to evaluate Python launch files and `$(eval ...)` substitutions in XML
+- **Python 3.10+** in `PATH` — used to evaluate Python launch files and `$(eval ...)` substitutions in XML
 - **Git** — for sparse-checkout operations
 - **ROS 2** — source your ROS 2 environment (`source /opt/ros/<distro>/setup.bash`)
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ and builds the minimal set:
 
 ```
 # launch-plus workflow
-launch-plus index                    # generate lockfile (one-time)
+launch-plus index autoware.repos     # generate lockfile (one-time)
 launch-plus build autoware_launch autoware.launch.xml \
   sensor_model:=sample_sensor_kit \
   vehicle_model:=sample_vehicle \

--- a/README.md
+++ b/README.md
@@ -1,46 +1,103 @@
 # launch-plus
 
-Static analyser and lazy resolver for ROS 2 launch files.
+**Bazel-like build system for ROS 2** — resolve, fetch, and build only what your
+launch file actually needs.
 
-Instead of cloning and building an entire workspace upfront, launch-plus
-reads a `.repos` manifest, generates a lockfile, and resolves a launch
-file on demand — fetching only the packages actually needed, then
-producing a single flattened XML that shows every node, parameter, and
-remap that would be active at runtime.
+Instead of cloning and building an entire workspace upfront, launch-plus reads a
+`.repos` manifest, generates a lockfile, and resolves a launch file on demand —
+fetching only the packages actually referenced, then producing a single flattened
+XML that shows every node, parameter, and remap that would be active at runtime.
 
-> **Status:** early development — API and CLI flags may change.
+## The problem
 
-## Prerequisites
+A typical ROS 2 workspace like [Autoware](https://github.com/autowarefoundation/autoware)
+contains **200+ packages** across dozens of repositories.  The standard workflow
+requires cloning everything, installing all system dependencies, and building the
+full workspace before you can launch a single node — even if your launch file
+only touches 30 of those packages.
 
-- Rust toolchain (`cargo`) — https://rustup.rs
-- `python3` in `PATH` (used to evaluate `$(eval ...)` substitutions and to resolve Python launch files)
-- ROS 2 sourced — only required for `--rosdep` (system package resolution); the resolver itself does not depend on any ROS 2 Python packages
+```
+# Traditional ROS 2 workflow
+vcs import src < autoware.repos      # clone ~50 repos
+rosdep install --from-paths src      # install ALL system deps
+colcon build                         # build ALL ~235 packages (30+ min)
+ros2 launch autoware_launch ...      # finally launch
+```
 
-## Quickstart
+This is slow, wasteful, and makes it hard to iterate on a subset of the system.
 
-### 1. Clone and build
+## The solution
+
+launch-plus treats **launch files as build targets**.  It parses the launch
+graph statically, determines exactly which packages are needed, fetches only
+those via [git sparse-checkout](https://git-scm.com/docs/git-sparse-checkout),
+and builds the minimal set:
+
+```
+# launch-plus workflow
+launch-plus index                    # generate lockfile (one-time)
+launch-plus build autoware_launch autoware.launch.xml \
+  sensor_model:=sample_sensor_kit \
+  vehicle_model:=sample_vehicle \
+  map_path:=/path/to/map \
+  --clean --rosdep                   # fetch + build only what's needed
+```
+
+The resolver also produces a **flattened, fully-resolved XML** that shows the
+complete launch graph with all includes inlined, conditionals evaluated, and
+variables substituted — invaluable for debugging and CI validation.
+
+## Key features
+
+- **Lazy fetching** — packages are sparse-checked out on demand; no full clone required
+- **Minimal builds** — only the transitive dependencies of your launch target are built
+- **Static analysis** — resolve launch files without building or executing anything
+- **Python launch support** — executes `generate_launch_description()` with shimmed
+  `launch`/`launch_ros` imports; no ROS 2 Python packages needed on the resolver host
+- **OpaqueFunction handling** — executes arbitrary Python callables with patched
+  filesystem access, transparently fetching packages as they are accessed
+- **Portable output** — resolved XML uses `$(find-pkg-share pkg)/...` paths that
+  work across machines and environments
+- **Lockfile pinning** — reproducible builds via commit-SHA-pinned lockfiles
+- **rosdep integration** — automatically installs system dependencies for the
+  packages being built
+
+> **Current scope:** launch-plus is a build-time tool today (resolve + build).
+> Execution support — both a built-in executor and integration with `ros2 launch`
+> and third-party launchers — is on the roadmap.
+
+## Quick start
+
+### Prerequisites
+
+- **Rust toolchain** — [rustup.rs](https://rustup.rs) (edition 2024, MSRV 1.85)
+- **Python 3** in `PATH` — used to evaluate Python launch files
+- **Git** — for sparse-checkout operations
+- **ROS 2** — source your ROS 2 environment (`source /opt/ros/<distro>/setup.bash`)
+
+### Install
 
 ```bash
 git clone https://github.com/paulsohn/launch-plus.git
 cd launch-plus
 cargo build --bin launch-plus --release
 # binary: target/release/launch-plus
-# or use `cargo run --bin launch-plus --` in place of the binary below
 ```
 
-### 2. Try the bundled Autoware example
+### Try the bundled Autoware example
 
-A pre-generated lockfile for a full [Autoware workspace](https://github.com/autowarefoundation/autoware/tree/a06b188d3275da9de561ef4aa5ce0c4bfd87d716/repositories) is included in
-[`example/autoware/`](example/autoware/).  You can run the resolver against it
-immediately without writing a manifest or running `index` first.
+A pre-generated lockfile for a full [Autoware workspace](https://github.com/autowarefoundation/autoware)
+is included in [`example/autoware/`](example/autoware/).  You can run the
+resolver immediately without writing a manifest or running `index` first.
 
 ```bash
-# Source ROS 2 first so that rosdep and ament can locate system packages.
+# Source ROS 2 first (only needed for --rosdep)
 source /opt/ros/humble/setup.bash
 
 cd example/autoware
 
-cargo run --bin launch-plus -- resolve -c autoware_launch autoware.launch.xml \
+# Preview-resolve: produces flattened XML without building
+cargo run --bin launch-plus -- resolve -d autoware_launch autoware.launch.xml \
   sensor_model:=sample_sensor_kit \
   vehicle_model:=sample_vehicle \
   map_path:="[map_path]" \
@@ -56,25 +113,18 @@ cargo run --bin launch-plus -- resolve -c autoware_launch autoware.launch.xml \
   > resolved.launch.xml
 ```
 
-On first run, the resolver will sparse-clone only the packages it needs into
-`example/autoware/src/` (this may take a few minutes). Subsequent runs reuse
+On first run, the resolver sparse-clones only the packages it needs into
+`example/autoware/src/` (this may take a few minutes).  Subsequent runs reuse
 the already-fetched packages and are fast.
 
-`--preview` keeps `$(find-pkg-share pkg)/...` placeholders in the output
-instead of absolute filesystem paths, making the result portable across machines.
-
-The pre-generated output files (paths anonymized, `[home]` replaces the home
-directory) are included for reference:
+The pre-generated output files are included for reference:
 - [`example/autoware/resolved.launch.xml`](example/autoware/resolved.launch.xml)
 - [`example/autoware/resolver.log`](example/autoware/resolver.log)
 
-To build the resolved packages with colcon (requires a sourced ROS 2 environment
-and `colcon` installed):
+To build the resolved packages (requires a sourced ROS 2 environment and `colcon`):
 
 ```bash
-cd example/autoware
-
-cargo run --bin launch-plus -- build -c autoware_launch autoware.launch.xml \
+cargo run --bin launch-plus -- build -d autoware_launch autoware.launch.xml \
   sensor_model:=sample_sensor_kit \
   vehicle_model:=sample_vehicle \
   map_path:="[map_path]" \
@@ -86,135 +136,64 @@ cargo run --bin launch-plus -- build -c autoware_launch autoware.launch.xml \
   --colcon-flagfile colcon-flags.txt
 ```
 
-`colcon-flags.txt` enables `--symlink-install` by default; edit it to add
-`--cmake-args`, `--parallel-workers`, etc.
+### Use your own project
 
-### 3. Use your own manifest
+1. Write a `.repos` file listing your repositories (standard
+   [vcstool](https://github.com/dirk-thomas/vcstool) format)
+2. Generate a lockfile: `launch-plus index`
+3. Resolve: `launch-plus resolve <pkg> <launcher> [args...]`
+4. Build: `launch-plus build <pkg> <launcher> [args...] --clean --rosdep`
 
-Write a `.repos` file listing the repositories you need — see
-[`example/autoware/manifest.repos`](example/autoware/manifest.repos) for the
-format — then generate a lockfile:
+See the [Getting Started guide](docs/getting-started.md) for a full walkthrough.
 
-```bash
-cd example/autoware
-
-cargo run --bin launch-plus -- index
-```
-
-The lockfile pins every repository to a concrete commit SHA and records the ROS
-packages it contains.  Commit it alongside your manifest, then run `resolve` as
-above pointing `--lockfile` at it.
-
-## Key commands
+## Commands
 
 | Command | Description |
 |---|---|
-| `index <manifest.repos>` | Parse `.repos` file and generate a lockfile |
-| `update [REPOS...]` | Re-resolve refs and update lockfile SHAs |
-| `resolve <pkg> <launcher> [args...]` | Resolve launch file to a flat XML |
-| `check <pkg> <launcher> [args...]` | Like `resolve` but exits non-zero on errors |
-| `fetch <pkg>...` | Sparse-checkout specific packages from the lockfile |
-| `build <pkg> <launcher> [args...]` | Resolve, plan dependencies, and run `colcon build` |
-| `test <pkg> <launcher> [args...]` | Like `build` but includes `test_depend` packages |
+| `index` | Parse `.repos` files and generate a lockfile |
+| `update` | Re-resolve refs and update lockfile SHAs |
+| `resolve` | Resolve and flatten a launch file to XML (no build) |
+| `check` | Like `resolve` but exits non-zero on warnings/errors |
+| `build` | Resolve, fetch dependencies, and run `colcon build` |
+| `build-pkg` | Build package(s) by name with transitive dependency fetching |
+| `test` | Like `build` but includes `test_depend` packages |
+| `fetch` | Sparse-checkout specific packages from the lockfile |
 | `clean` | Remove fetched packages |
 
-## Notable `resolve` / `check` flags
+Run `launch-plus <command> --help` for detailed usage of each command.
 
-### Workspace state (required — exactly one)
+## Workspace state flags
 
-| Flag | Short | Description |
+Commands that refer to source code support workspace state flags:
+
+| Flag | Short | When to use |
 |---|---|---|
-| `--clean` | `-c` | Reset every repository to the pinned lockfile SHA; discard local modifications |
-| `--dirty` | `-d` | Use whatever is on disk; skip all git operations for existing repos |
+| `--clean` | `-c` | CI / reproducible runs — resets repos to lockfile SHAs |
+| `--dirty` | `-d` | Local iteration — uses whatever is on disk |
+| *(default)* | | Verifies HEAD matches lockfile SHA; errors on mismatch |
 
-Use `--dirty` during local iteration (edits survive).
-Use `--clean` for reproducible CI runs.
+## Documentation
 
-### Resolution options
-
-| Flag | Description |
+| Document | Description |
 |---|---|
-| `--lockfile <path>` | Lockfile to use (default: `manifest.lock.repos`) |
-| `--src <dir>` | Directory where packages are fetched (default: `src/`) |
-| `--preview` | Use portable `$(find-pkg-share ...)` paths in output |
-| `--inline-params` | Expand `<param from="file.yaml"/>` entries inline |
-| `--flatten-namespaces` | Fold namespace into each node's name/topic |
-| `--show-args` | Emit `<!-- arg name=... -->` comments at include boundaries |
-| `--apply-opaque-file-access` | Let OpaqueFunction bodies read param files |
-| `--apply-launch-arg-defaults` | Fill unset args from their declared defaults |
-| `--allow-global-arg-cascade` | Propagate parent args into included files |
-| `--rosdep` | Resolve system packages via rosdep (requires sourced ROS 2) |
+| [Motivation](docs/motivation.md) | Why launch-plus exists and what problems it solves |
+| [Core Concepts](docs/concepts.md) | Lockfiles, sparse checkout, portable paths, and more |
+| [Getting Started](docs/getting-started.md) | Step-by-step tutorial for your own project |
+| [Architecture](docs/architecture.md) | How the resolver, fetcher, and builder work internally |
+| [Supported Environments](docs/supported-environments.md) | Platforms, ROS distros, and known limitations |
+| [FAQ](docs/faq.md) | Common questions and answers |
+| [Contributing](CONTRIBUTING.md) | Development setup and contribution guidelines |
 
-## `build` / `test` flags
+## Who is this for?
 
-`build` resolves the launch file, computes the transitive build-dependency closure
-(`build_depend`, `buildtool_depend`, `<depend>`, …), and calls `colcon build
---packages-select <exact list>`.  `test` does the same but also pulls in
-`test_depend` packages.
-
-### Workspace state (required — exactly one)
-
-| Flag | Short | Description |
-|---|---|---|
-| `--clean` | `-c` | Reset every repository to the pinned lockfile SHA |
-| `--dirty` | `-d` | Use whatever is on disk; skip git operations |
-
-### Build / install directories
-
-| Flag | Default | Description |
-|---|---|---|
-| `--build-base <dir>` | `build` | Colcon build output directory |
-| `--install-base <dir>` | `install` | Colcon install prefix |
-
-### Extra colcon flags (flagfile)
-
-Pass arbitrary colcon flags via a flagfile — one shell token per line,
-`#` comments allowed:
-
-```bash
-launch-plus build autoware_launch autoware.launch.xml \
-  sensor_model:=sample_sensor_kit vehicle_model:=sample_vehicle map_path:=/ \
-  --clean --colcon-flagfile example/colcon-flags.example.txt
-```
-
-Each line of the flagfile is inserted verbatim into `colcon build` before
-`--packages-select`.  Flags that conflict with launch-plus-managed arguments
-(`--packages-*`, `--base-paths`, `--build-base`, `--install-base`) are
-rejected as errors.  See [`example/colcon-flags.example.txt`](example/colcon-flags.example.txt)
-for an annotated template.
-
-| Flag | Description |
-|---|---|
-| `--colcon-flagfile <file>` | Path to a flagfile with extra colcon arguments |
-| `--dry-run` | Print the colcon command without running it |
-
-## How the resolver works
-
-**XML launch files** are parsed and resolved in Rust. Substitution expressions
-(`$(find-pkg-share ...)`, `$(var ...)`, `$(eval ...)`) are evaluated, `<include>`
-tags are followed recursively, and all `<node>`, `<param>`, and `<remap>` elements
-are collected into the output.
-
-**Python launch files** are executed with `importlib`, but before the file loads,
-a `MetaPathFinder` intercepts all imports of `launch`, `launch_ros`, and
-`ament_index_python` and replaces them with shim modules built entirely from the
-standard library.  The shims record constructor arguments (package, executable,
-parameters, remaps, included files) into a structured trace instead of scheduling
-anything for execution.  No ROS 2 packages need to be installed.
-
-**OpaqueFunction** bodies are arbitrary Python callables and cannot be statically
-analysed — they are executed directly.  `open()`, `yaml.safe_load()`, and
-`os.path.*` are patched so filesystem reads go through portable
-`$(find-pkg-share pkg)/...` paths; the package is sparse-checked out on demand if
-not yet present locally.
-
-## Development
-
-```bash
-cargo test --workspace
-cargo clippy --all-targets
-cargo fmt --check
-```
+- **ROS 2 developers** working with large multi-repository workspaces who want
+  faster iteration cycles
+- **CI/CD pipelines** that need to build and test only the packages affected by
+  a launch configuration change
+- **System integrators** who want a clear, auditable view of what a launch file
+  actually does — every node, parameter, and remap in one flat XML
+- **Anyone** tired of waiting 30+ minutes for a full workspace build when they
+  only need a handful of packages
 
 ## License
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -124,11 +124,11 @@ condition attributes for conditional dependencies.
 
 ### Fetcher (`fetcher.rs`)
 
-Manages git sparse-checkout.  Two levels of fetching:
-- **`fetch_file()`** — sparse-checks out only a specific launch file; creates
-  the package directory but does *not* include `package.xml` or other files
-- **`ensure_package_fetched()`** — full sparse-checkout of an entire package
-  subtree, including `package.xml` and all files
+Manages git sparse-checkout.  The primary API is:
+- **`fetch_packages()`** — full sparse-checkout of one or more package subtrees,
+  including `package.xml` and all files
+- **`is_package_fetched()`** — checks whether a package has been fetched
+  (sentinel: `package.xml` exists on disk)
 
 Sparse-checkout is additive: new paths are added without removing previously
 checked-out files.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,9 +2,12 @@
 
 ## Overview
 
-launch-plus is a Rust application with an embedded Python interpreter for
-resolving Python launch files.  The core library (`launch-plus-core`) contains
-all logic; the CLI (`launch-plus-cli`) is a thin `clap`-based wrapper.
+launch-plus is a Rust application that shells out to an external `python3`
+process for resolving Python launch files.  The Python resolver script
+(`py_resolver.py`) is embedded in the Rust binary via `include_str!` at compile
+time, written to a temporary file, and invoked as a subprocess.  The core
+library (`launch-plus-core`) contains all logic; the CLI (`launch-plus-cli`) is
+a thin `clap`-based wrapper.
 
 ```
 ┌───────────────────────────────────────────────────────┐

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,209 @@
+# Architecture
+
+## Overview
+
+launch-plus is a Rust application with an embedded Python interpreter for
+resolving Python launch files.  The core library (`launch-plus-core`) contains
+all logic; the CLI (`launch-plus-cli`) is a thin `clap`-based wrapper.
+
+```
+┌───────────────────────────────────────────────────────┐
+│  CLI (launch-plus-cli)                                │
+│  clap argument parsing → delegates to core            │
+├───────────────────────────────────────────────────────┤
+│  Core Library (launch-plus-core)                      │
+│  ├── indexer    — .repos → lockfile                   │
+│  ├── fetcher    — git sparse-checkout on demand       │
+│  ├── resolver   — launch file → resolved XML          │
+│  │   ├── XML parser (quick-xml)                       │
+│  │   ├── substitution engine ($(var), $(eval), etc.)  │
+│  │   └── Python resolver (embedded py_resolver.py)    │
+│  ├── orchestrator — coordinates resolve + fetch loop  │
+│  ├── builder    — colcon build orchestration          │
+│  └── rosdep     — system dependency resolution        │
+└───────────────────────────────────────────────────────┘
+```
+
+## Data flow
+
+### 1. Index phase
+
+```
+.repos file(s)
+    │
+    ▼
+[indexer]
+    ├── git ls-remote → resolve versions to SHAs
+    ├── git archive → fetch package.xml files (no full clone)
+    └── parse package.xml → extract dependencies
+    │
+    ▼
+manifest.lock.repos (lockfile)
+```
+
+The indexer reads one or more `.repos` files, resolves each version reference
+(tag, branch, or SHA) to a concrete commit SHA via `git ls-remote`, fetches
+`package.xml` files via `git archive` (without cloning), and writes the
+dual-indexed lockfile.
+
+### 2. Resolve phase
+
+```
+launch-plus resolve <pkg> <launcher>
+    │
+    ▼
+[orchestrator]
+    ├── lockfile lookup: pkg → repo + path
+    ├── fetch launch file via sparse-checkout
+    │
+    ▼
+[resolver] — recursive launch file processing
+    │
+    ├─── XML launch file?
+    │    ├── parse with quick-xml
+    │    ├── evaluate substitutions: $(var), $(arg), $(find-pkg-share), $(eval)
+    │    ├── evaluate conditionals: if="...", unless="..."
+    │    ├── follow <include> tags → recurse
+    │    └── collect <node>, <param>, <remap>, <composable_node>
+    │
+    └─── Python launch file?
+         ├── invoke py_resolver.py via subprocess
+         ├── py_resolver imports shimmed launch/launch_ros modules
+         ├── calls generate_launch_description()
+         ├── walks the LaunchDescription tree
+         ├── executes OpaqueFunction bodies with patched filesystem
+         └── returns structured JSON to Rust
+    │
+    ├── fetch additional packages on demand (sparse-checkout)
+    ├── retry if _PackageNotFetchedError signals missing package
+    │
+    ▼
+resolved launch XML (stdout)
+```
+
+### 3. Build phase
+
+```
+launch-plus build <pkg> <launcher>
+    │
+    ▼
+[orchestrator]
+    ├── resolve launch file (preview mode)
+    ├── collect direct packages from launch graph
+    │
+    ▼
+[dependency planner]
+    ├── expand transitive build deps from package.xml
+    ├── separate lockfile packages from system packages
+    │
+    ▼
+[fetcher] — fetch any missing build dependencies
+    │
+    ▼
+[rosdep] — install system packages (with --rosdep)
+    ├── rosdep resolve → apt/pip package names
+    ├── apt-get install
+    └── pip install
+    │
+    ▼
+[builder]
+    └── colcon build --packages-select <minimal set>
+```
+
+## Key components
+
+### Indexer (`indexer.rs`)
+
+Generates lockfiles from `.repos` manifests.  Uses `git ls-remote` for version
+resolution and `git archive` to fetch `package.xml` files without full clones.
+Parses `package.xml` to extract dependency information including REP-149
+condition attributes for conditional dependencies.
+
+### Fetcher (`fetcher.rs`)
+
+Manages git sparse-checkout.  Two levels of fetching:
+- **`fetch_file()`** — sparse-checks out only a specific launch file; creates
+  the package directory but does *not* include `package.xml` or other files
+- **`ensure_package_fetched()`** — full sparse-checkout of an entire package
+  subtree, including `package.xml` and all files
+
+Sparse-checkout is additive: new paths are added without removing previously
+checked-out files.
+
+### Resolver (`resolver.rs`, `orchestrator.rs`)
+
+The XML resolver is implemented in Rust using `quick-xml`.  It handles:
+- Substitution expressions: `$(var ...)`, `$(arg ...)`, `$(find-pkg-share ...)`,
+  `$(find-pkg-prefix ...)`, `$(env ...)`, `$(eval ...)`
+- Conditional attributes: `if="..."`, `unless="..."`
+- `<include>` expansion with argument forwarding
+- `<group>` scoping
+- `<push-ros-namespace>` namespace composition
+
+### Python resolver (`py_resolver.py`)
+
+An embedded Python script (`include_str!` at compile time) that resolves Python
+launch files.  It:
+
+1. Installs a `MetaPathFinder` that intercepts imports of `launch`, `launch_ros`,
+   and `ament_index_python`
+2. Replaces them with shim modules that record constructor arguments
+3. Loads the target launch file via `importlib`
+4. Calls `generate_launch_description()`
+5. Walks the resulting `LaunchDescription` tree
+6. Returns a JSON structure describing all actions (nodes, includes, params, etc.)
+
+The shims require no ROS 2 Python packages to be installed.  `OpaqueFunction`
+bodies are executed directly with patched `open()`, `yaml.safe_load()`,
+`os.path.*`, and `pathlib.Path.open`.
+
+### Orchestrator (`orchestrator.rs`)
+
+Coordinates the resolve-fetch loop.  When the Python resolver encounters a
+package that hasn't been fetched yet, it signals via `_PackageNotFetchedError`.
+The orchestrator catches this, fetches the missing package, and retries (up to
+3 times).
+
+### Builder (`builder.rs`)
+
+Computes the transitive build-dependency closure and invokes `colcon build`.
+Reads extra arguments from a flagfile.  Validates that flagfile tokens don't
+conflict with launch-plus-managed arguments.
+
+### Rosdep (`rosdep.rs`)
+
+Resolves rosdep keys to system package names via `rosdep resolve`, then installs
+via `apt-get` or `pip` directly.  Caches the set of already-installed ROS
+packages per-process to skip redundant resolution.
+
+## Design decisions
+
+### Why `rosdep resolve` instead of `rosdep install`?
+
+`rosdep install` without `--from-paths` treats its arguments as ROS package
+names (via `rospkg.expand_to_packages()`) and fails on pure system keys like
+`asio`.  With `--from-paths`, it scans every `package.xml` and pulls in
+unresolvable test-only dependencies.  `rosdep resolve` maps keys to system
+packages cleanly without either problem.
+
+### Why shim modules instead of real launch/launch_ros?
+
+Installing `launch` and `launch_ros` would require a full ROS 2 Python
+environment on the resolver host.  The shims let launch-plus work with just
+Python 3 and no ROS 2 installation — the resolver is a standalone tool.
+
+### Why Rust?
+
+- Performance: parsing and resolving large launch graphs (200+ packages) needs
+  to be fast
+- Single binary: no Python environment setup required on the target machine
+  (Python is only invoked as a subprocess for `.launch.py` files)
+- Strong typing: the dependency graph and lockfile schema benefit from
+  compile-time checks
+
+### Why embed py_resolver.py via `include_str!`?
+
+The Python resolver is embedded at compile time so the Rust binary is fully
+self-contained.  No external Python file needs to be distributed alongside the
+binary.  The trade-off is that changes to `py_resolver.py` require a Rust
+rebuild.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -38,7 +38,7 @@ a thin `clap`-based wrapper.
 [indexer]
     ├── git ls-remote → resolve versions to SHAs
     ├── git archive → fetch package.xml files (no full clone)
-    └── parse package.xml → extract dependencies
+    └── parse package.xml → discover package names and paths
     │
     ▼
 manifest.lock.repos (lockfile)

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -224,11 +224,17 @@ that strips `<exec_depend>` entries from every `package.xml` before building —
 a workaround for colcon's inability to distinguish build-time from runtime
 dependencies.
 
-launch-plus avoids this entirely.  Because the resolver already knows which
-packages are actually needed (it read the launch file), it computes the build
-closure using only `build_depend` and `buildtool_depend`.  Packages that are
-only referenced at runtime are expected to be available as installed system
-packages — exactly the role `exec_depend` was designed to express.
+launch-plus's goal is to avoid this entirely: because the resolver already knows
+which packages are actually needed (it read the launch file), it *should* compute
+the build closure using only `build_depend` and `buildtool_depend`.
+
+**Current status:** today, launch-plus still includes `exec_depend` in the build
+set because it delegates to `colcon build`, which validates that all
+`package.xml` dependencies — including `exec_depend` — have install artifacts
+before running cmake.  There is no colcon flag to disable this check.  Replacing
+colcon with direct ament invocations (see [#18](https://github.com/paulsohn/launch-plus/issues/18))
+will remove this constraint, allowing the build closure to use only true
+build-time dependencies.
 
 ## Static analysis: what the resolver can verify
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -1,0 +1,314 @@
+# Core Concepts
+
+## Lockfile: why `.repos` is not enough
+
+The ROS 2 community uses `.repos` files (vcstool format) to describe workspaces.
+A typical `.repos` entry looks like:
+
+```yaml
+repositories:
+  autoware/universe:
+    type: git
+    url: https://github.com/autowarefoundation/autoware_universe.git
+    version: v0.49.0
+```
+
+This has a fundamental problem: **`version: v0.49.0` is a moving target**.  Tags
+can be force-pushed, branches advance with every commit, and there is no record
+of *which packages* a repository contains or what their dependencies are.  Two
+developers running `vcs import` a week apart may get different source code with
+no way to detect or reproduce the difference.
+
+Other ecosystems solved this long ago:
+- **npm** has `package-lock.json`
+- **Cargo** has `Cargo.lock`
+- **pip** has `pip freeze` / `requirements.txt` with pinned hashes
+- **Pixi** (conda) has `pixi.lock`
+
+ROS 2 has had no equivalent — until now.
+
+### The launch-plus lockfile
+
+A **lockfile** (`manifest.lock.repos`) is a snapshot of your workspace that pins
+every repository to a concrete commit SHA and records the ROS packages each
+repository contains.
+
+```yaml
+version: 1
+repos:
+  autowarefoundation/autoware_msgs:
+    url: https://github.com/autowarefoundation/autoware_msgs.git
+    version: 1.11.0
+    sha: abc123def456...
+    workspace_path: core/autoware_msgs
+    packages:
+      - autoware_msgs
+      - autoware_planning_msgs
+
+packages:
+  autoware_msgs:
+    repo: autowarefoundation/autoware_msgs
+    path: autoware_msgs
+    dependencies:
+      build: [rosidl_default_generators]
+      exec: [rosidl_default_runtime]
+      test: [ament_lint_auto]
+```
+
+The lockfile is dual-indexed:
+- **`repos`** — grouped by repository, used during fetching
+- **`packages`** — indexed by package name, used for O(1) dependency lookup
+
+This gives you:
+- **Reproducibility** — `sha` pins mean identical source code every time
+- **Sparse clone map** — the lockfile records which packages live in which
+  repository and at what path, so launch-plus can sparse-checkout *only* the
+  packages it needs without cloning entire repositories
+- **Offline dependency graph** — transitive build closures can be computed from
+  the lockfile alone, without cloning anything
+- **`.repos` compatibility** — the lockfile is a valid `.repos` file.  You can
+  pass it to `vcs import` as a drop-in replacement for your original manifest,
+  getting the same repos at the exact pinned SHAs.  This means adopting
+  launch-plus does not require abandoning your existing vcstool workflow
+
+Generate a lockfile with `launch-plus index`.  Commit it alongside your
+`.repos` manifest — it serves the same role as `Cargo.lock` or
+`package-lock.json`.
+
+## Sparse checkout
+
+launch-plus uses [git sparse-checkout](https://git-scm.com/docs/git-sparse-checkout)
+to fetch only the files it needs from each repository.  When the resolver first
+encounters a package, it checks out just that package's directory — not the
+entire repository.
+
+This is additive: once a package is fetched, it stays on disk until you run
+`launch-plus clean`.  Over multiple resolve/build cycles, only the packages
+actually used accumulate on disk.
+
+The `--src` flag controls where packages are fetched (default: `src/`).
+
+## Portable paths
+
+The resolver produces output using **portable paths** — substitution expressions
+like `$(find-pkg-share pkg)/config/params.yaml` that are valid across machines
+and environments.
+
+In `--preview` mode, these paths remain as substitutions in the output XML.
+Without `--preview` (post-build), paths are expanded using `AMENT_PREFIX_PATH` to
+point at the installed package locations.
+
+Portable paths are the canonical output format.  They ensure that:
+- Resolved XML can be shared between developers
+- CI artifacts are not tied to a specific filesystem layout
+- `diff` between preview and post-build resolutions shows only semantic differences
+
+### Source/install path equivalence convention
+
+For preview mode to produce correct results, launch-plus assumes that **launch
+files and parameter files have the same relative path within a package in both
+the source directory and the install directory**.  Concretely:
+
+```
+# Source path
+src/my_pkg/launch/bringup.launch.xml
+src/my_pkg/config/params.yaml
+
+# Install path (after colcon build --symlink-install)
+install/my_pkg/share/my_pkg/launch/bringup.launch.xml
+install/my_pkg/share/my_pkg/config/params.yaml
+```
+
+Both are reachable via `$(find-pkg-share my_pkg)/launch/bringup.launch.xml`.
+In preview mode, `$(find-pkg-share my_pkg)` is interpreted as `src/my_pkg`
+(the source directory); post-build, it resolves to the installed share path
+via `AMENT_PREFIX_PATH`.
+
+This means packages that **transform or generate** launch files or parameter
+files during the build (e.g. template expansion, code generation) are not
+supported in preview mode — the resolver needs to read the files as they exist
+in the source tree.  Standard `ament_cmake` / `ament_python` packages that
+simply install files to the share directory work correctly.
+
+## Workspace state: clean vs dirty
+
+Every command that refers to source code supports **workspace state flags** that
+control how launch-plus treats the on-disk state of fetched repositories:
+
+- **`--clean` (`-c`)** — Resets every fetched repository to the exact SHA
+  recorded in the lockfile.  Guarantees reproducible output.  Use in CI.
+- **`--dirty` (`-d`)** — Uses whatever is currently on disk.  Only fetches
+  repositories that are completely missing.  Use during local development to
+  preserve your edits.
+- **Default (no flag)** — Verifies that each repository's HEAD matches the
+  lockfile SHA and that the working tree is clean.  Errors if either check
+  fails.  This is the safest mode: it refuses to proceed on ambiguous state
+  without forcing any changes.
+
+## Resolution modes
+
+### Preview resolution
+
+With `--preview`, the resolver works against the **source workspace** (`src/`)
+without requiring packages to be built or installed.  The output carries a
+`<!-- PREVIEW -->` header and uses portable `$(find-pkg-share ...)` paths.
+
+This is the primary mode for static analysis: you can see the full launch graph
+without building anything.
+
+### Post-build resolution
+
+Without `--preview`, the resolver works against **installed packages** via
+`AMENT_PREFIX_PATH`.  Source your workspace's `install/setup.bash` first.
+The output uses absolute installed paths and represents what `ros2 launch`
+would actually see.
+
+You can verify consistency between the two by resolving in both modes and
+comparing the output.
+
+## OpaqueFunction handling
+
+Python launch files can contain `OpaqueFunction` — arbitrary Python callables
+that generate launch actions at runtime.  These cannot be statically analyzed.
+
+launch-plus handles them by **executing the Python callable** with patched
+filesystem access:
+- `open()`, `yaml.safe_load()`, `os.path.*`, and `pathlib.Path.open` are
+  intercepted
+- File reads go through portable `$(find-pkg-share pkg)/...` paths
+- If a package hasn't been fetched yet, it is sparse-checked out on demand
+
+The `--apply-opaque-file-access` flag enables this.  Without it, file access in
+OpaqueFunction bodies is recorded as an error (strict mode).
+
+## Python launch shims
+
+When resolving Python launch files, launch-plus does **not** import the real
+`launch` or `launch_ros` packages.  Instead, it injects lightweight shim modules
+that record constructor arguments (package, executable, parameters, remaps)
+into a structured trace.
+
+This means:
+- No ROS 2 Python packages need to be installed on the resolver host
+- The resolver captures the launch description structure without scheduling
+  anything for execution
+- All standard `launch` / `launch_ros` API patterns are supported
+
+## Dependency closure
+
+When building (`launch-plus build`), the tool computes the **transitive
+build-dependency closure** from the resolved launch graph:
+
+1. **Direct packages** — every package referenced in the launch file
+   (`<node pkg="...">`, `$(find-pkg-share ...)`, `<include>`)
+2. **Transitive build deps** — `build_depend`, `buildtool_depend`, and `<depend>`
+   from each package's `package.xml`, expanded recursively
+3. **System deps** — packages not in the lockfile are resolved via `rosdep`
+   (with `--rosdep`)
+
+Only the resulting minimal set is passed to `colcon build --packages-select`.
+
+### Why `exec_depend` is excluded
+
+A critical difference from `colcon build --packages-up-to` is that launch-plus
+**does not follow `exec_depend`** when computing the build closure.
+
+`exec_depend` declares packages needed at *runtime* — not at build time.  When
+you run `colcon build --packages-up-to my_node`, colcon treats `exec_depend` as
+an implicit build dependency and pulls those packages (and their transitive
+dependencies) into the build set.  This is conservative but wasteful: runtime
+dependencies like message transport libraries or shared utility packages are
+often already installed as system packages and don't need to be built from
+source.
+
+This is a well-known pain point.  The Autoware project, for instance, maintains
+a dedicated CI action
+([`remove-exec-depend`](https://github.com/autowarefoundation/autoware-github-actions/tree/main/remove-exec-depend))
+that strips `<exec_depend>` entries from every `package.xml` before building —
+a workaround for colcon's inability to distinguish build-time from runtime
+dependencies.
+
+launch-plus avoids this entirely.  Because the resolver already knows which
+packages are actually needed (it read the launch file), it computes the build
+closure using only `build_depend` and `buildtool_depend`.  Packages that are
+only referenced at runtime are expected to be available as installed system
+packages — exactly the role `exec_depend` was designed to express.
+
+## Static analysis: what the resolver can verify
+
+The `resolve` and `check` commands perform static analysis on the launch graph.
+Here is what the resolver can and cannot verify.
+
+### What it verifies
+
+- **Package existence** — every `$(find-pkg-share pkg)`, `<node pkg="...">`,
+  and `<include>` target must reference a package that exists in the lockfile
+  or on `AMENT_PREFIX_PATH`
+- **Launch file existence** — included launch files must exist on disk (or be
+  fetchable from the lockfile)
+- **Argument completeness** — every `$(var name)` / `$(arg name)` reference must
+  have a corresponding `<arg name="...">` declaration or be supplied on the
+  command line (in strict mode without `--apply-launch-arg-defaults`)
+- **Argument forwarding** — in strict mode (without `--allow-global-arg-cascade`),
+  arguments used in an included file must be explicitly forwarded via
+  `<arg name="..." value="..."/>` in the `<include>` tag
+- **Conditional evaluation** — `if="..."` and `unless="..."` attributes are
+  fully evaluated, so only the active branches appear in the output
+- **Substitution resolution** — all `$(var)`, `$(arg)`, `$(env)`, `$(eval)`,
+  `$(find-pkg-share)` expressions are resolved; unresolvable substitutions are
+  errors
+- **Parameter file validity** — with `--inline-params`, YAML parameter files are
+  parsed and their structure validated (must follow ROS 2 `ros__parameters`
+  conventions)
+- **Namespace composition** — with `--flatten-namespaces`, the full namespace
+  stack is computed for every node
+- **OpaqueFunction execution** — Python callables are executed (not just parsed),
+  so runtime errors in OpaqueFunction bodies are caught during resolution
+
+### What it does not verify
+
+- **Runtime type correctness** — parameter types are not checked against what
+  the node code expects
+- **Topic/service connectivity** — the resolver does not verify that publishers
+  match subscribers or that service servers exist for clients
+- **Executable existence** — `<node pkg="..." exec="...">` does not verify that
+  the executable exists in the installed package
+- **Message type compatibility** — no check that connected topics use compatible
+  message types
+- **Resource availability** — hardware devices, network interfaces, GPU
+  resources, etc. are not verified
+- **Non-launch-graph side effects** — if an OpaqueFunction spawns a subprocess,
+  modifies global state, or performs network I/O, those effects are not analyzed
+
+### The `check` command
+
+`launch-plus check` is a thin alias over `resolve` that exits non-zero on any
+warning or error.  Use it in CI to catch:
+- Missing packages or launch files
+- Undefined or unforwarded arguments
+- Broken `$(eval ...)` expressions
+- OpaqueFunction failures
+- Unresolvable `$(find-pkg-share ...)` references
+
+```bash
+# CI validation example
+launch-plus check -c my_pkg my_launch.xml \
+  arg1:=value1 \
+  --preview --rosdep
+```
+
+## rosdep integration
+
+The `--rosdep` flag enables automatic system dependency resolution.  When a
+package required by the build is not in the lockfile (e.g. a ROS buildfarm
+package like `rosbridge_server`), launch-plus:
+
+1. Checks `AMENT_PREFIX_PATH` — if the package is already installed, it's used
+   directly
+2. Runs `rosdep resolve` to map rosdep keys to system package names
+3. Installs via `apt-get` (for `#apt`) or `pip` (for `#pip`)
+
+This uses `rosdep resolve` + manual install rather than `rosdep install` directly,
+because `rosdep install` cannot handle an explicit list of rosdep keys without
+either scanning an entire source tree (`--from-paths`) or misinterpreting keys
+as ROS package names.

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -34,33 +34,29 @@ every repository to a concrete commit SHA and records the ROS packages each
 repository contains.
 
 ```yaml
-version: 1
-repos:
-  autowarefoundation/autoware_msgs:
+repositories:
+  core/autoware_msgs:
+    type: git
     url: https://github.com/autowarefoundation/autoware_msgs.git
-    version: 1.11.0
-    sha: abc123def456...
-    workspace_path: core/autoware_msgs
+    version: 588f00df3acca009ea709a74acd6538897eef424  # pinned SHA
+    ref: 1.11.0                                        # original tag/branch
     packages:
+      - autoware_common_msgs
       - autoware_msgs
       - autoware_planning_msgs
 
 packages:
   autoware_msgs:
-    repo: autowarefoundation/autoware_msgs
+    repo: core/autoware_msgs
     path: autoware_msgs
-    dependencies:
-      build: [rosidl_default_generators]
-      exec: [rosidl_default_runtime]
-      test: [ament_lint_auto]
 ```
 
 The lockfile is dual-indexed:
-- **`repos`** — grouped by repository, used during fetching
+- **`repositories`** — grouped by repository, used during fetching
 - **`packages`** — indexed by package name, used for O(1) dependency lookup
 
 This gives you:
-- **Reproducibility** — `sha` pins mean identical source code every time
+- **Reproducibility** — SHA pins mean identical source code every time
 - **Sparse clone map** — the lockfile records which packages live in which
   repository and at what path, so launch-plus can sparse-checkout *only* the
   packages it needs without cloning entire repositories

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -60,8 +60,9 @@ This gives you:
 - **Sparse clone map** — the lockfile records which packages live in which
   repository and at what path, so launch-plus can sparse-checkout *only* the
   packages it needs without cloning entire repositories
-- **Offline dependency graph** — transitive build closures can be computed from
-  the lockfile alone, without cloning anything
+- **On-demand dependency expansion** — the lockfile maps every package to its
+  repository and path, enabling launch-plus to fetch only the `package.xml`
+  files it needs and expand the dependency graph incrementally
 - **`.repos` compatibility** — the lockfile is a valid `.repos` file.  You can
   pass it to `vcs import` as a drop-in replacement for your original manifest,
   getting the same repos at the exact pinned SHAs.  This means adopting
@@ -197,8 +198,9 @@ build-dependency closure** from the resolved launch graph:
 
 1. **Direct packages** — every package referenced in the launch file
    (`<node pkg="...">`, `$(find-pkg-share ...)`, `<include>`)
-2. **Transitive build deps** — `build_depend`, `buildtool_depend`, and `<depend>`
-   from each package's `package.xml`, expanded recursively
+2. **Transitive build deps** — `build_depend`, `buildtool_depend`,
+   `build_export_depend`, `buildtool_export_depend`, and `<depend>` from each
+   package's `package.xml`, expanded recursively
 3. **System deps** — packages not in the lockfile are resolved via `rosdep`
    (with `--rosdep`)
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -206,10 +206,10 @@ build-dependency closure** from the resolved launch graph:
 
 Only the resulting minimal set is passed to `colcon build --packages-select`.
 
-### Why `exec_depend` is excluded
+### The `exec_depend` problem
 
-A critical difference from `colcon build --packages-up-to` is that launch-plus
-**does not follow `exec_depend`** when computing the build closure.
+A key design goal is to exclude `exec_depend` from the build closure — a critical
+difference from `colcon build --packages-up-to`.
 
 `exec_depend` declares packages needed at *runtime* — not at build time.  When
 you run `colcon build --packages-up-to my_node`, colcon treats `exec_depend` as

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -143,7 +143,8 @@ building, just to work around colcon's behavior.
 
 Once colcon is replaced with direct ament invocations
 ([#18](https://github.com/paulsohn/launch-plus/issues/18)), the build closure
-will use only `build_depend` and `buildtool_depend`.  Runtime dependencies will
+will use only `build_depend`, `buildtool_depend`, `build_export_depend`, and
+`buildtool_export_depend`.  Runtime dependencies will
 be expected to be satisfied by installed system packages — exactly the role
 `exec_depend` was designed to express.  See
 [Dependency closure](concepts.md#dependency-closure) for details.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -195,8 +195,9 @@ launch-plus update core/my_msgs     # update a specific repo (uses lockfile key)
 ### What if a package isn't in the lockfile?
 
 If a package is referenced in a launch file but not in the lockfile:
-1. With `--rosdep`: launch-plus checks `AMENT_PREFIX_PATH` first, then tries
-   `rosdep install` to install it as a system package
+1. With `--rosdep`: launch-plus checks `AMENT_PREFIX_PATH` first, then runs
+   `rosdep resolve` to map the key to a system package name and installs it
+   via `apt-get` or `pip`
 2. Without `--rosdep`: the resolver reports an error
 
 This is by design — the lockfile is the single source of truth for your

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,230 @@
+# FAQ
+
+## General
+
+### How is this different from just using colcon with `--packages-up-to`?
+
+`colcon build --packages-up-to <pkg>` builds a package and its transitive
+dependencies, but it requires:
+1. All source code to already be cloned
+2. You to know which packages to list
+3. All system dependencies to already be installed
+
+launch-plus automates all three: it determines the package list by analyzing the
+launch file, sparse-checks out only those packages, and installs their system
+dependencies.
+
+### Is this Bazel but for ROS?
+
+There are real similarities.  Like Bazel, launch-plus treats a **target** (in our
+case, a launch file) as the entry point and computes the minimal set of things that
+need to be built.  Both aim for reproducible, hermetic builds — Bazel through its
+sandbox and content-addressable cache, launch-plus through its SHA-pinned lockfile.
+
+But launch-plus is **not** a general-purpose build system.  It is a
+ROS 2-specific tool that understands launch files, `package.xml`, and the
+`colcon`/`ament` ecosystem natively.
+
+Bazel rules for ROS 2 do exist (e.g. the ones provided by Apex.AI), and they
+work well for teams that can commit to a full Bazel migration.  However, adopting
+Bazel in an existing ROS 2 project is a significant undertaking:
+
+- Every package needs a `BUILD` file — `package.xml` and `CMakeLists.txt` are not
+  enough
+- The entire build toolchain changes: `colcon`, `ament_cmake`, and `rosdep` are
+  replaced by Bazel equivalents
+- Third-party ROS packages (from the buildfarm or other `.repos` sources) must be
+  wrapped with Bazel build rules
+- Teams must learn and maintain a parallel build system
+
+launch-plus takes the opposite approach: **zero migration**.  It works with the
+ROS 2 conventions your project already uses — `.repos` manifests, `package.xml`,
+`colcon build`, `rosdep` — and layers the dependency-tracing and sparse-checkout
+capabilities on top.  You can adopt it incrementally without changing any existing
+build files.
+
+Additionally, launch-plus provides **launch-graph-aware static analysis** that
+Bazel does not: argument validation, namespace composition, conditional evaluation,
+OpaqueFunction execution, and parameter file verification.  These are
+ROS 2-specific concerns that a general-purpose build system has no reason to
+address.
+
+In short: if your team has already invested in Bazel for ROS 2, you may not need
+launch-plus for the build subset.  But if you use the standard `colcon`/`ament`
+toolchain — as most ROS 2 projects do — launch-plus gives you Bazel-like
+targeted builds and reproducibility without requiring a build system migration.
+
+### Do I need ROS 2 installed to use the resolver?
+
+Yes — you should have ROS 2 installed and sourced.  Since launch-plus operates on
+ROS 2 projects, a sourced ROS 2 environment (`AMENT_PREFIX_PATH`) is the expected
+baseline.  Even packages like `numpy` that are installed system-wide won't be found
+by the resolver unless they are on `AMENT_PREFIX_PATH`.
+
+That said, the resolver itself (especially without `--rosdep`) does not link against any
+ROS 2 libraries — it only needs Python 3, Git, and the environment variables that
+`source /opt/ros/<distro>/setup.bash` provides.
+
+### Can I use this with my existing `.repos` files?
+
+Yes.  launch-plus reads standard [vcstool](https://github.com/dirk-thomas/vcstool)
+`.repos` files.  You can point `launch-plus index` at your existing manifests.
+
+### Does this replace `ros2 launch`?
+
+Not yet.  Today launch-plus is a **build-time** tool: it resolves and builds the
+packages you need, but you still use `ros2 launch` (or your preferred launcher)
+to actually run the system.  The `resolve` command produces a flattened XML that
+shows what `ros2 launch` would do — useful for debugging and CI.
+
+**Execution support is planned.**  The roadmap includes:
+- A **built-in executor** that directly consumes the resolved launch structure
+  to spawn and manage processes
+- **Integration with existing launchers** — `ros2 launch`, and third-party
+  reimplementations — so you can choose the execution backend that fits your
+  project
+
+The goal is a complete `resolve → build → launch` pipeline in a single tool,
+while remaining compatible with the broader ROS 2 launch ecosystem.
+
+## Resolution
+
+### What does "preview" mode mean?
+
+Preview mode (`--preview`) resolves the launch file against the **source
+workspace** without requiring packages to be built.  The output uses portable
+`$(find-pkg-share ...)` paths.  This is the fastest way to see the full launch
+graph.
+
+Without `--preview`, resolution uses `AMENT_PREFIX_PATH` (installed packages).
+
+### Why do some flags have such long names?
+
+Flags like `--allow-global-arg-cascade` and `--apply-launch-arg-defaults` are
+intentionally verbose.  They enable behaviors that work around common anti-
+patterns in legacy launch files (implicit argument propagation, reliance on
+defaults).  The verbose names encourage fixing the root cause in the launch files
+rather than permanently depending on the workaround.
+
+### What happens with OpaqueFunction?
+
+`OpaqueFunction` is a ROS 2 launch construct that wraps an arbitrary Python
+callable.  launch-plus **executes** these callables with patched filesystem
+access so that:
+- `open()` calls are intercepted and resolved via portable paths
+- Missing packages are fetched on demand
+- Parameter YAML files are read and their contents captured
+
+Use `--apply-opaque-file-access` to enable this.  Without it, file access in
+OpaqueFunction bodies produces an error (strict mode).
+
+### Why is the resolver redirecting my print() output?
+
+The Python resolver communicates with the Rust host via JSON on stdout.  Any
+`print()` in your launch file (including inside OpaqueFunction bodies) would
+corrupt this channel.  launch-plus redirects `sys.stdout` to `sys.stderr` before
+executing your launch file, so `print()` still works — it just goes to stderr.
+
+## Building
+
+### Why doesn't launch-plus build `exec_depend` packages?
+
+By design.  `exec_depend` declares packages needed at *runtime*, not at build
+time.  `colcon build --packages-up-to` treats `exec_depend` as a build
+dependency, pulling in packages (and their transitive closures) that never
+needed to be compiled from source — they're already available as installed
+system packages.
+
+This is a well-known problem.  The Autoware project maintains
+[`remove-exec-depend`](https://github.com/autowarefoundation/autoware-github-actions/tree/main/remove-exec-depend),
+a CI action that strips `<exec_depend>` from every `package.xml` before
+building, just to work around colcon's behavior.
+
+launch-plus computes the build closure using only `build_depend` and
+`buildtool_depend`.  Runtime dependencies are expected to be satisfied by
+installed system packages — exactly the role `exec_depend` was designed to
+express.  See [Dependency closure](concepts.md#dependency-closure) for details.
+
+### How does `--colcon-flagfile` work?
+
+The flagfile contains extra arguments for `colcon build`, one shell token per
+line.  Comments (`#`) are supported:
+
+```txt
+--symlink-install
+--cmake-args
+-DCMAKE_BUILD_TYPE=Release
+--parallel-workers
+4
+```
+
+Flags that conflict with launch-plus-managed arguments (`--packages-select`,
+`--base-paths`, `--build-base`, `--install-base`) are rejected.
+
+### Can I build for a different ROS distro?
+
+The resolver uses the currently-sourced ROS 2 environment (`ROS_DISTRO`,
+`AMENT_PREFIX_PATH`).  To build for a different distro, source that distro's
+setup file before running launch-plus.
+
+### What about cross-compilation?
+
+launch-plus itself is a native tool.  Cross-compilation of ROS 2 packages
+depends on your colcon/CMake cross-compilation setup.  You can pass
+cross-compilation flags via the colcon flagfile.
+
+## Lockfile
+
+### Should I commit the lockfile?
+
+Yes.  The lockfile pins every repository to a concrete commit SHA, ensuring
+reproducible builds.  Without it, different developers or CI runs may get
+different source code.
+
+### How do I update the lockfile?
+
+```bash
+launch-plus update              # re-resolve all refs
+launch-plus update my_msgs      # update specific repos
+```
+
+### What if a package isn't in the lockfile?
+
+If a package is referenced in a launch file but not in the lockfile:
+1. With `--rosdep`: launch-plus checks `AMENT_PREFIX_PATH` first, then tries
+   `rosdep install` to install it as a system package
+2. Without `--rosdep`: the resolver reports an error
+
+This is by design — the lockfile is the single source of truth for your
+workspace's source packages.  System packages (installed via apt/rosdep) are
+handled separately.
+
+### What if different ECUs need different versions of the same package?
+
+Use **separate lockfiles** for each context that requires a different package
+version.  A lockfile maps each package name to exactly one version — this
+matches the ROS 2 runtime constraint where `AMENT_PREFIX_PATH` resolves each
+package name to a single location.
+
+```bash
+# Different .repos → different lockfiles
+launch-plus index -l perception.lock.repos perception.repos
+launch-plus index -l planning.lock.repos planning.repos
+
+# Each context builds against its own lockfile
+launch-plus build -l perception.lock.repos perception_launch perception.launch.xml --clean
+launch-plus build -l planning.lock.repos planning_launch planning.launch.xml --clean
+```
+
+That said, **sharing a single lockfile across all ECUs in a system is strongly
+recommended** whenever possible.  ECUs communicate via ROS 2 topics and
+services — if message type definitions diverge between ECUs, the system breaks
+at runtime.  A shared lockfile guarantees that all ECUs agree on message types,
+interface packages, and shared libraries.  Real-world multi-ECU deployments
+(7+ ECUs) routinely share a single lockfile for this reason.
+
+Multiple lockfiles should be reserved for cases where version divergence is
+genuinely required and the teams have explicitly verified interface
+compatibility.  In practice this is rare — the `.repos` files can overlap, and
+launch-plus already builds only the subset each ECU needs from the shared
+lockfile.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -128,23 +128,25 @@ executing your launch file, so `print()` still works — it just goes to stderr.
 
 ## Building
 
-### Why doesn't launch-plus build `exec_depend` packages?
+### Why does launch-plus still build `exec_depend` packages?
 
-By design.  `exec_depend` declares packages needed at *runtime*, not at build
-time.  `colcon build --packages-up-to` treats `exec_depend` as a build
-dependency, pulling in packages (and their transitive closures) that never
-needed to be compiled from source — they're already available as installed
-system packages.
+It shouldn't have to — `exec_depend` declares packages needed at *runtime*, not
+at build time.  However, launch-plus currently delegates to `colcon build`, which
+validates that **all** `package.xml` dependencies (including `exec_depend`) have
+install artifacts before running cmake.  There is no colcon flag to disable this
+check, so launch-plus must include `exec_depend` in the build set today.
 
-This is a well-known problem.  The Autoware project maintains
+This is a well-known pain point.  The Autoware project maintains
 [`remove-exec-depend`](https://github.com/autowarefoundation/autoware-github-actions/tree/main/remove-exec-depend),
 a CI action that strips `<exec_depend>` from every `package.xml` before
 building, just to work around colcon's behavior.
 
-launch-plus computes the build closure using only `build_depend` and
-`buildtool_depend`.  Runtime dependencies are expected to be satisfied by
-installed system packages — exactly the role `exec_depend` was designed to
-express.  See [Dependency closure](concepts.md#dependency-closure) for details.
+Once colcon is replaced with direct ament invocations
+([#18](https://github.com/paulsohn/launch-plus/issues/18)), the build closure
+will use only `build_depend` and `buildtool_depend`.  Runtime dependencies will
+be expected to be satisfied by installed system packages — exactly the role
+`exec_depend` was designed to express.  See
+[Dependency closure](concepts.md#dependency-closure) for details.
 
 ### How does `--colcon-flagfile` work?
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -58,10 +58,11 @@ targeted builds and reproducibility without requiring a build system migration.
 
 Yes — you should have ROS 2 installed and sourced.  Since launch-plus operates on
 ROS 2 projects, a sourced ROS 2 environment (`AMENT_PREFIX_PATH`) is the expected
-baseline.  Even packages like `numpy` that are installed system-wide won't be found
-by the resolver unless they are on `AMENT_PREFIX_PATH`.
+baseline.  The resolver uses `AMENT_PREFIX_PATH` to locate installed ROS packages
+(e.g. buildfarm packages like `tf2_ros` or `rosbridge_server`), so packages that
+are only available through the ROS 2 overlay won't be found without sourcing.
 
-That said, the resolver itself (especially without `--rosdep`) does not link against any
+That said, the resolver itself (without `--rosdep`) does not link against any
 ROS 2 libraries — it only needs Python 3, Git, and the environment variables that
 `source /opt/ros/<distro>/setup.bash` provides.
 
@@ -184,8 +185,8 @@ different source code.
 ### How do I update the lockfile?
 
 ```bash
-launch-plus update              # re-resolve all refs
-launch-plus update my_msgs      # update specific repos
+launch-plus update                  # re-resolve all refs
+launch-plus update core/my_msgs     # update a specific repo (uses lockfile key)
 ```
 
 ### What if a package isn't in the lockfile?

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -5,8 +5,8 @@ This guide walks through using launch-plus with your own ROS 2 project.
 ## Prerequisites
 
 - **Rust toolchain** (edition 2024, MSRV 1.85) — install via [rustup.rs](https://rustup.rs)
-- **Python 3** — used to evaluate Python launch files and `$(eval ...)` substitutions
-  in XML launch files
+- **Python 3.10+** — used to evaluate Python launch files and `$(eval ...)`
+  substitutions in XML launch files
 - **Git** — for sparse-checkout operations
 - **ROS 2** — required for `--rosdep` (system dependency resolution) and
   post-build resolution; the resolver itself does not depend on ROS 2 Python

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,198 @@
+# Getting Started
+
+This guide walks through using launch-plus with your own ROS 2 project.
+
+## Prerequisites
+
+- **Rust toolchain** (edition 2024, MSRV 1.85) — install via [rustup.rs](https://rustup.rs)
+- **Python 3** — used to evaluate Python launch files
+- **Git** — for sparse-checkout operations
+- **ROS 2** — required for `--rosdep` (system dependency resolution) and
+  post-build resolution; the resolver itself does not depend on ROS 2 Python
+  packages
+
+## Installation
+
+```bash
+git clone https://github.com/paulsohn/launch-plus.git
+cd launch-plus
+cargo build --bin launch-plus --release
+
+# Add to PATH (optional)
+export PATH="$PWD/target/release:$PATH"
+```
+
+## Step 1: Create a .repos manifest
+
+Write a `.repos` file listing the git repositories your project uses.  This is
+the standard [vcstool](https://github.com/dirk-thomas/vcstool) format:
+
+```yaml
+# my_project.repos
+repositories:
+  core/my_msgs:
+    type: git
+    url: https://github.com/my-org/my_msgs.git
+    version: v1.0.0              # tag, branch, or SHA
+
+  drivers/my_driver:
+    type: git
+    url: https://github.com/my-org/my_driver.git
+    version: main
+
+  launch/my_bringup:
+    type: git
+    url: https://github.com/my-org/my_bringup.git
+    version: v2.1.0
+```
+
+If you already have a `.repos` file (e.g. from an existing vcstool workflow),
+you can use it directly.
+
+## Step 2: Generate a lockfile
+
+```bash
+launch-plus index my_project.repos
+```
+
+This resolves every version reference to a concrete commit SHA, scans each
+repository for ROS packages, and writes `manifest.lock.repos`.
+
+The lockfile records:
+- Exact commit SHAs for every repository
+- Package names and their locations within each repository
+- Dependencies from `package.xml`
+
+**Commit the lockfile** alongside your `.repos` manifest.  This ensures
+reproducible builds — anyone with the same lockfile will get exactly the same
+source code.
+
+To update the lockfile when upstream repos change:
+
+```bash
+launch-plus update          # re-resolve all refs
+launch-plus update my_msgs  # update specific repos
+```
+
+## Step 3: Resolve a launch file
+
+```bash
+launch-plus resolve -d my_bringup robot.launch.xml \
+  robot_name:=my_robot \
+  --preview \
+  > resolved.launch.xml
+```
+
+This will:
+1. Look up `my_bringup` in the lockfile
+2. Sparse-checkout just the `my_bringup` package
+3. Parse `robot.launch.xml`, following all `<include>` tags
+4. Fetch additional packages as they're discovered in the launch graph
+5. Output a single flattened XML with all includes inlined, variables
+   substituted, and conditionals evaluated
+
+The `-d` (dirty) flag tells launch-plus to use whatever is on disk and only
+fetch what's missing.  Use `-c` (clean) for CI to ensure reproducibility.
+
+### Useful resolve flags
+
+```bash
+# Show launch arguments at include boundaries
+--show-args
+
+# Expand <param from="file.yaml"/> entries inline
+--inline-params
+
+# Fold namespace stacks onto each <node> element
+--flatten-namespaces
+
+# Allow OpaqueFunction bodies to read parameter files
+--apply-opaque-file-access
+
+# Fill unset args from their declared defaults
+--apply-launch-arg-defaults
+
+# Propagate parent args into included files (legacy launch files)
+--allow-global-arg-cascade
+
+# Install system deps via rosdep (requires sourced ROS 2)
+--rosdep
+```
+
+## Step 4: Build
+
+```bash
+source /opt/ros/humble/setup.bash
+
+launch-plus build -c my_bringup robot.launch.xml \
+  robot_name:=my_robot \
+  --rosdep \
+  --colcon-flagfile colcon-flags.txt
+```
+
+This resolves the launch file, computes the transitive build-dependency closure,
+fetches any missing packages, installs system dependencies via rosdep, and runs
+`colcon build` with only the needed packages.
+
+### Colcon flagfile
+
+Extra colcon arguments are passed via a **flagfile** — one shell token per line:
+
+```txt
+# colcon-flags.txt
+--symlink-install
+--cmake-args
+-DCMAKE_BUILD_TYPE=Release
+--parallel-workers
+4
+```
+
+## Step 5: Verify (optional)
+
+After building, you can verify that the pre-build (preview) resolution matches
+the post-build resolution:
+
+```bash
+# Source the built workspace
+source install/setup.bash
+
+# Post-build resolve
+launch-plus resolve -d my_bringup robot.launch.xml \
+  robot_name:=my_robot \
+  > postbuild.launch.xml
+
+# Preview resolve with path expansion (for comparison)
+launch-plus resolve -d my_bringup robot.launch.xml \
+  robot_name:=my_robot \
+  --preview --expand-paths \
+  > preview.launch.xml
+
+# Compare — should be identical
+diff preview.launch.xml postbuild.launch.xml
+```
+
+## Directory layout
+
+After running launch-plus, your workspace will look like:
+
+```
+my_workspace/
+├── my_project.repos          # your manifest
+├── manifest.lock.repos       # generated lockfile (commit this)
+├── colcon-flags.txt          # colcon arguments
+├── src/                      # sparse-checked out packages
+│   ├── core/my_msgs/
+│   ├── drivers/my_driver/
+│   └── launch/my_bringup/
+├── build/                    # colcon build output
+├── install/                  # colcon install output
+└── log/                      # colcon log output
+```
+
+## Next steps
+
+- Read [Core Concepts](concepts.md) for deeper understanding of lockfiles,
+  portable paths, and OpaqueFunction handling
+- See [Architecture](architecture.md) for how the resolver works internally
+- Check [Supported Environments](supported-environments.md) for platform
+  compatibility and known limitations

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -62,7 +62,6 @@ repository for ROS packages, and writes `manifest.lock.repos`.
 The lockfile records:
 - Exact commit SHAs for every repository
 - Package names and their locations within each repository
-- Dependencies from `package.xml`
 
 **Commit the lockfile** alongside your `.repos` manifest.  This ensures
 reproducible builds — anyone with the same lockfile will get exactly the same

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -5,7 +5,8 @@ This guide walks through using launch-plus with your own ROS 2 project.
 ## Prerequisites
 
 - **Rust toolchain** (edition 2024, MSRV 1.85) — install via [rustup.rs](https://rustup.rs)
-- **Python 3** — used to evaluate Python launch files
+- **Python 3** — used to evaluate Python launch files and `$(eval ...)` substitutions
+  in XML launch files
 - **Git** — for sparse-checkout operations
 - **ROS 2** — required for `--rosdep` (system dependency resolution) and
   post-build resolution; the resolver itself does not depend on ROS 2 Python
@@ -70,8 +71,8 @@ source code.
 To update the lockfile when upstream repos change:
 
 ```bash
-launch-plus update          # re-resolve all refs
-launch-plus update my_msgs  # update specific repos
+launch-plus update              # re-resolve all refs
+launch-plus update core/my_msgs # update a specific repo (uses lockfile key)
 ```
 
 ## Step 3: Resolve a launch file

--- a/docs/motivation.md
+++ b/docs/motivation.md
@@ -1,0 +1,165 @@
+# Motivation
+
+## The scaling problem in ROS 2 workspaces
+
+ROS 2 projects tend to grow into large multi-repository workspaces.  A production
+autonomous driving stack may contain 200+ packages across 50+ repositories.  The
+standard development workflow looks like this:
+
+```bash
+vcs import src < project.repos       # clone all repositories
+rosdep install --from-paths src      # install ALL system dependencies
+colcon build                         # build ALL packages
+source install/setup.bash
+ros2 launch my_package my_launch.xml # finally launch
+```
+
+Every developer, every CI job, and every deployment target repeats this process
+in full — even when only a fraction of the workspace is actually needed.
+
+## Pain points of the traditional workflow
+
+### Each step is a separate, uncoordinated tool
+
+The `vcs import → rosdep install → colcon build → ros2 launch` pipeline is a
+chain of independent tools that share no context:
+
+1. **`vcs import`** clones everything in the `.repos` file.  It has no knowledge
+   of which packages you actually need.
+2. **`rosdep install --from-paths src`** scans *every* `package.xml` under `src/`
+   and installs system dependencies for *all* of them — including packages you
+   will never build, and test-only dependencies you don't need.
+3. **`colcon build`** builds everything.  You can use `--packages-up-to` to
+   build a subset, but you need to know which packages to list, all source
+   code must already be cloned, and colcon still pulls in `exec_depend`
+   packages — runtime dependencies that don't need to be built from source.
+   The Autoware project maintains a dedicated CI action
+   ([`remove-exec-depend`](https://github.com/autowarefoundation/autoware-github-actions/tree/main/remove-exec-depend))
+   that strips `<exec_depend>` from every `package.xml` before building, just
+   to work around this.
+4. **`ros2 launch`** finally runs the system — but at this point you've already
+   paid the full cost.
+
+There is no way to say "I want to launch *this* launch file — give me exactly
+what I need and nothing more."
+
+### No lockfile, no reproducibility
+
+The `.repos` format uses mutable references (`version: main`, `version: v1.0.0`)
+that can change between runs.  A tag can be force-pushed, a branch advances with
+every commit.  Two developers running `vcs import` on the same `.repos` file a
+week apart may get different source code with no way to detect the difference.
+
+Other ecosystems solved this with lockfiles long ago (npm's `package-lock.json`,
+Cargo's `Cargo.lock`, Pixi's `pixi.lock`).  ROS 2 has had no equivalent.
+
+### Whole-workspace operations are expensive
+
+A full workspace build takes **30–60 minutes** on a reasonably powerful
+machine.  During active development, most changes affect only a handful of
+packages, yet the entire workspace must be cloned, dependency-resolved, and
+built before anything can run.
+
+### Multi-ECU / multi-target deployments
+
+Production robotics systems often run across **multiple compute units** (ECUs),
+each responsible for a different subsystem — perception on a GPU node, planning
+on a CPU node, logging/streaming on a third.
+
+Each ECU needs only a subset of the full workspace, but the standard ROS 2
+tooling provides no way to express "build only the packages needed for *this*
+launch configuration."  Teams end up maintaining **per-ECU build configurations**
+— manually curated lists of which repositories or packages to clone and build
+for each target.
+
+The specifics vary across organizations: some use label-based repository
+filtering, some maintain separate `.repos` files per ECU, some use custom
+scripts that hardcode package lists.  Regardless of the mechanism, the
+fundamental problem is the same:
+
+- **Manual maintenance** — someone must keep the per-ECU package list in sync
+  with the actual launch-time dependencies.  When a launch file starts including
+  a new package, someone must remember to update the build configuration.
+- **Coarse granularity** — these lists typically operate at the repository level,
+  not the package level.  A repository with 20 packages gets cloned and built in
+  full even if only 1 package is needed.
+- **No single source of truth** — the real dependency information is in the
+  launch files and `package.xml` files, but the build system ignores it and
+  relies on manually-curated lists instead.
+- **Drift** — over time, build configurations accumulate stale entries.  Nobody
+  removes a package when a dependency is dropped.  Nobody adds one until CI
+  breaks.
+
+### The insight: launch files already declare runtime dependencies
+
+A ROS 2 launch file is, in effect, a **runtime dependency manifest**.  It
+declares which packages to load, which nodes to run, which config files to read,
+and which other launch files to include.  This is the same information that
+`exec_depend` tries to capture in `package.xml` — but the launch file expresses
+it more precisely, because it reflects the *actual* runtime composition rather
+than a manually-maintained, often over-inclusive list.
+
+All the information needed to determine the minimal build set is already there —
+it just needs to be extracted.
+
+This is the core insight behind launch-plus: **treat the launch file as a build
+target**, like Bazel treats a `BUILD` file.  Instead of relying on `exec_depend`
+or manually labeling repositories, let the tool trace the launch graph and
+determine exactly which packages are needed.
+
+## What launch-plus provides
+
+launch-plus replaces the four-step pipeline with a single command that
+understands the full picture:
+
+```
+# Traditional: 4 tools, no shared context
+vcs import src < project.repos            # clone everything
+rosdep install --from-paths src           # install all deps
+colcon build                              # build everything
+ros2 launch my_pkg my_launch.xml          # launch
+
+# launch-plus: 1 tool, launch-file-driven
+launch-plus build my_pkg my_launch.xml \
+  --clean --rosdep                        # fetch + deps + build (only what's needed)
+ros2 launch my_pkg my_launch.xml          # launch
+```
+
+| Traditional workflow | launch-plus workflow |
+|---|---|
+| Mutable `.repos` refs | SHA-pinned lockfile (reproducible) |
+| Clone all repos | Sparse-checkout only needed packages |
+| Install all system deps | Install deps for needed packages only |
+| Build all packages | Build minimal transitive closure |
+| Manual per-ECU configs | Automatic dependency tracing |
+| Separate build lists per target | Per-ECU launch file = per-ECU build set |
+
+With launch-plus, the multi-ECU problem reduces to:
+
+```bash
+# Perception ECU — just point at the perception launch file
+launch-plus build perception_launch perception.launch.xml --clean --rosdep
+
+# Planning ECU — point at the planning launch file
+launch-plus build planning_launch planning.launch.xml --clean --rosdep
+
+# Logging ECU — point at the logging launch file
+launch-plus build logging_launch logging.launch.xml --clean --rosdep
+```
+
+No labels.  No manual filtering.  The launch file *is* the build specification.
+
+## Beyond Autoware
+
+While launch-plus was developed with Autoware as the primary test case, it is
+designed to work with **any ROS 2 project** that uses standard `.repos` manifests
+and launch files.  The tool has no Autoware-specific logic — it operates on
+standard ROS 2 conventions:
+
+- `.repos` files (vcstool format)
+- `package.xml` (REP-149 / REP-127)
+- XML and Python launch files (ROS 2 launch API)
+- `colcon` for building
+- `rosdep` for system dependency resolution
+
+If your project follows these conventions, launch-plus can help.

--- a/docs/supported-environments.md
+++ b/docs/supported-environments.md
@@ -33,7 +33,7 @@ launch-plus.
 
 ## Python
 
-- **Python 3.8+** required (for evaluating Python launch files and `$(eval ...)`
+- **Python 3.10+** required (for evaluating Python launch files and `$(eval ...)`
   substitutions in XML launch files)
 - Must be available as `python3` in `PATH`
 - No ROS 2 Python packages needed on the resolver host
@@ -46,7 +46,7 @@ command — the table below shows which tools are needed and when.
 | Executable | Required for | Notes |
 |---|---|---|
 | `git` | All commands | Sparse-checkout, ls-remote, archive |
-| `python3` | `resolve`, `build`, `check` | Evaluating Python launch files |
+| `python3` | `resolve`, `build`, `check`, `test` | Evaluating Python launch files and `$(eval ...)` |
 | `colcon` | `build`, `test` | Build orchestration; **planned to be replaceable** |
 | `rosdep` | `--rosdep` flag only | System dependency resolution; **planned to be replaceable** |
 | `apt-get` | `--rosdep` with `#apt` deps | Called via `sudo` |

--- a/docs/supported-environments.md
+++ b/docs/supported-environments.md
@@ -36,6 +36,8 @@ launch-plus.
 - **Python 3.10+** required (for evaluating Python launch files and `$(eval ...)`
   substitutions in XML launch files)
 - Must be available as `python3` in `PATH`
+- **PyYAML** (`python3-yaml`) must be installed — the Python resolver imports it
+  to parse parameter files in OpaqueFunction bodies
 - No ROS 2 Python packages needed on the resolver host
 
 ## External executables

--- a/docs/supported-environments.md
+++ b/docs/supported-environments.md
@@ -1,0 +1,143 @@
+# Supported Environments
+
+## Platforms
+
+| Platform | Status | Notes |
+|---|---|---|
+| Ubuntu 22.04 (x86_64) | Supported | Primary development platform |
+| Ubuntu 24.04 (x86_64) | Supported | |
+| Ubuntu 22.04 (aarch64) | Planned | Cross-compilation via `cross` |
+| Ubuntu 24.04 (aarch64) | Planned | Cross-compilation via `cross` |
+| macOS | Not supported | No `apt-get`; rosdep/colcon untested |
+| Windows | Not supported | Git sparse-checkout paths untested |
+
+## ROS 2 distributions
+
+| Distribution | Ubuntu | Status |
+|---|---|---|
+| Humble Hawksbill | 22.04 | Supported |
+| Jazzy Jalisco | 24.04 | Supported |
+| Rolling | 24.04 | Should work (untested in CI) |
+
+A sourced ROS 2 environment is expected.  While the resolver does not link against
+any ROS 2 libraries, it relies on `AMENT_PREFIX_PATH` to locate installed packages
+(including system packages like `numpy` that are only visible through the ROS 2
+overlay).  Source your ROS 2 setup file (`source /opt/ros/<distro>/setup.bash`)
+before running launch-plus.
+
+## Rust toolchain
+
+- **Minimum supported Rust version (MSRV):** 1.85
+- **Edition:** 2024
+- Install via [rustup.rs](https://rustup.rs)
+
+## Python
+
+- **Python 3.8+** required (for evaluating Python launch files)
+- Must be available as `python3` in `PATH`
+- No ROS 2 Python packages needed on the resolver host
+
+## External executables
+
+launch-plus shells out to several external tools.  Not all are required for every
+command — the table below shows which tools are needed and when.
+
+| Executable | Required for | Notes |
+|---|---|---|
+| `git` | All commands | Sparse-checkout, ls-remote, archive |
+| `python3` | `resolve`, `build`, `check` | Evaluating Python launch files |
+| `colcon` | `build`, `test` | Build orchestration; **planned to be replaceable** |
+| `rosdep` | `--rosdep` flag only | System dependency resolution; **planned to be replaceable** |
+| `apt-get` | `--rosdep` with `#apt` deps | Called via `sudo` |
+| `pip` | `--rosdep` with `#pip` deps | Called with `--break-system-packages` |
+
+**Planned changes:** `colcon` and `rosdep` are currently invoked as subprocesses,
+but we plan to support alternative build backends and dependency resolvers in
+the future, reducing the number of external dependencies.
+
+## Launch file support
+
+### XML launch files (`*.launch.xml`)
+
+Fully supported.  All standard ROS 2 XML launch constructs are handled:
+
+- `<node>`, `<composable_node>`, `<load_composable_node>`
+- `<include>` with argument forwarding
+- `<group>` with scoping and `<push-ros-namespace>`
+- `<arg>`, `<let>`, `<set_env>`, `<unset_env>`
+- `if=` / `unless=` conditional attributes
+- Substitutions: `$(var)`, `$(arg)`, `$(find-pkg-share)`, `$(find-pkg-prefix)`,
+  `$(env)`, `$(eval)`, `$(dirname)`
+
+### Python launch files (`*.launch.py`)
+
+Supported via shimmed imports.  Standard patterns work:
+
+- `generate_launch_description()` entry point
+- `Node`, `LifecycleNode`, `ComposableNodeContainer`, `LoadComposableNodes`
+- `IncludeLaunchDescription` with `PythonLaunchDescriptionSource` and
+  `AnyLaunchDescriptionSource`
+- `DeclareLaunchArgument`, `LaunchConfiguration`
+- `GroupAction`, `PushROSNamespace`
+- `OpaqueFunction` (with `--apply-opaque-file-access`)
+- `FindPackageShare`, `PathJoinSubstitution`
+- Conditions: `IfCondition`, `UnlessCondition`, `LaunchConfigurationEquals`
+
+### YAML launch files (`*.launch.yaml`)
+
+Not yet supported.  XML and Python cover the vast majority of ROS 2 launch
+files in practice.
+
+### Xacro (`*.xacro`, `*.urdf.xacro`)
+
+**Not supported.**  Xacro files are not launch files — they are XML macro
+templates for URDF/SDF robot descriptions.  When a launch file references a
+xacro file (e.g. via `xacro.process_file()` in an OpaqueFunction), the xacro
+processing call is preserved in the resolved output but not executed by
+launch-plus.  The actual xacro expansion happens at runtime when the system is
+launched.
+
+## Known limitations
+
+### OpaqueFunction constraints
+
+`OpaqueFunction` bodies are executed, not analyzed.  They work correctly when:
+- File reads use standard patterns (`open()`, `yaml.safe_load()`)
+- Package paths use `FindPackageShare` or `get_package_share_directory()`
+
+They may fail when:
+- The function performs network I/O or other side effects
+- The function imports non-standard packages not available on the resolver host
+- The function modifies global state that affects other launch actions
+
+### stdout in Python launch files
+
+Any `print()` output in Python launch files (including inside `OpaqueFunction`
+bodies) is redirected to stderr.  This is because the Python resolver
+communicates with Rust via JSON on stdout — any extraneous output would corrupt
+the protocol.
+
+### Conditional dependencies (REP-149)
+
+`package.xml` condition attributes (e.g.
+`<depend condition="$ROS_DISTRO == humble">pkg</depend>`) are evaluated using
+the current environment.  If `ROS_DISTRO` is not set, conditional dependencies
+are excluded.
+
+### Single-machine resolution
+
+The resolver runs on a single machine and produces output for that machine's
+architecture and ROS distribution.  Cross-distribution resolution (e.g.
+resolving a Humble launch file on a Jazzy host) is not supported.
+
+## Assumptions
+
+- **vcstool `.repos` format** — launch-plus reads standard `.repos` files.
+  Other manifest formats (rosinstall, wstool) are not supported.
+- **Standard package layout** — packages must have a `package.xml` at their root.
+  Non-standard layouts (e.g. nested packages without a top-level `package.xml`)
+  may not be detected during indexing.
+- **colcon as build tool** — the `build` command invokes `colcon build`.  Other
+  build tools (catkin_make, catkin_tools) are not supported.
+- **Git repositories** — only git repos are supported in `.repos` files.
+  Subversion, Mercurial, etc. are not handled.

--- a/docs/supported-environments.md
+++ b/docs/supported-environments.md
@@ -20,10 +20,10 @@
 | Rolling | 24.04 | Should work (untested in CI) |
 
 A sourced ROS 2 environment is expected.  While the resolver does not link against
-any ROS 2 libraries, it relies on `AMENT_PREFIX_PATH` to locate installed packages
-(including system packages like `numpy` that are only visible through the ROS 2
-overlay).  Source your ROS 2 setup file (`source /opt/ros/<distro>/setup.bash`)
-before running launch-plus.
+any ROS 2 libraries, it relies on `AMENT_PREFIX_PATH` to locate installed ROS
+packages (e.g. buildfarm packages like `rosbridge_server` or `tf2_ros`).  Source
+your ROS 2 setup file (`source /opt/ros/<distro>/setup.bash`) before running
+launch-plus.
 
 ## Rust toolchain
 
@@ -33,7 +33,8 @@ before running launch-plus.
 
 ## Python
 
-- **Python 3.8+** required (for evaluating Python launch files)
+- **Python 3.8+** required (for evaluating Python launch files and `$(eval ...)`
+  substitutions in XML launch files)
 - Must be available as `python3` in `PATH`
 - No ROS 2 Python packages needed on the resolver host
 
@@ -82,6 +83,20 @@ Supported via shimmed imports.  Standard patterns work:
 - `OpaqueFunction` (with `--apply-opaque-file-access`)
 - `FindPackageShare`, `PathJoinSubstitution`
 - Conditions: `IfCondition`, `UnlessCondition`, `LaunchConfigurationEquals`
+- Event handlers: `OnProcessExit`, `OnProcessStart`, etc.
+- `EmitEvent` and other built-in event actions
+
+**Lifecycle and event handling caveats:**  `LifecycleNode` and event-related
+constructs (`RegisterEventHandler`, `OnProcessExit`, `OnProcessStart`, etc.)
+are captured by the shims and appear as static elements in the resolved XML
+(e.g. `<lifecycle_node>`, `<on_process_exit>`).  However:
+
+- There is currently **no executor that recognizes these extended XML elements**.
+  The resolved output preserves the structure for inspection, but `ros2 launch`
+  does not understand `<lifecycle_node>` or `<on_process_exit>` tags in XML.
+- Event handler **callbacks have very limited support**: built-in actions like
+  `EmitEvent` are supported, but arbitrary Python function callbacks are not —
+  they cannot be serialized to XML.
 
 ### YAML launch files (`*.launch.yaml`)
 
@@ -91,11 +106,14 @@ files in practice.
 ### Xacro (`*.xacro`, `*.urdf.xacro`)
 
 **Not supported.**  Xacro files are not launch files — they are XML macro
-templates for URDF/SDF robot descriptions.  When a launch file references a
-xacro file (e.g. via `xacro.process_file()` in an OpaqueFunction), the xacro
-processing call is preserved in the resolved output but not executed by
-launch-plus.  The actual xacro expansion happens at runtime when the system is
-launched.
+templates for URDF/SDF robot descriptions.  When an XML launch file references
+xacro (e.g. via a `$(xacro ...)` substitution), the xacro call is preserved
+in the resolved output but not executed by launch-plus — the actual xacro
+expansion happens at runtime when the system is launched.
+
+Python-side xacro calls (e.g. `xacro.process_file()` in an OpaqueFunction)
+are not supported and will fail, since the `xacro` package is not available
+through the resolver's shimmed imports.
 
 ## Known limitations
 


### PR DESCRIPTION
## Summary

- Rewrite README.md for public release with problem/solution framing, key features, quick start, and doc links
- Add comprehensive `docs/` directory: motivation, core concepts, getting started, architecture, supported environments, FAQ
- Key topics covered: lockfile design, sparse checkout, portable paths, exec_depend bypass, Bazel comparison, multi-ECU lockfile strategy, static analysis scope, OpaqueFunction handling

## Test plan

- [x] Review all docs for accuracy and completeness
- [x] Verify internal links between docs work correctly
- [x] Verify Autoware example commands in README match actual usage


🤖 Generated with [Claude Code](https://claude.com/claude-code)