### PR TITLE
fix: resolve LaunchConfiguration substitutions in py_resolver

### DIFF
--- a/.agents/rules.md
+++ b/.agents/rules.md
@@ -87,6 +87,7 @@ docs: update architecture diagram in context.md
 - Unit tests for all public functions
 - Integration tests for each milestone
 - At least one end-to-end test per major feature
+- Every bug fix or code change addressing PR review comments must include corresponding unit tests
 
 ### Naming
 - Rust: `test_<function>_<scenario>`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,17 @@ jobs:
           key: doc
       - run: cargo doc --workspace --no-deps
 
+  pytest:
+    name: Python Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      - run: pip install pytest
+      - run: PYTHONPATH=python python -m pytest tests/ -v
+
   audit:
     name: Audit
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,10 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
       - name: Compare tag version with Cargo.toml version
         run: |
           TAG_VERSION="${GITHUB_REF_NAME#v}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,8 +8,26 @@ permissions:
   contents: write
 
 jobs:
+  version-check:
+    name: Verify tag matches Cargo.toml
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Compare tag version with Cargo.toml version
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          CARGO_VERSION=$(python3 -c "import tomllib; print(tomllib.load(open('Cargo.toml','rb'))['workspace']['package']['version'])")
+          echo "Tag version:       $TAG_VERSION"
+          echo "Cargo.toml version: $CARGO_VERSION"
+          if [ "$TAG_VERSION" != "$CARGO_VERSION" ]; then
+            echo "::error::Version mismatch: tag is v${TAG_VERSION} but Cargo.toml has ${CARGO_VERSION}"
+            exit 1
+          fi
+
   build:
     name: Build (${{ matrix.target }}, ${{ matrix.os }})
+    needs: version-check
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,9 +13,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -28,15 +28,15 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -87,9 +87,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "clap"
-version = "4.5.60"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -97,9 +97,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.60"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -109,9 +109,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.55"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -121,15 +121,15 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "equivalent"
@@ -245,7 +245,7 @@ checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "launch-plus-cli"
-version = "0.1.1"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -256,7 +256,7 @@ dependencies = [
 
 [[package]]
 name = "launch-plus-core"
-version = "0.1.1"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "libc",
@@ -348,9 +348,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -732,9 +732,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.22"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "matchers",
  "nu-ansi-term",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.1.1"
+version = "0.1.3"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/paulsohn/launch-plus"

--- a/example/autoware/manifest.lock.repos
+++ b/example/autoware/manifest.lock.repos
@@ -30,7 +30,7 @@ repositories:
   core/autoware_core:
     type: git
     url: https://github.com/autowarefoundation/autoware_core.git
-    version: 4d092e8e974446e05aa09638d73cf59024010043
+    version: 9fe7ac2cfc28dae8d7529dd3eb17dd737f1f3b27
     ref: main
     packages:
     - autoware_adapi_adaptors
@@ -173,7 +173,7 @@ repositories:
   launcher/autoware_launch:
     type: git
     url: https://github.com/autowarefoundation/autoware_launch.git
-    version: 1fe467463098cef2a4ace98635632df9c72ec1a3
+    version: 8a4b2ec1140fdc88f3b61fdf7697acd20654095c
     ref: main
     packages:
     - autoware_launch
@@ -379,7 +379,7 @@ repositories:
   universe/autoware_universe:
     type: git
     url: https://github.com/autowarefoundation/autoware_universe.git
-    version: 1fa7b5558de3d1261fdad09b8996bd593756151d
+    version: d702d678392837529fad335c4fce38cfff95f64b
     ref: main
     packages:
     - autoware_accel_brake_map_calibrator
@@ -598,8 +598,8 @@ repositories:
     - autoware_trajectory_modifier
     - autoware_trajectory_optimizer
     - autoware_trajectory_ranker
-    - autoware_trajectory_safety_filter
     - autoware_trajectory_traffic_rule_filter
+    - autoware_trajectory_validator
     - autoware_universe_utils
     - autoware_vehicle_cmd_gate
     - autoware_vehicle_door_simulator
@@ -1738,12 +1738,12 @@ packages:
   autoware_trajectory_ranker:
     repo: universe/autoware_universe
     path: planning/autoware_trajectory_ranker
-  autoware_trajectory_safety_filter:
-    repo: universe/autoware_universe
-    path: planning/autoware_trajectory_safety_filter
   autoware_trajectory_traffic_rule_filter:
     repo: universe/autoware_universe
     path: planning/autoware_trajectory_traffic_rule_filter
+  autoware_trajectory_validator:
+    repo: universe/autoware_universe
+    path: planning/autoware_trajectory_validator
   autoware_twist2accel:
     repo: core/autoware_core
     path: localization/autoware_twist2accel

--- a/example/autoware/resolved.launch.xml
+++ b/example/autoware/resolved.launch.xml
@@ -34,7 +34,6 @@
   <!-- end: autoware_global_parameter_loader://launch/global_params.launch.py -->
   <!-- source: autoware_launch://launch/pointcloud_container.launch.py -->
   <group>
-    <!-- arg name="agnocast_heaphook_path" default="/opt/ros/humble/lib/libagnocast_heaphook.so" -->
     <!-- arg name="container_name" value="pointcloud_container" -->
     <!-- arg name="use_multithread" value="true" -->
     <node_container pkg="rclcpp_components" exec="component_container_mt" name="pointcloud_container"/>

--- a/example/autoware/resolved.launch.xml
+++ b/example/autoware/resolved.launch.xml
@@ -34,9 +34,10 @@
   <!-- end: autoware_global_parameter_loader://launch/global_params.launch.py -->
   <!-- source: autoware_launch://launch/pointcloud_container.launch.py -->
   <group>
+    <!-- arg name="agnocast_heaphook_path" default="/opt/ros/humble/lib/libagnocast_heaphook.so" -->
     <!-- arg name="container_name" value="pointcloud_container" -->
     <!-- arg name="use_multithread" value="true" -->
-    <node_container pkg="container_package" exec="container_executable" name="pointcloud_container"/>
+    <node_container pkg="rclcpp_components" exec="component_container_mt" name="pointcloud_container"/>
     <!-- source: autoware_agnocast_wrapper://launch/agnocast_env.launch.py -->
       <!-- arg name="agnocast_heaphook_path" default="/opt/ros/humble/lib/libagnocast_heaphook.so" -->
       <!-- arg name="use_multithread" default="false" -->
@@ -765,7 +766,6 @@
         <!-- arg name="vehicle_mirror_param_file" value="$(find-pkg-share sample_vehicle_description)/config/mirror.param.yaml" -->
         <!-- source: sample_sensor_kit_launch://launch/lidar.launch.xml -->
         <group>
-          <!-- arg name="container_executable" default="component_container_mt" -->
           <!-- arg name="host_ip" default="192.168.1.10" -->
           <!-- arg name="launch_driver" value="true" -->
           <!-- arg name="pointcloud_container_name" value="pointcloud_container" -->
@@ -1754,7 +1754,6 @@
       <!-- arg name="common_downsample_voxel_size_x" default="0.05" -->
       <!-- arg name="common_downsample_voxel_size_y" default="0.05" -->
       <!-- arg name="common_downsample_voxel_size_z" default="0.05" -->
-      <!-- arg name="container_executable" default="component_container_mt" -->
       <!-- arg name="crosswalk_traffic_light_estimator_param_path" value="$(find-pkg-share autoware_launch)/config/perception/traffic_light_recognition/crosswalk_traffic_light_estimator/crosswalk_traffic_light_estimator.param.yaml" -->
       <!-- arg name="cuda_pointcloud_preprocessing" default="false" -->
       <!-- arg name="data_path" value="[home]/autoware_data" -->

--- a/example/autoware/resolved.launch.xml
+++ b/example/autoware/resolved.launch.xml
@@ -36,7 +36,11 @@
   <group>
     <!-- arg name="container_name" value="pointcloud_container" -->
     <!-- arg name="use_multithread" value="true" -->
-    <node_container pkg="rclcpp_components" exec="container_executable" name="container_name"/>
+    <node_container pkg="container_package" exec="container_executable" name="pointcloud_container"/>
+    <!-- source: autoware_agnocast_wrapper://launch/agnocast_env.launch.py -->
+      <!-- arg name="agnocast_heaphook_path" default="/opt/ros/humble/lib/libagnocast_heaphook.so" -->
+      <!-- arg name="use_multithread" default="false" -->
+    <!-- end: autoware_agnocast_wrapper://launch/agnocast_env.launch.py -->
   </group>
   <!-- end: autoware_launch://launch/pointcloud_container.launch.py -->
   <!-- source: tier4_vehicle_launch://launch/vehicle.launch.xml -->
@@ -526,6 +530,7 @@
         <!-- arg name="graph_vars" value="" -->
         <!-- arg name="param_file" value="$(find-pkg-share autoware_diagnostic_graph_aggregator)/config/default.param.yaml" -->
         <!-- arg name="~/availability" default="/system/command_mode/availability" -->
+        <!-- arg name="~/diagnostics" default="/diagnostics" -->
         <!-- arg name="~/reset" value="/diagnostics_graph/reset" -->
         <!-- arg name="~/status" value="/diagnostics_graph/status" -->
         <!-- arg name="~/struct" value="/diagnostics_graph/struct" -->
@@ -541,6 +546,7 @@
           <!-- end params from: $(find-pkg-share autoware_diagnostic_graph_aggregator)/config/default.param.yaml -->
           <param name="graph_file" value="$(find-pkg-share autoware_launch)/config/system/diagnostics/autoware-main.yaml"/>
           <param name="graph_vars" value=""/>
+          <remap from="~/diagnostics" to="/diagnostics"/>
           <remap from="~/struct" to="/diagnostics_graph/struct"/>
           <remap from="~/status" to="/diagnostics_graph/status"/>
           <remap from="~/unknowns" to="/diagnostics_graph/unknowns"/>
@@ -759,6 +765,7 @@
         <!-- arg name="vehicle_mirror_param_file" value="$(find-pkg-share sample_vehicle_description)/config/mirror.param.yaml" -->
         <!-- source: sample_sensor_kit_launch://launch/lidar.launch.xml -->
         <group>
+          <!-- arg name="container_executable" default="component_container_mt" -->
           <!-- arg name="host_ip" default="192.168.1.10" -->
           <!-- arg name="launch_driver" value="true" -->
           <!-- arg name="pointcloud_container_name" value="pointcloud_container" -->
@@ -813,7 +820,7 @@
               <!-- arg name="use_intra_process" value="true" -->
               <!-- arg name="use_multithread" value="false" -->
               <!-- arg name="vehicle_mirror_param_file" value="$(find-pkg-share sample_vehicle_description)/config/mirror.param.yaml" -->
-              <node_container pkg="rclcpp_components" exec="container_executable" name="container_name" namespace="/sensing/lidar/top/pointcloud_preprocessor">
+              <node_container pkg="rclcpp_components" exec="component_container_mt" name="pointcloud_container" namespace="/sensing/lidar/top/pointcloud_preprocessor">
                 <composable_node pkg="nebula_velodyne" plugin="VelodyneRosWrapper" name="velodyne_ros_wrapper_node">
                   <param name="calibration_file" value="$(find-pkg-share nebula_velodyne_decoders)/calibration/VLS128.yaml"/>
                   <param name="cloud_max_angle" value="360"/>
@@ -947,7 +954,7 @@
               <!-- arg name="use_intra_process" value="true" -->
               <!-- arg name="use_multithread" value="false" -->
               <!-- arg name="vehicle_mirror_param_file" value="$(find-pkg-share sample_vehicle_description)/config/mirror.param.yaml" -->
-              <node_container pkg="rclcpp_components" exec="container_executable" name="container_name" namespace="/sensing/lidar/rear/pointcloud_preprocessor">
+              <node_container pkg="rclcpp_components" exec="component_container_mt" name="pointcloud_container" namespace="/sensing/lidar/rear/pointcloud_preprocessor">
                 <composable_node pkg="nebula_velodyne" plugin="VelodyneRosWrapper" name="velodyne_ros_wrapper_node">
                   <param name="calibration_file" value="$(find-pkg-share nebula_velodyne_decoders)/calibration/VLP16.yaml"/>
                   <param name="cloud_max_angle" value="60"/>
@@ -1747,6 +1754,7 @@
       <!-- arg name="common_downsample_voxel_size_x" default="0.05" -->
       <!-- arg name="common_downsample_voxel_size_y" default="0.05" -->
       <!-- arg name="common_downsample_voxel_size_z" default="0.05" -->
+      <!-- arg name="container_executable" default="component_container_mt" -->
       <!-- arg name="crosswalk_traffic_light_estimator_param_path" value="$(find-pkg-share autoware_launch)/config/perception/traffic_light_recognition/crosswalk_traffic_light_estimator/crosswalk_traffic_light_estimator.param.yaml" -->
       <!-- arg name="cuda_pointcloud_preprocessing" default="false" -->
       <!-- arg name="data_path" value="[home]/autoware_data" -->
@@ -1960,7 +1968,7 @@
           <!-- arg name="use_intra_process" value="true" -->
           <!-- arg name="use_multithread" value="true" -->
           <!-- arg name="use_pointcloud_container" value="true" -->
-          <node_container pkg="rclcpp_components" exec="container_executable" name="individual_container_name" namespace="/perception/occupancy_grid_map">
+          <node_container pkg="rclcpp_components" exec="component_container_mt" name="occupancy_grid_map_container" namespace="/perception/occupancy_grid_map">
             <composable_node pkg="autoware_probabilistic_occupancy_grid_map" plugin="autoware::occupancy_grid_map::PointcloudBasedOccupancyGridMapNode" name="occupancy_grid_map_node">
               <param name="OccupancyGridMapFixedBlindSpot" value="{'distance_margin': 1.0}"/>
               <param name="OccupancyGridMapProjectiveBlindSpot" value="{'projection_dz_threshold': 0.01, 'obstacle_separation_threshold': 1.0, 'pub_debug_grid': False}"/>
@@ -2819,7 +2827,7 @@
           <!-- arg name="whole_image_detection/label_path" value="[home]/autoware_data/tensorrt_yolox/car_ped_tl_detector_labels.txt" -->
           <!-- arg name="whole_image_detection/model_path" value="[home]/autoware_data/tensorrt_yolox/yolox_s_car_ped_tl_detector_960_960_batch_1.onnx" -->
           <!-- arg name="yolox_traffic_light_detector_param_path" value="$(find-pkg-share autoware_launch)/config/perception/traffic_light_recognition/tensorrt_yolox/yolox_traffic_light_detector.param.yaml" -->
-          <node_container pkg="rclcpp_components" exec="container_executable" name="traffic_light_node_container" namespace="/perception/traffic_light_recognition/camera6">
+          <node_container pkg="rclcpp_components" exec="component_container_mt" name="traffic_light_node_container" namespace="/perception/traffic_light_recognition/camera6">
             <composable_node pkg="autoware_traffic_light_classifier" plugin="autoware::traffic_light::TrafficLightClassifierNodelet" name="car_traffic_light_classifier">
               <param name="build_only" value="False"/>
               <param name="label_path" value="[home]/autoware_data/traffic_light_classifier/lamp_labels.txt"/>
@@ -2892,7 +2900,7 @@
               <remap from="output/traffic_signals" to="/perception/traffic_light_recognition/camera6/classification/traffic_signals"/>
             </composable_node>
           </load_composable_node>
-          <node_container pkg="rclcpp_components" exec="container_executable" name="traffic_light_node_container" namespace="/perception/traffic_light_recognition/camera7">
+          <node_container pkg="rclcpp_components" exec="component_container_mt" name="traffic_light_node_container" namespace="/perception/traffic_light_recognition/camera7">
             <composable_node pkg="autoware_traffic_light_classifier" plugin="autoware::traffic_light::TrafficLightClassifierNodelet" name="car_traffic_light_classifier">
               <param name="build_only" value="False"/>
               <param name="label_path" value="[home]/autoware_data/traffic_light_classifier/lamp_labels.txt"/>
@@ -4489,6 +4497,10 @@
                 <param name="lane_change.lane_change_finish_judge_buffer" value="2.0"/>
                 <param name="lane_change.finish_judge_lateral_threshold" value="0.1"/>
                 <param name="lane_change.finish_judge_lateral_angle_deviation" value="1.0"/>
+                <param name="lane_change.path_miss.enable_path_miss_detection" value="true"/>
+                <param name="lane_change.path_miss.threshold_longitudinal" value="1.0"/>
+                <param name="lane_change.path_miss.velocity_points" value="[0.0, 0.1, 0.11, 2.77, 2.78, 20.0]"/>
+                <param name="lane_change.path_miss.lateral_thresholds" value="[3.0, 3.0, 5.0, 5.0, 1.5, 0.8]"/>
                 <param name="lane_change.publish_debug_marker" value="true"/>
                 <!-- end params from: $(find-pkg-share autoware_launch)/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/lane_change/lane_change.param.yaml -->
                 <!-- params from: $(find-pkg-share autoware_launch)/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/goal_planner/goal_planner.param.yaml -->

--- a/python/launch_plus/py_resolver.py
+++ b/python/launch_plus/py_resolver.py
@@ -1394,12 +1394,15 @@ def _resolve_node_details(node, context):
         raw = getattr(node, f"_raw_{field}", None)
         if _is_substitution(raw):
             resolved = _resolve_substitution(raw, context)
-            if resolved:
+            if resolved is not None:
                 entry[field] = resolved
                 if field == "package":
-                    # Only track when perform() actually resolved (not display fallback)
-                    performed = raw.perform(context) if context and hasattr(raw, "perform") else None
-                    if performed is not None:
+                    # Only track when _resolve_substitution returned a real
+                    # value (not the display-name fallback).  We detect the
+                    # fallback case by checking whether the resolved string
+                    # equals str(raw) — if so, perform() failed or returned
+                    # None and _resolve_substitution fell back to str(sub).
+                    if resolved != str(raw):
                         _track_package(resolved)
 
     # Namespace: emit raw inputs — Rust computes effective_namespace from these
@@ -1478,21 +1481,21 @@ def _resolve_composable_plugins(descs, context):
         pkg = desc._package
         if _is_substitution(desc._raw_package):
             resolved_pkg = _resolve_substitution(desc._raw_package, context)
-            if resolved_pkg:
+            if resolved_pkg is not None:
                 pkg = resolved_pkg
-                # Only track when perform() actually resolved (not display fallback)
-                performed = desc._raw_package.perform(context) if context and hasattr(desc._raw_package, "perform") else None
-                if performed is not None:
+                # Only track when resolution returned a real value, not the
+                # display-name fallback (same heuristic as _resolve_node_details).
+                if resolved_pkg != str(desc._raw_package):
                     _track_package(resolved_pkg)
         plg = desc._plugin
         if _is_substitution(desc._raw_plugin):
             resolved_plg = _resolve_substitution(desc._raw_plugin, context)
-            if resolved_plg:
+            if resolved_plg is not None:
                 plg = resolved_plg
         nm = desc._name
         if _is_substitution(desc._raw_name):
             resolved_nm = _resolve_substitution(desc._raw_name, context)
-            if resolved_nm:
+            if resolved_nm is not None:
                 nm = resolved_nm
         plugins.append({
             "package": pkg,
@@ -1514,6 +1517,7 @@ def _inline_resolve_python_launch(launch_file, parent_context, child_args, depth
     the child mutate the shared ``LaunchContext``.  The orchestrator still
     handles the recursive node/include dependency resolution separately.
     """
+    global _declared_arg_names
     if depth > 20:
         _warn(f"Max inline include depth for {launch_file}")
         return
@@ -1538,7 +1542,7 @@ def _inline_resolve_python_launch(launch_file, parent_context, child_args, depth
         spec = importlib.util.spec_from_file_location(
             f"_inline_launch_{depth}", real_path
         )
-        if spec is None:
+        if spec is None or spec.loader is None:
             _warn(f"cannot load included launch file: {real_path}")
             return
         mod = importlib.util.module_from_spec(spec)
@@ -1565,6 +1569,10 @@ def _inline_resolve_python_launch(launch_file, parent_context, child_args, depth
     saved_include_args_keys = set(_tracked["include_args"])
     saved_param_files_len = len(_tracked["param_files"])
     saved_param_file_deps_len = len(_tracked["param_file_deps"])
+    saved_declared_args_len = len(_tracked["declared_args"])
+    saved_declared_arg_names = set(_declared_arg_names)
+    saved_event_handlers_len = len(_tracked["event_handlers"])
+    saved_namespace_depth = len(_namespace_stack)
 
     try:
         ld = mod.generate_launch_description()
@@ -1576,11 +1584,16 @@ def _inline_resolve_python_launch(launch_file, parent_context, child_args, depth
 
     entities = getattr(ld, "entities", None) or getattr(ld, "_actions", None) or []
 
-    # Apply child launch arguments to the context (parent values take precedence
-    # for identically-named args, but child-only args need their defaults).
+    # Snapshot parent context BEFORE applying child_args so we can fully
+    # restore it after the inline walk.  Only deliberate side-effects
+    # (SetLaunchConfiguration) survive.
     saved_configs = dict(parent_context._launch_configurations)
+
+    # Apply child launch arguments: only set keys that the parent hasn't
+    # already defined, so parent values are never overwritten.
     for k, v in child_args.items():
-        parent_context._launch_configurations[k] = v
+        if k not in parent_context._launch_configurations:
+            parent_context._launch_configurations[k] = v
 
     # Pass 1: apply DeclareLaunchArgument defaults (child-only args).
     for entity in entities:
@@ -1605,6 +1618,11 @@ def _inline_resolve_python_launch(launch_file, parent_context, child_args, depth
         del _tracked["param_files"][saved_param_files_len:]
         del _tracked["param_file_deps"][saved_param_file_deps_len:]
         _tracked["packages"][:] = saved_pkgs
+        del _tracked["declared_args"][saved_declared_args_len:]
+        _declared_arg_names.clear()
+        _declared_arg_names.update(saved_declared_arg_names)
+        del _tracked["event_handlers"][saved_event_handlers_len:]
+        del _namespace_stack[saved_namespace_depth:]
 
     # Restore child-only args that were not SetLaunchConfiguration'd —
     # child DeclareLaunchArgument defaults should NOT leak into the parent

--- a/python/launch_plus/py_resolver.py
+++ b/python/launch_plus/py_resolver.py
@@ -1391,7 +1391,10 @@ def _resolve_node_details(node, context):
             if resolved:
                 entry[field] = resolved
                 if field == "package":
-                    _track_package(resolved)
+                    # Only track when perform() actually resolved (not display fallback)
+                    performed = raw.perform(context) if context and hasattr(raw, "perform") else None
+                    if performed is not None:
+                        _track_package(resolved)
 
     # Namespace: emit raw inputs — Rust computes effective_namespace from these
     ns = _resolve_substitution(node._raw_namespace, context) if node._raw_namespace is not None else None
@@ -1471,7 +1474,10 @@ def _resolve_composable_plugins(descs, context):
             resolved_pkg = _resolve_substitution(desc._raw_package, context)
             if resolved_pkg:
                 pkg = resolved_pkg
-                _track_package(resolved_pkg)
+                # Only track when perform() actually resolved (not display fallback)
+                performed = desc._raw_package.perform(context) if context and hasattr(desc._raw_package, "perform") else None
+                if performed is not None:
+                    _track_package(resolved_pkg)
         plg = desc._plugin
         if _is_substitution(desc._raw_plugin):
             resolved_plg = _resolve_substitution(desc._raw_plugin, context)

--- a/python/launch_plus/py_resolver.py
+++ b/python/launch_plus/py_resolver.py
@@ -243,8 +243,19 @@ _declared_arg_names: set = set()
 _namespace_stack: list = []
 
 def _is_substitution(value):
-    """Return True if *value* is a launch substitution (not yet resolved to a string)."""
-    return value is not None and not isinstance(value, str) and hasattr(value, "perform")
+    """Return True if *value* is a launch substitution (not yet resolved to a string).
+
+    Handles both single substitution objects (with a ``perform`` method) and
+    list-of-substitutions (``SomeSubstitutionsType`` in ROS 2), where any
+    element may be a substitution object.
+    """
+    if value is None or isinstance(value, str):
+        return False
+    if hasattr(value, "perform"):
+        return True
+    if isinstance(value, (list, tuple)):
+        return any(hasattr(item, "perform") for item in value)
+    return False
 
 
 def _track_package(pkg):

--- a/python/launch_plus/py_resolver.py
+++ b/python/launch_plus/py_resolver.py
@@ -1546,6 +1546,16 @@ def _inline_resolve_python_launch(launch_file, parent_context, child_args, depth
     if not hasattr(mod, "generate_launch_description"):
         return
 
+    # Save tracking state BEFORE generate_launch_description() — constructors
+    # (e.g. _TrackedNode, _TrackedSetParameter) append to _tracked["nodes"]
+    # at construction time.  The Rust orchestrator will resolve this same
+    # child file separately and produce its own tracked entries, so we must
+    # discard everything created by the inline execution.
+    saved_nodes_len = len(_tracked["nodes"])
+    saved_gp_len = len(_tracked["global_params"])
+    saved_deps_len = len(_tracked["include_deps"])
+    saved_pkgs = list(_tracked["packages"])
+
     try:
         ld = mod.generate_launch_description()
     except _PackageNotFetchedError:
@@ -1569,19 +1579,26 @@ def _inline_resolve_python_launch(launch_file, parent_context, child_args, depth
 
     # Pass 2: walk actions — SetLaunchConfiguration, OpaqueFunction, etc.
     # all mutate parent_context directly, which is the desired effect.
+    # Only context mutations survive; tracked state is rolled back.
     try:
         _walk_actions(entities, parent_context, depth)
     except _PackageNotFetchedError:
         raise
+    finally:
+        del _tracked["nodes"][saved_nodes_len:]
+        del _tracked["global_params"][saved_gp_len:]
+        del _tracked["include_deps"][saved_deps_len:]
+        _tracked["packages"][:] = saved_pkgs
 
     # Restore child-only args that were not SetLaunchConfiguration'd —
     # child DeclareLaunchArgument defaults should NOT leak into the parent
     # scope, only SetLaunchConfiguration is a deliberate side-effect.
     # Keep keys that were either already in the parent or were set via
-    # SetLaunchConfiguration (tracked globally in _tracked["set_launch_configurations"]).
+    # SetLaunchConfiguration.  Also preserve "global_params" — this is the
+    # accumulation list for SetParameter, not a launch argument.
     set_configs = set(_tracked["set_launch_configurations"].keys())
     for k in list(parent_context._launch_configurations):
-        if k not in saved_configs and k not in set_configs:
+        if k not in saved_configs and k not in set_configs and k != "global_params":
             del parent_context._launch_configurations[k]
 
 

--- a/python/launch_plus/py_resolver.py
+++ b/python/launch_plus/py_resolver.py
@@ -702,10 +702,12 @@ class _TrackedComposableNodeContainer:
         self._raw_env = kwargs.get("env") or []
         self._descs = list(composable_node_descriptions or [])
         self._detailed = False
-        # Eager: track packages from descriptions
+        # Eager: track packages from descriptions — pass raw object so
+        # _track_package can filter out substitution objects.
         for desc in self._descs:
-            if hasattr(desc, "_package") and desc._package:
-                _track_package(desc._package)
+            raw_pkg = getattr(desc, "_raw_package", None) or getattr(desc, "_package", None)
+            if raw_pkg:
+                _track_package(raw_pkg)
 
 class _TrackedLoadComposableNodes:
     """Loads composable nodes into an existing container.
@@ -724,7 +726,8 @@ class _TrackedLoadComposableNodes:
             target_str = _tracked["nodes"][target_container._idx].get("name", "")
         elif hasattr(target_container, "perform"):
             try:
-                target_str = str(target_container.perform(_StubLaunchContext()))
+                result = target_container.perform(_StubLaunchContext())
+                target_str = str(result) if result is not None else str(target_container)
             except Exception:
                 target_str = str(target_container)
         else:
@@ -747,10 +750,12 @@ class _TrackedLoadComposableNodes:
         })
         self._descs = list(composable_node_descriptions or [])
         self._detailed = False
-        # Eager: track packages from descriptions
+        # Eager: track packages from descriptions — pass raw object so
+        # _track_package can filter out substitution objects.
         for desc in self._descs:
-            if hasattr(desc, "_package") and desc._package:
-                _track_package(desc._package)
+            raw_pkg = getattr(desc, "_raw_package", None) or getattr(desc, "_package", None)
+            if raw_pkg:
+                _track_package(raw_pkg)
 
 class _TrackedPushRosNamespace:
     """Tracks PushRosNamespace so _walk_action can update _namespace_stack."""
@@ -770,7 +775,8 @@ class _TrackedParameterFile:
                 path = param_file  # Keep portable; Rust handles $(find-pkg-share ...) format
             elif hasattr(param_file, "perform"):
                 try:
-                    path = str(param_file.perform(_StubLaunchContext()))
+                    result = param_file.perform(_StubLaunchContext())
+                    path = str(result) if result is not None else str(param_file)
                 except Exception:
                     path = str(param_file)
             else:
@@ -1555,6 +1561,10 @@ def _inline_resolve_python_launch(launch_file, parent_context, child_args, depth
     saved_gp_len = len(_tracked["global_params"])
     saved_deps_len = len(_tracked["include_deps"])
     saved_pkgs = list(_tracked["packages"])
+    saved_includes_len = len(_tracked["includes"])
+    saved_include_args_keys = set(_tracked["include_args"])
+    saved_param_files_len = len(_tracked["param_files"])
+    saved_param_file_deps_len = len(_tracked["param_file_deps"])
 
     try:
         ld = mod.generate_launch_description()
@@ -1588,6 +1598,12 @@ def _inline_resolve_python_launch(launch_file, parent_context, child_args, depth
         del _tracked["nodes"][saved_nodes_len:]
         del _tracked["global_params"][saved_gp_len:]
         del _tracked["include_deps"][saved_deps_len:]
+        del _tracked["includes"][saved_includes_len:]
+        for k in list(_tracked["include_args"]):
+            if k not in saved_include_args_keys:
+                del _tracked["include_args"][k]
+        del _tracked["param_files"][saved_param_files_len:]
+        del _tracked["param_file_deps"][saved_param_file_deps_len:]
         _tracked["packages"][:] = saved_pkgs
 
     # Restore child-only args that were not SetLaunchConfiguration'd —
@@ -1695,7 +1711,8 @@ def _walk_action(action, context, depth):
             if action._raw_launch_arguments:
                 for k, v in action._raw_launch_arguments:
                     k_str = str(k)
-                    v_str = _resolve_substitution(v, context) or str(v)
+                    resolved = _resolve_substitution(v, context)
+                    v_str = resolved if resolved is not None else str(v)
                     child_args[k_str] = v_str
             _inline_resolve_python_launch(action._path, context, child_args, depth + 1)
 
@@ -2116,7 +2133,8 @@ def _build_patched_launch_launch_description_sources():
                 self._location = None
             elif hasattr(location, "perform"):
                 try:
-                    self._location = str(location.perform(_StubLaunchContext()))
+                    result = location.perform(_StubLaunchContext())
+                    self._location = str(result) if result is not None else str(location)
                 except Exception:
                     self._location = None
             elif isinstance(location, list):
@@ -2125,7 +2143,8 @@ def _build_patched_launch_launch_description_sources():
                 for sub in location:
                     if hasattr(sub, "perform"):
                         try:
-                            parts.append(str(sub.perform(stub_ctx)))
+                            result = sub.perform(stub_ctx)
+                            parts.append(str(result) if result is not None else str(sub))
                         except Exception:
                             parts.append(str(sub))
                     else:

--- a/python/launch_plus/py_resolver.py
+++ b/python/launch_plus/py_resolver.py
@@ -356,21 +356,25 @@ def _resolve_substitution_ex(sub, context):
         # _resolve_ros_substitutions here — that would eagerly expand portable
         # $(find-pkg-share ...) paths back to machine-specific filesystem paths.
         return sub, False
-    if isinstance(sub, list):
+    if isinstance(sub, (list, tuple)):
         parts = []
         any_fallback = False
         for s in sub:
-            if context is not None and hasattr(s, "perform"):
-                try:
-                    result = s.perform(context)
-                    if result is not None:
-                        parts.append(str(result))
-                    else:
+            if hasattr(s, "perform"):
+                if context is not None:
+                    try:
+                        result = s.perform(context)
+                        if result is not None:
+                            parts.append(str(result))
+                        else:
+                            parts.append(str(s))
+                            any_fallback = True
+                    except _PackageNotFetchedError:
+                        raise
+                    except Exception:
                         parts.append(str(s))
                         any_fallback = True
-                except _PackageNotFetchedError:
-                    raise
-                except Exception:
+                else:
                     parts.append(str(s))
                     any_fallback = True
             else:

--- a/python/launch_plus/py_resolver.py
+++ b/python/launch_plus/py_resolver.py
@@ -325,39 +325,57 @@ def _track_param_file(path):
 
 def _resolve_substitution(sub, context):
     """Resolve a substitution, list-of-substitutions, or plain string to str."""
+    value, _fallback = _resolve_substitution_ex(sub, context)
+    return value
+
+
+def _resolve_substitution_ex(sub, context):
+    """Resolve a substitution and report whether the result is a fallback.
+
+    Returns ``(resolved_str_or_None, is_fallback)`` where *is_fallback* is
+    ``True`` when ``perform()`` returned ``None`` or raised and the display
+    name was used instead.  Callers that need to distinguish "really resolved"
+    from "fell back to variable name" (e.g. package tracking) should use this.
+    """
     if sub is None:
-        return None
+        return None, False
     if isinstance(sub, str):
         # Plain strings from Python launch code are already resolved (they come from
         # Python expressions, not unresolved XML/YAML text).  Do NOT call
         # _resolve_ros_substitutions here — that would eagerly expand portable
         # $(find-pkg-share ...) paths back to machine-specific filesystem paths.
-        return sub
+        return sub, False
     if isinstance(sub, list):
         parts = []
+        any_fallback = False
         for s in sub:
             if context is not None and hasattr(s, "perform"):
                 try:
                     result = s.perform(context)
-                    parts.append(str(result) if result is not None else str(s))
+                    if result is not None:
+                        parts.append(str(result))
+                    else:
+                        parts.append(str(s))
+                        any_fallback = True
                 except _PackageNotFetchedError:
                     raise
                 except Exception:
                     parts.append(str(s))
+                    any_fallback = True
             else:
                 parts.append(str(s))
-        return "".join(parts)
+        return "".join(parts), any_fallback
     if context is not None and hasattr(sub, "perform"):
         try:
             result = sub.perform(context)
             if result is None:
-                return str(sub)  # unresolved — use display name
-            return str(result)
+                return str(sub), True  # unresolved — use display name
+            return str(result), False
         except _PackageNotFetchedError:
             raise
         except Exception:
-            return str(sub)
-    return str(sub)
+            return str(sub), True
+    return str(sub), True
 
 
 def _track_node(package, executable, name=None):
@@ -1393,17 +1411,11 @@ def _resolve_node_details(node, context):
     for field in ("package", "executable", "name"):
         raw = getattr(node, f"_raw_{field}", None)
         if _is_substitution(raw):
-            resolved = _resolve_substitution(raw, context)
+            resolved, is_fallback = _resolve_substitution_ex(raw, context)
             if resolved is not None:
                 entry[field] = resolved
-                if field == "package":
-                    # Only track when _resolve_substitution returned a real
-                    # value (not the display-name fallback).  We detect the
-                    # fallback case by checking whether the resolved string
-                    # equals str(raw) — if so, perform() failed or returned
-                    # None and _resolve_substitution fell back to str(sub).
-                    if resolved != str(raw):
-                        _track_package(resolved)
+                if field == "package" and not is_fallback:
+                    _track_package(resolved)
 
     # Namespace: emit raw inputs — Rust computes effective_namespace from these
     ns = _resolve_substitution(node._raw_namespace, context) if node._raw_namespace is not None else None
@@ -1480,12 +1492,10 @@ def _resolve_composable_plugins(descs, context):
         # Resolve package/plugin/name substitutions with the live context
         pkg = desc._package
         if _is_substitution(desc._raw_package):
-            resolved_pkg = _resolve_substitution(desc._raw_package, context)
+            resolved_pkg, is_fallback = _resolve_substitution_ex(desc._raw_package, context)
             if resolved_pkg is not None:
                 pkg = resolved_pkg
-                # Only track when resolution returned a real value, not the
-                # display-name fallback (same heuristic as _resolve_node_details).
-                if resolved_pkg != str(desc._raw_package):
+                if not is_fallback:
                     _track_package(resolved_pkg)
         plg = desc._plugin
         if _is_substitution(desc._raw_plugin):
@@ -1574,36 +1584,39 @@ def _inline_resolve_python_launch(launch_file, parent_context, child_args, depth
     saved_event_handlers_len = len(_tracked["event_handlers"])
     saved_namespace_depth = len(_namespace_stack)
 
-    try:
-        ld = mod.generate_launch_description()
-    except _PackageNotFetchedError:
-        raise
-    except Exception as e:
-        _warn(f"generate_launch_description() failed in {launch_file}: {e}")
-        return
-
-    entities = getattr(ld, "entities", None) or getattr(ld, "_actions", None) or []
-
-    # Snapshot parent context BEFORE applying child_args so we can fully
-    # restore it after the inline walk.  Only deliberate side-effects
+    # Snapshot parent context BEFORE generate_launch_description() so we can
+    # fully restore it after the inline walk.  Only deliberate side-effects
     # (SetLaunchConfiguration) survive.
     saved_configs = dict(parent_context._launch_configurations)
 
-    # Apply child launch arguments: only set keys that the parent hasn't
-    # already defined, so parent values are never overwritten.
-    for k, v in child_args.items():
-        if k not in parent_context._launch_configurations:
-            parent_context._launch_configurations[k] = v
-
-    # Pass 1: apply DeclareLaunchArgument defaults (child-only args).
-    for entity in entities:
-        if isinstance(entity, _DeclaredArg):
-            _apply_declared_arg(entity, parent_context)
-
-    # Pass 2: walk actions — SetLaunchConfiguration, OpaqueFunction, etc.
-    # all mutate parent_context directly, which is the desired effect.
-    # Only context mutations survive; tracked state is rolled back.
+    # All _tracked mutations (from constructors in generate_launch_description
+    # AND from _walk_actions) must be rolled back on any exit path, including
+    # exceptions from generate_launch_description() itself.
     try:
+        try:
+            ld = mod.generate_launch_description()
+        except _PackageNotFetchedError:
+            raise
+        except Exception as e:
+            _warn(f"generate_launch_description() failed in {launch_file}: {e}")
+            return
+
+        entities = getattr(ld, "entities", None) or getattr(ld, "_actions", None) or []
+
+        # Apply child launch arguments: only set keys that the parent hasn't
+        # already defined, so parent values are never overwritten.
+        for k, v in child_args.items():
+            if k not in parent_context._launch_configurations:
+                parent_context._launch_configurations[k] = v
+
+        # Pass 1: apply DeclareLaunchArgument defaults (child-only args).
+        for entity in entities:
+            if isinstance(entity, _DeclaredArg):
+                _apply_declared_arg(entity, parent_context)
+
+        # Pass 2: walk actions — SetLaunchConfiguration, OpaqueFunction, etc.
+        # all mutate parent_context directly, which is the desired effect.
+        # Only context mutations survive; tracked state is rolled back.
         _walk_actions(entities, parent_context, depth)
     except _PackageNotFetchedError:
         raise

--- a/python/launch_plus/py_resolver.py
+++ b/python/launch_plus/py_resolver.py
@@ -242,8 +242,18 @@ _declared_arg_names: set = set()
 # Each entry is a resolved string.  Managed by _walk_action; reset in main().
 _namespace_stack: list = []
 
+def _is_substitution(value):
+    """Return True if *value* is a launch substitution (not yet resolved to a string)."""
+    return value is not None and not isinstance(value, str) and hasattr(value, "perform")
+
+
 def _track_package(pkg):
     if not pkg:
+        return
+    # Skip substitution objects (e.g. LaunchConfiguration) — the variable name
+    # is NOT a real package.  The resolved value will be tracked later in
+    # _resolve_node_details / _resolve_composable_plugins.
+    if _is_substitution(pkg):
         return
     pkg = str(pkg)
     if pkg and pkg not in _tracked["packages"]:
@@ -328,7 +338,8 @@ def _resolve_substitution(sub, context):
         for s in sub:
             if context is not None and hasattr(s, "perform"):
                 try:
-                    parts.append(str(s.perform(context)))
+                    result = s.perform(context)
+                    parts.append(str(result) if result is not None else str(s))
                 except _PackageNotFetchedError:
                     raise
                 except Exception:
@@ -338,7 +349,10 @@ def _resolve_substitution(sub, context):
         return "".join(parts)
     if context is not None and hasattr(sub, "perform"):
         try:
-            return str(sub.perform(context))
+            result = sub.perform(context)
+            if result is None:
+                return str(sub)  # unresolved — use display name
+            return str(result)
         except _PackageNotFetchedError:
             raise
         except Exception:
@@ -394,6 +408,9 @@ class _TrackedNode:
             "target": None,
         })
         # Save raw kwargs for deferred resolution in _walk_action
+        self._raw_package = package
+        self._raw_executable = executable
+        self._raw_name = name
         self._raw_namespace = kwargs.get("namespace")
         self._raw_parameters = list(kwargs.get("parameters") or [])
         self._raw_remappings = list(kwargs.get("remappings") or [])
@@ -636,8 +653,11 @@ class _TrackedComposableNode:
     """
     def __init__(self, *, package=None, plugin=None, name=None, **kwargs):
         _track_package(package)
+        self._raw_package = package
         self._package = str(package) if package else ""
+        self._raw_plugin = plugin
         self._plugin = str(plugin) if plugin else ""
+        self._raw_name = name
         self._name = str(name) if name else ""
         self._raw_parameters = list(kwargs.get("parameters") or [])
         self._raw_remappings = list(kwargs.get("remappings") or [])
@@ -673,6 +693,9 @@ class _TrackedComposableNodeContainer:
             "plugins": [],
             "target": None,
         })
+        self._raw_package = package
+        self._raw_executable = executable
+        self._raw_name = name
         self._raw_namespace = kwargs.get("namespace")
         self._raw_parameters = list(kwargs.get("parameters") or [])
         self._raw_remappings = list(kwargs.get("remappings") or [])
@@ -784,7 +807,8 @@ class _TrackedFindPackageShare:
             parts = []
             for sub in subs:
                 if context is not None and hasattr(sub, "perform"):
-                    parts.append(str(sub.perform(context)))
+                    result = sub.perform(context)
+                    parts.append(str(result) if result is not None else str(sub))
                 else:
                     parts.append(str(sub))
             return "".join(parts)
@@ -814,7 +838,8 @@ class _TrackedPathJoinSubstitution:
         parts = []
         for sub in self._subs:
             if hasattr(sub, "perform"):
-                parts.append(str(sub.perform(context)))
+                result = sub.perform(context)
+                parts.append(str(result) if result is not None else str(sub))
             else:
                 parts.append(str(sub))
         return str(Path(*parts))
@@ -848,7 +873,8 @@ def _resolve_include_args(path, launch_arguments, context, dep_idx=-1):
                 for sub in v:
                     if hasattr(sub, "perform"):
                         try:
-                            parts.append(str(sub.perform(context)))
+                            result = sub.perform(context)
+                            parts.append(str(result) if result is not None else str(sub))
                         except _PackageNotFetchedError:
                             raise
                         except Exception:
@@ -858,7 +884,8 @@ def _resolve_include_args(path, launch_arguments, context, dep_idx=-1):
                 v_str = "".join(parts)
             elif hasattr(v, "perform"):
                 try:
-                    v_str = str(v.perform(context))
+                    result = v.perform(context)
+                    v_str = str(result) if result is not None else str(v)
                 except _PackageNotFetchedError:
                     raise
                 except Exception:
@@ -912,8 +939,11 @@ class _LaunchConfiguration:
         self._default = default
     def perform(self, context):
         if context and hasattr(context, "_launch_configurations"):
-            return context._launch_configurations.get(self._name, self._name)
-        return self._name
+            if self._name in context._launch_configurations:
+                return context._launch_configurations[self._name]
+            if self._default is not None:
+                return str(self._default)
+        return None
     def __str__(self):
         return self._name
 
@@ -964,12 +994,14 @@ def _apply_declared_arg(arg: "_DeclaredArg", context) -> None:
     try:
         dv = arg.default_value
         if hasattr(dv, "perform"):
-            resolved = str(dv.perform(context))
+            result = dv.perform(context)
+            resolved = str(result) if result is not None else str(dv)
         elif isinstance(dv, list):
             parts = []
             for sub in dv:
                 if hasattr(sub, "perform"):
-                    parts.append(str(sub.perform(context)))
+                    result = sub.perform(context)
+                    parts.append(str(result) if result is not None else str(sub))
                 else:
                     parts.append(str(sub))
             resolved = "".join(parts)
@@ -1343,12 +1375,23 @@ def _make_launch_context(args_dict):
 # ─── Node detail resolution helpers ──────────────────────────────────────────
 
 def _resolve_node_details(node, context):
-    """Fill in deferred details (namespace, params, remaps, env) for a tracked node.
+    """Fill in deferred details (package, executable, name, namespace, params, remaps, env).
 
     Works for both ``_TrackedNode`` / ``_TrackedLifecycleNode`` and
     ``_TrackedComposableNodeContainer`` — both expose the same raw fields.
     """
     entry = _tracked["nodes"][node._idx]
+
+    # Package / executable / name: resolve substitutions (e.g. LaunchConfiguration)
+    # that could not be resolved at construction time.
+    for field in ("package", "executable", "name"):
+        raw = getattr(node, f"_raw_{field}", None)
+        if _is_substitution(raw):
+            resolved = _resolve_substitution(raw, context)
+            if resolved:
+                entry[field] = resolved
+                if field == "package":
+                    _track_package(resolved)
 
     # Namespace: emit raw inputs — Rust computes effective_namespace from these
     ns = _resolve_substitution(node._raw_namespace, context) if node._raw_namespace is not None else None
@@ -1422,14 +1465,118 @@ def _resolve_composable_plugins(descs, context):
                 src = _resolve_substitution(r[0], context)
                 dst = _resolve_substitution(r[1], context)
                 remaps.append([src or str(r[0]), dst or str(r[1])])
+        # Resolve package/plugin/name substitutions with the live context
+        pkg = desc._package
+        if _is_substitution(desc._raw_package):
+            resolved_pkg = _resolve_substitution(desc._raw_package, context)
+            if resolved_pkg:
+                pkg = resolved_pkg
+                _track_package(resolved_pkg)
+        plg = desc._plugin
+        if _is_substitution(desc._raw_plugin):
+            resolved_plg = _resolve_substitution(desc._raw_plugin, context)
+            if resolved_plg:
+                plg = resolved_plg
+        nm = desc._name
+        if _is_substitution(desc._raw_name):
+            resolved_nm = _resolve_substitution(desc._raw_name, context)
+            if resolved_nm:
+                nm = resolved_nm
         plugins.append({
-            "package": desc._package,
-            "plugin": desc._plugin,
-            "name": desc._name or None,
+            "package": pkg,
+            "plugin": plg,
+            "name": nm or None,
             "parameters": params,
             "remappings": remaps,
         })
     return plugins
+
+
+# ─── Inline Python include resolution ─────────────────────────────────────────
+
+def _inline_resolve_python_launch(launch_file, parent_context, child_args, depth):
+    """Load a Python launch file and walk its actions in the parent context.
+
+    This mirrors real ROS 2 behavior where ``IncludeLaunchDescription``
+    synchronously executes the child, so ``SetLaunchConfiguration`` calls in
+    the child mutate the shared ``LaunchContext``.  The orchestrator still
+    handles the recursive node/include dependency resolution separately.
+    """
+    if depth > 20:
+        _warn(f"Max inline include depth for {launch_file}")
+        return
+
+    # Resolve portable paths — $(find-pkg-share pkg)/rest → real filesystem path.
+    real_path = launch_file
+    parsed = _parse_portable_path(launch_file)
+    if parsed:
+        pkg, rest = parsed
+        try:
+            pkg_share = _resolve_pkg_share(pkg)
+        except _PackageNotFetchedError:
+            raise
+        except Exception:
+            return  # Package not available — orchestrator will resolve later
+        real_path = os.path.join(pkg_share, rest)
+
+    if not os.path.isfile(real_path):
+        return  # File not on disk — orchestrator will fetch and resolve later
+
+    try:
+        spec = importlib.util.spec_from_file_location(
+            f"_inline_launch_{depth}", real_path
+        )
+        if spec is None:
+            _warn(f"cannot load included launch file: {real_path}")
+            return
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+    except _PackageNotFetchedError:
+        raise
+    except Exception as e:
+        _warn(f"failed to load included launch file {real_path}: {e}")
+        return
+
+    if not hasattr(mod, "generate_launch_description"):
+        return
+
+    try:
+        ld = mod.generate_launch_description()
+    except _PackageNotFetchedError:
+        raise
+    except Exception as e:
+        _warn(f"generate_launch_description() failed in {launch_file}: {e}")
+        return
+
+    entities = getattr(ld, "entities", None) or getattr(ld, "_actions", None) or []
+
+    # Apply child launch arguments to the context (parent values take precedence
+    # for identically-named args, but child-only args need their defaults).
+    saved_configs = dict(parent_context._launch_configurations)
+    for k, v in child_args.items():
+        parent_context._launch_configurations[k] = v
+
+    # Pass 1: apply DeclareLaunchArgument defaults (child-only args).
+    for entity in entities:
+        if isinstance(entity, _DeclaredArg):
+            _apply_declared_arg(entity, parent_context)
+
+    # Pass 2: walk actions — SetLaunchConfiguration, OpaqueFunction, etc.
+    # all mutate parent_context directly, which is the desired effect.
+    try:
+        _walk_actions(entities, parent_context, depth)
+    except _PackageNotFetchedError:
+        raise
+
+    # Restore child-only args that were not SetLaunchConfiguration'd —
+    # child DeclareLaunchArgument defaults should NOT leak into the parent
+    # scope, only SetLaunchConfiguration is a deliberate side-effect.
+    # Keep keys that were either already in the parent or were set via
+    # SetLaunchConfiguration (tracked globally in _tracked["set_launch_configurations"]).
+    set_configs = set(_tracked["set_launch_configurations"].keys())
+    for k in list(parent_context._launch_configurations):
+        if k not in saved_configs and k not in set_configs:
+            del parent_context._launch_configurations[k]
 
 
 # ─── Action walker ────────────────────────────────────────────────────────────
@@ -1516,6 +1663,19 @@ def _walk_action(action, context, depth):
                 action._path = path
                 dep_idx = _track_include(path)
                 _resolve_include_args(path, action._raw_launch_arguments, context, dep_idx)
+
+        # Inline-execute Python includes within the parent context so that
+        # SetLaunchConfiguration side-effects propagate to sibling actions,
+        # just like the real ROS 2 launch system processes includes synchronously.
+        if action._path and action._path.endswith(".py") and context is not None:
+            child_args = {}
+            if action._raw_launch_arguments:
+                for k, v in action._raw_launch_arguments:
+                    k_str = str(k)
+                    v_str = _resolve_substitution(v, context) or str(v)
+                    child_args[k_str] = v_str
+            _inline_resolve_python_launch(action._path, context, child_args, depth + 1)
+
         return
 
     # SetParameter: append (name, value) to context['global_params'], mirroring the real
@@ -1568,13 +1728,15 @@ def _walk_action(action, context, depth):
     if isinstance(action, _TrackedExecutable):
         parts = []
         for part in action._cmd:
+            raw_part = part
             if hasattr(part, "perform") and context is not None:
                 try:
-                    part = part.perform(context)
+                    result = part.perform(context)
+                    part = result if result is not None else raw_part
                 except _PackageNotFetchedError:
                     raise
                 except Exception:
-                    part = str(part)
+                    part = str(raw_part)
             parts.append(str(part))
         cmd_str = " ".join(parts)
         name = action._name
@@ -2239,7 +2401,7 @@ def main():
         _emit(_tracked)
         return
 
-    # Walk the LaunchDescription tree — two passes, mirroring the XML resolver's behaviour:
+    # Walk the LaunchDescription tree — two passes, mirroring the XML resolver's behavior:
     #
     # Pass 1 (sequential): Apply all top-level DeclareLaunchArgument defaults to the context
     #   in list order.  This populates ctx._launch_configurations so that a later declaration

--- a/python/launch_plus/py_resolver.py
+++ b/python/launch_plus/py_resolver.py
@@ -379,10 +379,12 @@ def _resolve_substitution_ex(sub, context):
 
 
 def _track_node(package, executable, name=None):
+    # Pass raw package to _track_package BEFORE stringifying — _track_package
+    # has an _is_substitution guard that filters out substitution objects.
+    _track_package(package)
     package = str(package) if package else ""
     executable = str(executable) if executable else ""
     name = str(name) if name else ""
-    _track_package(package)
     _tracked["nodes"].append({
         "package": package,
         "executable": executable,
@@ -823,30 +825,44 @@ class _TrackedFindPackageShare:
             _track_package(package)
 
     def _resolve_name(self, context=None):
-        """Concatenate package name from string or list of substitution objects."""
+        """Concatenate package name from string or list of substitution objects.
+
+        Returns ``(name, is_fallback)`` where *is_fallback* is ``True`` when
+        any part could not be resolved and the display name was used instead.
+        """
         subs = self._package_subs
         if isinstance(subs, str):
-            return subs
+            return subs, False
         if isinstance(subs, list):
             parts = []
+            any_fallback = False
             for sub in subs:
                 if context is not None and hasattr(sub, "perform"):
                     result = sub.perform(context)
-                    parts.append(str(result) if result is not None else str(sub))
+                    if result is not None:
+                        parts.append(str(result))
+                    else:
+                        parts.append(str(sub))
+                        any_fallback = True
                 else:
                     parts.append(str(sub))
-            return "".join(parts)
-        return str(subs)
+                    if hasattr(sub, "perform"):
+                        any_fallback = True
+            return "".join(parts), any_fallback
+        if hasattr(subs, "perform"):
+            return str(subs), True
+        return str(subs), False
 
     def perform(self, context):
-        pkg = self._resolve_name(context)
-        _track_package(pkg)
+        pkg, is_fallback = self._resolve_name(context)
+        if not is_fallback:
+            _track_package(pkg)
         if not _preview_mode and pkg in _package_shares:
             return _package_shares[pkg]
         return f"$(find-pkg-share {pkg})"
 
     def __str__(self):
-        pkg = self._resolve_name(None)
+        pkg, is_fallback = self._resolve_name(None)
         if not _preview_mode and pkg in _package_shares:
             return _package_shares[pkg]
         return f"$(find-pkg-share {pkg})"
@@ -857,7 +873,9 @@ class _TrackedPathJoinSubstitution:
         # Track packages from nested FindPackageShare
         for sub in substitutions:
             if isinstance(sub, _TrackedFindPackageShare):
-                _track_package(sub._resolve_name())
+                pkg, is_fallback = sub._resolve_name()
+                if not is_fallback:
+                    _track_package(pkg)
     def perform(self, context):
         parts = []
         for sub in self._subs:

--- a/python/launch_plus/py_resolver.py
+++ b/python/launch_plus/py_resolver.py
@@ -1521,7 +1521,10 @@ def _resolve_composable_plugins(descs, context):
             if isinstance(r, (tuple, list)) and len(r) == 2:
                 src = _resolve_substitution(r[0], context)
                 dst = _resolve_substitution(r[1], context)
-                remaps.append([src or str(r[0]), dst or str(r[1])])
+                remaps.append([
+                    src if src is not None else str(r[0]),
+                    dst if dst is not None else str(r[1]),
+                ])
         # Resolve package/plugin/name substitutions with the live context
         pkg = desc._package
         if _is_substitution(desc._raw_package):
@@ -1622,9 +1625,14 @@ def _inline_resolve_python_launch(launch_file, parent_context, child_args, depth
     # (SetLaunchConfiguration) survive.
     saved_configs = dict(parent_context._launch_configurations)
 
-    # All _tracked mutations (from constructors in generate_launch_description
+    # Most _tracked mutations (from constructors in generate_launch_description
     # AND from _walk_actions) must be rolled back on any exit path, including
     # exceptions from generate_launch_description() itself.
+    #
+    # Intentionally preserved side-effects (NOT rolled back):
+    #   - set_launch_configurations: the whole purpose of inline includes
+    #   - warnings / errors: diagnostic messages should propagate to the user
+    # Everything else in _tracked is rolled back in the finally block below.
     try:
         try:
             ld = mod.generate_launch_description()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,48 @@
+"""Shared fixtures for py_resolver tests."""
+
+import copy
+import sys
+import pytest
+
+from launch_plus import py_resolver as R
+
+
+# Snapshot the initial state of all py_resolver globals so each test starts clean.
+_TRACKED_TEMPLATE = copy.deepcopy(R._tracked)
+
+
+def _install_import_patching():
+    """Install the import patcher so child launch files can import shim modules."""
+    # Add the patching finder if not already present.
+    if not any(isinstance(f, R._PatchingFinder) for f in sys.meta_path):
+        sys.meta_path.insert(0, R._PatchingFinder())
+    # Force patched modules into sys.modules.
+    for mod_name, builder in R._PatchingFinder.PATCHED.items():
+        if mod_name not in R._PATCHED_MODULES:
+            R._PATCHED_MODULES[mod_name] = builder()
+        sys.modules[mod_name] = R._PATCHED_MODULES[mod_name]
+
+
+# Install once at import time so all tests can load child launch files.
+_install_import_patching()
+
+
+@pytest.fixture(autouse=True)
+def _reset_py_resolver_state():
+    """Reset py_resolver module-level globals before every test."""
+    # Restore _tracked to a fresh deep-copy of the template.
+    R._tracked.clear()
+    R._tracked.update(copy.deepcopy(_TRACKED_TEMPLATE))
+
+    # Scalar / set / list globals
+    R._packages_to_fetch.clear()
+    R._declared_arg_names.clear()
+    R._namespace_stack.clear()
+    R._package_shares.clear()
+    R._lockfile_packages.clear()
+    R._apply_opaque_file_access = False
+    R._preview_mode = True
+
+    yield
+
+    # No teardown needed — next invocation resets again.

--- a/tests/test_py_resolver.py
+++ b/tests/test_py_resolver.py
@@ -69,6 +69,20 @@ class TestIsSubstitution:
     def test_none_is_not_substitution(self):
         assert not R._is_substitution(None)
 
+    def test_list_of_substitutions_is_substitution(self):
+        parts = [R._LaunchConfiguration("x"), "_suffix"]
+        assert R._is_substitution(parts)
+
+    def test_list_of_plain_strings_is_not_substitution(self):
+        assert not R._is_substitution(["hello", "world"])
+
+    def test_empty_list_is_not_substitution(self):
+        assert not R._is_substitution([])
+
+    def test_tuple_of_substitutions_is_substitution(self):
+        parts = (R._LaunchConfiguration("x"),)
+        assert R._is_substitution(parts)
+
 
 # ─── _track_package ──────────────────────────────────────────────────────────
 
@@ -92,6 +106,11 @@ class TestTrackPackage:
         R._track_package("pkg_a")
         R._track_package("pkg_a")
         assert R._tracked["packages"].count("pkg_a") == 1
+
+    def test_skips_list_of_substitutions(self):
+        parts = [R._LaunchConfiguration("pkg_var"), "_suffix"]
+        R._track_package(parts)
+        assert len(R._tracked["packages"]) == 0
 
 
 # ─── _resolve_substitution ───────────────────────────────────────────────────
@@ -132,6 +151,39 @@ class TestResolveSubstitution:
         ctx = _make_context({"resolved_var": "abc"})
         # Unresolved element falls back to str(lc) = variable name
         assert R._resolve_substitution(parts, ctx) == "abc/unresolved_var"
+
+    def test_ex_returns_not_fallback_when_resolved(self):
+        lc = R._LaunchConfiguration("my_var")
+        ctx = _make_context({"my_var": "resolved_value"})
+        value, is_fallback = R._resolve_substitution_ex(lc, ctx)
+        assert value == "resolved_value"
+        assert is_fallback is False
+
+    def test_ex_returns_fallback_when_unresolved(self):
+        lc = R._LaunchConfiguration("missing")
+        ctx = _make_context({})
+        value, is_fallback = R._resolve_substitution_ex(lc, ctx)
+        assert value == "missing"
+        assert is_fallback is True
+
+    def test_ex_list_fallback_when_any_unresolved(self):
+        parts = [R._LaunchConfiguration("a"), "_", R._LaunchConfiguration("b")]
+        ctx = _make_context({"a": "resolved"})
+        value, is_fallback = R._resolve_substitution_ex(parts, ctx)
+        assert value == "resolved_b"
+        assert is_fallback is True
+
+    def test_ex_list_not_fallback_when_all_resolved(self):
+        parts = [R._LaunchConfiguration("a"), "_", R._LaunchConfiguration("b")]
+        ctx = _make_context({"a": "foo", "b": "bar"})
+        value, is_fallback = R._resolve_substitution_ex(parts, ctx)
+        assert value == "foo_bar"
+        assert is_fallback is False
+
+    def test_ex_plain_string_not_fallback(self):
+        value, is_fallback = R._resolve_substitution_ex("hello", None)
+        assert value == "hello"
+        assert is_fallback is False
 
 
 # ─── Node deferred resolution ────────────────────────────────────────────────

--- a/tests/test_py_resolver.py
+++ b/tests/test_py_resolver.py
@@ -185,6 +185,27 @@ class TestResolveSubstitution:
         assert value == "hello"
         assert is_fallback is False
 
+    def test_ex_tuple_resolves_same_as_list(self):
+        parts = (R._LaunchConfiguration("a"), "_", R._LaunchConfiguration("b"))
+        ctx = _make_context({"a": "foo", "b": "bar"})
+        value, is_fallback = R._resolve_substitution_ex(parts, ctx)
+        assert value == "foo_bar"
+        assert is_fallback is False
+
+    def test_ex_tuple_fallback_when_unresolved(self):
+        parts = (R._LaunchConfiguration("a"), "_suffix")
+        ctx = _make_context({})
+        value, is_fallback = R._resolve_substitution_ex(parts, ctx)
+        assert value == "a_suffix"
+        assert is_fallback is True
+
+    def test_ex_list_fallback_when_no_context(self):
+        """When context is None, substitutions with perform() should be fallback."""
+        parts = [R._LaunchConfiguration("x"), "_literal"]
+        value, is_fallback = R._resolve_substitution_ex(parts, None)
+        assert value == "x_literal"
+        assert is_fallback is True
+
 
 # ─── Node deferred resolution ────────────────────────────────────────────────
 

--- a/tests/test_py_resolver.py
+++ b/tests/test_py_resolver.py
@@ -292,6 +292,20 @@ class TestComposablePluginResolution:
         assert plugins[0]["package"] == "unknown"  # display fallback
         assert "unknown" not in R._tracked["packages"]
 
+    def test_composable_node_empty_string_remapping_preserved(self):
+        """Remapping resolved to empty string should be preserved, not
+        replaced with the substitution display name."""
+        ctx = _make_context({"remap_src": "", "remap_dst": ""})
+        desc = R._TrackedComposableNode(
+            package="my_pkg",
+            plugin="my_pkg::Node",
+        )
+        desc._raw_remappings = [
+            (R._LaunchConfiguration("remap_src"), R._LaunchConfiguration("remap_dst")),
+        ]
+        plugins = R._resolve_composable_plugins([desc], ctx)
+        assert plugins[0]["remappings"] == [["", ""]]
+
 
 # ─── Inline Python include resolution ────────────────────────────────────────
 

--- a/tests/test_py_resolver.py
+++ b/tests/test_py_resolver.py
@@ -310,3 +310,88 @@ class TestInlinePythonInclude:
         ctx = _make_context({})
         R._inline_resolve_python_launch("/nonexistent/path.py", ctx, {}, depth=1)
         # No error, no crash
+
+    def test_inline_include_does_not_duplicate_tracked_nodes(self):
+        """Inline include must NOT create tracked node entries — the Rust
+        orchestrator resolves the child file separately, so any entries
+        created by the inline walk would be duplicates."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            child_path = _write_launch_py(tmpdir, "child.launch.py", """\
+                from launch import LaunchDescription
+                from launch_ros.actions import Node
+
+                def generate_launch_description():
+                    return LaunchDescription([
+                        Node(package="my_pkg", executable="my_exec"),
+                    ])
+            """)
+
+            nodes_before = len(R._tracked["nodes"])
+            pkgs_before = list(R._tracked["packages"])
+            ctx = _make_context({})
+            R._inline_resolve_python_launch(child_path, ctx, {}, depth=1)
+
+            # No new tracked nodes or packages from the inline walk
+            assert len(R._tracked["nodes"]) == nodes_before
+            assert R._tracked["packages"] == pkgs_before
+
+    def test_inline_include_does_not_duplicate_global_params(self):
+        """SetParameter inside an inline-included child must NOT create
+        tracked global_params entries — only context mutations survive."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            child_path = _write_launch_py(tmpdir, "child.launch.py", """\
+                from launch import LaunchDescription
+                from launch_ros.actions import SetParameter
+
+                def generate_launch_description():
+                    return LaunchDescription([
+                        SetParameter(name="wheel_radius", value="0.383"),
+                    ])
+            """)
+
+            gp_before = len(R._tracked["global_params"])
+            ctx = _make_context({})
+            R._inline_resolve_python_launch(child_path, ctx, {}, depth=1)
+
+            # No new tracked global_params
+            assert len(R._tracked["global_params"]) == gp_before
+            # But context should have the global_params for downstream use
+            gp_list = ctx._launch_configurations.get("global_params", [])
+            assert any(name == "wheel_radius" for name, _ in gp_list)
+
+    def test_inline_include_does_not_duplicate_include_deps(self):
+        """Include dependencies discovered during inline walk should NOT
+        be tracked — the Rust orchestrator tracks them when it processes
+        the child file."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create a grandchild that the child includes
+            _write_launch_py(tmpdir, "grandchild.launch.py", """\
+                from launch import LaunchDescription
+
+                def generate_launch_description():
+                    return LaunchDescription([])
+            """)
+
+            child_path = _write_launch_py(tmpdir, "child.launch.py", """\
+                import os
+                from launch import LaunchDescription
+                from launch.actions import IncludeLaunchDescription
+                from launch.launch_description_sources import PythonLaunchDescriptionSource
+
+                def generate_launch_description():
+                    here = os.path.dirname(__file__)
+                    return LaunchDescription([
+                        IncludeLaunchDescription(
+                            PythonLaunchDescriptionSource(
+                                os.path.join(here, "grandchild.launch.py")
+                            ),
+                        ),
+                    ])
+            """)
+
+            deps_before = len(R._tracked["include_deps"])
+            ctx = _make_context({})
+            R._inline_resolve_python_launch(child_path, ctx, {}, depth=1)
+
+            # No new include deps
+            assert len(R._tracked["include_deps"]) == deps_before

--- a/tests/test_py_resolver.py
+++ b/tests/test_py_resolver.py
@@ -1,0 +1,312 @@
+"""Tests for py_resolver internals — substitution handling, node tracking,
+and inline Python include resolution."""
+
+import os
+import textwrap
+import tempfile
+
+from launch_plus import py_resolver as R
+
+
+# ─── Helpers ──────────────────────────────────────────────────────────────────
+
+def _make_context(configs=None):
+    """Build a _StubLaunchContext with the given launch configurations."""
+    ctx = R._StubLaunchContext()
+    ctx._launch_configurations = dict(configs or {})
+    return ctx
+
+
+def _write_launch_py(directory, filename, body):
+    """Write a minimal Python launch file into *directory*."""
+    path = os.path.join(directory, filename)
+    with open(path, "w") as f:
+        f.write(textwrap.dedent(body))
+    return path
+
+
+# ─── _LaunchConfiguration ────────────────────────────────────────────────────
+
+class TestLaunchConfiguration:
+    def test_perform_returns_value_when_set(self):
+        lc = R._LaunchConfiguration("my_var")
+        ctx = _make_context({"my_var": "hello"})
+        assert lc.perform(ctx) == "hello"
+
+    def test_perform_returns_none_when_unset(self):
+        lc = R._LaunchConfiguration("missing_var")
+        ctx = _make_context({})
+        assert lc.perform(ctx) is None
+
+    def test_perform_returns_default_when_unset_but_default_given(self):
+        lc = R._LaunchConfiguration("missing_var", default="fallback")
+        ctx = _make_context({})
+        assert lc.perform(ctx) == "fallback"
+
+    def test_perform_prefers_context_over_default(self):
+        lc = R._LaunchConfiguration("my_var", default="fallback")
+        ctx = _make_context({"my_var": "from_context"})
+        assert lc.perform(ctx) == "from_context"
+
+    def test_perform_returns_none_without_context(self):
+        lc = R._LaunchConfiguration("x")
+        assert lc.perform(None) is None
+
+    def test_str_returns_variable_name(self):
+        lc = R._LaunchConfiguration("pkg_name")
+        assert str(lc) == "pkg_name"
+
+
+# ─── _is_substitution ────────────────────────────────────────────────────────
+
+class TestIsSubstitution:
+    def test_launch_configuration_is_substitution(self):
+        assert R._is_substitution(R._LaunchConfiguration("x"))
+
+    def test_string_is_not_substitution(self):
+        assert not R._is_substitution("rclcpp_components")
+
+    def test_none_is_not_substitution(self):
+        assert not R._is_substitution(None)
+
+
+# ─── _track_package ──────────────────────────────────────────────────────────
+
+class TestTrackPackage:
+    def test_tracks_plain_string(self):
+        R._track_package("my_pkg")
+        assert "my_pkg" in R._tracked["packages"]
+
+    def test_skips_substitution_object(self):
+        lc = R._LaunchConfiguration("container_pkg")
+        R._track_package(lc)
+        assert "container_pkg" not in R._tracked["packages"]
+        assert len(R._tracked["packages"]) == 0
+
+    def test_skips_empty_and_none(self):
+        R._track_package(None)
+        R._track_package("")
+        assert len(R._tracked["packages"]) == 0
+
+    def test_deduplicates(self):
+        R._track_package("pkg_a")
+        R._track_package("pkg_a")
+        assert R._tracked["packages"].count("pkg_a") == 1
+
+
+# ─── _resolve_substitution ───────────────────────────────────────────────────
+
+class TestResolveSubstitution:
+    def test_resolves_launch_configuration(self):
+        lc = R._LaunchConfiguration("my_var")
+        ctx = _make_context({"my_var": "resolved_value"})
+        assert R._resolve_substitution(lc, ctx) == "resolved_value"
+
+    def test_unresolved_falls_back_to_str(self):
+        lc = R._LaunchConfiguration("missing")
+        ctx = _make_context({})
+        # perform() returns None → _resolve_substitution falls back to str(lc)
+        assert R._resolve_substitution(lc, ctx) == "missing"
+
+    def test_plain_string_passthrough(self):
+        assert R._resolve_substitution("hello", None) == "hello"
+
+    def test_none_returns_none(self):
+        assert R._resolve_substitution(None, None) is None
+
+    def test_list_of_substitutions(self):
+        parts = [
+            R._LaunchConfiguration("prefix"),
+            "_",
+            R._LaunchConfiguration("suffix"),
+        ]
+        ctx = _make_context({"prefix": "foo", "suffix": "bar"})
+        assert R._resolve_substitution(parts, ctx) == "foo_bar"
+
+    def test_list_with_unresolved_element(self):
+        parts = [
+            R._LaunchConfiguration("resolved_var"),
+            "/",
+            R._LaunchConfiguration("unresolved_var"),
+        ]
+        ctx = _make_context({"resolved_var": "abc"})
+        # Unresolved element falls back to str(lc) = variable name
+        assert R._resolve_substitution(parts, ctx) == "abc/unresolved_var"
+
+
+# ─── Node deferred resolution ────────────────────────────────────────────────
+
+class TestNodeDeferredResolution:
+    def test_tracked_node_resolves_package_substitution(self):
+        """When package is a LaunchConfiguration, _resolve_node_details should
+        resolve it to the concrete value and track the resolved package."""
+        ctx = _make_context({"my_pkg_var": "actual_package"})
+        node = R._TrackedNode(
+            package=R._LaunchConfiguration("my_pkg_var"),
+            executable="my_exec",
+        )
+        # Before resolution: str(LaunchConfiguration) = variable name
+        assert R._tracked["nodes"][node._idx]["package"] == "my_pkg_var"
+        assert "my_pkg_var" not in R._tracked["packages"]  # not tracked eagerly
+
+        R._resolve_node_details(node, ctx)
+
+        assert R._tracked["nodes"][node._idx]["package"] == "actual_package"
+        assert "actual_package" in R._tracked["packages"]
+
+    def test_tracked_node_unresolved_package_stays_as_name(self):
+        """When the LaunchConfiguration cannot be resolved (not in context),
+        the entry keeps the variable name but does NOT track it as a package."""
+        ctx = _make_context({})
+        node = R._TrackedNode(
+            package=R._LaunchConfiguration("unknown_pkg"),
+            executable="exec",
+        )
+        R._resolve_node_details(node, ctx)
+
+        # The entry shows the variable name (display fallback from str(lc))
+        assert R._tracked["nodes"][node._idx]["package"] == "unknown_pkg"
+        # But it must NOT be tracked as a real package dependency
+        assert "unknown_pkg" not in R._tracked["packages"]
+
+    def test_tracked_container_resolves_all_fields(self):
+        ctx = _make_context({
+            "pkg": "rclcpp_components",
+            "exe": "component_container_mt",
+            "cname": "my_container",
+        })
+        container = R._TrackedComposableNodeContainer(
+            package=R._LaunchConfiguration("pkg"),
+            executable=R._LaunchConfiguration("exe"),
+            name=R._LaunchConfiguration("cname"),
+        )
+        R._resolve_node_details(container, ctx)
+
+        entry = R._tracked["nodes"][container._idx]
+        assert entry["package"] == "rclcpp_components"
+        assert entry["executable"] == "component_container_mt"
+        assert entry["name"] == "my_container"
+        assert "rclcpp_components" in R._tracked["packages"]
+
+    def test_plain_string_package_tracked_eagerly(self):
+        """When package is a plain string, it should be tracked at construction."""
+        R._TrackedNode(package="my_real_pkg", executable="exec")
+        assert "my_real_pkg" in R._tracked["packages"]
+
+
+# ─── Composable plugin deferred resolution ────────────────────────────────────
+
+class TestComposablePluginResolution:
+    def test_composable_node_resolves_package(self):
+        ctx = _make_context({"plugin_pkg": "sensor_driver"})
+        desc = R._TrackedComposableNode(
+            package=R._LaunchConfiguration("plugin_pkg"),
+            plugin="sensor_driver::SensorNode",
+            name="sensor",
+        )
+        plugins = R._resolve_composable_plugins([desc], ctx)
+        assert len(plugins) == 1
+        assert plugins[0]["package"] == "sensor_driver"
+        assert "sensor_driver" in R._tracked["packages"]
+
+    def test_composable_node_unresolved_package_not_tracked(self):
+        ctx = _make_context({})
+        desc = R._TrackedComposableNode(
+            package=R._LaunchConfiguration("unknown"),
+            plugin="foo::Bar",
+        )
+        plugins = R._resolve_composable_plugins([desc], ctx)
+        assert plugins[0]["package"] == "unknown"  # display fallback
+        assert "unknown" not in R._tracked["packages"]
+
+
+# ─── Inline Python include resolution ────────────────────────────────────────
+
+class TestInlinePythonInclude:
+    def test_set_launch_configuration_propagates(self):
+        """A child Python launch file that calls SetLaunchConfiguration
+        should update the parent context."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            child_path = _write_launch_py(tmpdir, "child.launch.py", """\
+                from launch import LaunchDescription
+                from launch.actions import SetLaunchConfiguration
+
+                def generate_launch_description():
+                    return LaunchDescription([
+                        SetLaunchConfiguration("child_var", "child_value"),
+                    ])
+            """)
+
+            ctx = _make_context({"parent_var": "parent_value"})
+            R._inline_resolve_python_launch(child_path, ctx, {}, depth=1)
+
+            assert ctx._launch_configurations["child_var"] == "child_value"
+            assert ctx._launch_configurations["parent_var"] == "parent_value"
+
+    def test_child_declared_args_do_not_leak(self):
+        """DeclareLaunchArgument defaults from a child file should NOT
+        persist in the parent context (only SetLaunchConfiguration should)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            child_path = _write_launch_py(tmpdir, "child.launch.py", """\
+                from launch import LaunchDescription
+                from launch.actions import DeclareLaunchArgument
+                from launch.actions import SetLaunchConfiguration
+
+                def generate_launch_description():
+                    return LaunchDescription([
+                        DeclareLaunchArgument("child_only_arg", default_value="should_not_leak"),
+                        SetLaunchConfiguration("sticky_var", "persists"),
+                    ])
+            """)
+
+            ctx = _make_context({})
+            R._inline_resolve_python_launch(child_path, ctx, {}, depth=1)
+
+            assert "child_only_arg" not in ctx._launch_configurations
+            assert ctx._launch_configurations["sticky_var"] == "persists"
+
+    def test_child_args_forwarded(self):
+        """launch_arguments passed to the include should be available
+        in the child's context."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            child_path = _write_launch_py(tmpdir, "child.launch.py", """\
+                from launch import LaunchDescription
+                from launch.actions import DeclareLaunchArgument
+                from launch.actions import SetLaunchConfiguration
+                from launch.substitutions import LaunchConfiguration
+
+                def generate_launch_description():
+                    return LaunchDescription([
+                        DeclareLaunchArgument("mode", default_value="default"),
+                        SetLaunchConfiguration("resolved_mode",
+                                               LaunchConfiguration("mode")),
+                    ])
+            """)
+
+            ctx = _make_context({})
+            R._inline_resolve_python_launch(
+                child_path, ctx, {"mode": "custom"}, depth=1
+            )
+
+            assert ctx._launch_configurations["resolved_mode"] == "custom"
+
+    def test_depth_limit_prevents_infinite_recursion(self):
+        """Exceeding the depth limit should warn, not crash."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            child_path = _write_launch_py(tmpdir, "child.launch.py", """\
+                from launch import LaunchDescription
+
+                def generate_launch_description():
+                    return LaunchDescription([])
+            """)
+
+            ctx = _make_context({})
+            R._inline_resolve_python_launch(child_path, ctx, {}, depth=21)
+            # Should not raise; just warns
+            assert any("depth" in w.lower() for w in R._tracked["warnings"])
+
+    def test_missing_file_silently_skipped(self):
+        """A non-existent include file should not raise."""
+        ctx = _make_context({})
+        R._inline_resolve_python_launch("/nonexistent/path.py", ctx, {}, depth=1)
+        # No error, no crash


### PR DESCRIPTION
## Summary

Resolve `LaunchConfiguration` substitutions in py_resolver's deferred resolution phase, so node `package`/`executable`/`name` fields reflect actual values instead of variable names.

### What changed
- **Deferred substitution resolution**: `_resolve_node_details` and `_resolve_composable_plugins` now resolve `LaunchConfiguration` substitutions using the live `LaunchContext`, with an explicit `is_fallback` signal (`_resolve_substitution_ex`) to distinguish real values from unresolved display names
- **Inline include isolation**: `_inline_resolve_python_launch` snapshots and restores all `_tracked` collections and globals so child file execution never leaks into parent output
- **Package tracking correctness**: All `_track_package` call sites propagate fallback/substitution signals — no string-comparison heuristics remain; `_is_substitution` handles list-of-substitutions (`SomeSubstitutionsType`)
- **Test suite**: 43 tests covering substitution handling (including `_resolve_substitution_ex` fallback flag), node tracking, composable plugins, and inline include behavior
- **CI**: Added `actions/setup-python@v5` (3.11+) to release workflow for `tomllib`

## Test plan
- [x] 43 pytest + 191 Rust tests pass
- [x] Autoware example resolved output updated (reflects deferred substitution resolution — expected change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)