### PR TITLE
feat: add --allow-cross-include-set-launch-config flag

### DIFF
--- a/.agents/edge-cases.md
+++ b/.agents/edge-cases.md
@@ -124,6 +124,14 @@ Cross-include `<let>` / `SetLaunchConfiguration` propagation should only be allo
 `--allow-cross-include-set-launch-config` is set, with a clear error message otherwise.
 The flag name is intentionally verbose to discourage the anti-pattern.
 
+**Analogous pattern:** this is structurally identical to the YAML preset pattern (Section 13).
+Both are "include a file for its side-effects on the context" — presets inject `<arg>` defaults
+via implicit scope inheritance (`--allow-global-arg-cascade`), while agnocast-style includes
+inject `<let>` / `SetLaunchConfiguration` values (`--allow-cross-include-set-launch-config`).
+The difference is the mechanism (`DeclareLaunchArgument` defaults vs `SetLaunchConfiguration`
+mutation), but the intent and the anti-pattern are the same: a child include exists solely to
+configure the parent's context for subsequent siblings.
+
 ### Conditional Includes
 ```xml
 <include file="..." if="$(var launch_driver)">
@@ -634,6 +642,17 @@ It **works and is used widely in Autoware**, but has downsides:
 
 The idiomatic alternative is explicit arg passing through each `<include>`, which is more
 verbose but makes dependencies legible.
+
+**Analogous pattern:** this is structurally identical to the cross-include `<let>` /
+`SetLaunchConfiguration` pattern (Section 2 → "Cross-Include `<let>` / `SetLaunchConfiguration`
+Propagation"). Both are "include a file for its side-effects on the context":
+
+| Aspect | Preset YAML | Cross-include `<let>` / `SetLaunchConfiguration` |
+|--------|-------------|--------------------------------------------------|
+| Mechanism | `DeclareLaunchArgument` defaults via scope inheritance | `SetLaunchConfiguration` / `<let>` context mutation |
+| Gate flag | `--allow-global-arg-cascade` | `--allow-cross-include-set-launch-config` |
+| Real-world example | `default_preset.yaml` → `launch_parking_module` | `agnocast_env.launch.py` → `container_package` |
+| Anti-pattern | Child exists solely to inject arg defaults for siblings | Child exists solely to mutate parent context for siblings |
 
 ### Support Status (as of M4.5)
 

--- a/.agents/edge-cases.md
+++ b/.agents/edge-cases.md
@@ -94,6 +94,36 @@ intentional design choice — namespace scope is always group-bounded regardless
 the parent `SubstitutionContext` so `<let>` assignments propagate, while `scoped=true`
 (default) creates a new context that is discarded on exit.
 
+### Cross-Include `<let>` / `SetLaunchConfiguration` Propagation
+
+**ROS 2 design fact:** XML `<let>` is `@expose_action('let')` on `SetLaunchConfiguration`.
+It mutates `context.launch_configurations` — the same global dict used by `LaunchConfiguration`
+substitutions and Python's `SetLaunchConfiguration`.
+
+`IncludeLaunchDescription.execute()` does **not** scope the child (no
+`PushLaunchConfigurations` / `PopLaunchConfigurations`). Only `GroupAction(scoped=True)`
+provides scoping. This means a `<let>` or `SetLaunchConfiguration` in **any** nested
+include — child, grandchild, etc. — mutates the entrypoint's context and is visible to
+every subsequently-executed action at any depth.
+
+**Real-world example:** Autoware's `agnocast_env.launch.xml` sets `container_package` and
+`container_executable` via `<let>`. The parent `pointcloud_container.launch.py` reads them
+via `LaunchConfiguration("container_package")`. Both the
+[XML](https://github.com/autowarefoundation/autoware_core/blob/main/common/autoware_agnocast_wrapper/launch/agnocast_env.launch.xml)
+and Python versions use the same `SetLaunchConfiguration` mechanism.
+
+**launch-plus behavior:**
+
+| Path | Current behavior | Correct behavior |
+|------|-----------------|------------------|
+| Python `SetLaunchConfiguration` in child include | Tracked in `set_launch_configurations`; orchestrator patches unresolved sentinels when `--allow-cross-include-set-launch-config` is set | ✅ Correct (PR #25) |
+| XML `<let>` in child include | Stored in file-local `ctx.vars`; `HashMap::new()` for includes means no propagation in either direction | ❌ Needs fix (issue #26) |
+
+**Design principle:** our resolver should maintain file-boundary context isolation by default.
+Cross-include `<let>` / `SetLaunchConfiguration` propagation should only be allowed when
+`--allow-cross-include-set-launch-config` is set, with a clear error message otherwise.
+The flag name is intentionally verbose to discourage the anti-pattern.
+
 ### Conditional Includes
 ```xml
 <include file="..." if="$(var launch_driver)">

--- a/crates/launch-plus-cli/src/main.rs
+++ b/crates/launch-plus-cli/src/main.rs
@@ -272,6 +272,18 @@ enum Commands {
         #[arg(long)]
         inline_params: bool,
 
+        /// Allow SetLaunchConfiguration calls in child include files to propagate
+        /// back to the parent file, patching unresolved LaunchConfiguration references.
+        ///
+        /// In real ROS 2, included files share a LaunchContext so SetLaunchConfiguration
+        /// in a child mutates the parent's context.  This is an anti-pattern but some
+        /// launch trees (e.g. Autoware's agnocast_env.launch.py) depend on it.
+        ///
+        /// Without this flag, cross-include SetLaunchConfiguration side-effects are
+        /// reported as errors.  The flag name is intentionally verbose.
+        #[arg(long)]
+        allow_cross_include_set_launch_config: bool,
+
         /// Automatically install packages not in the lockfile via rosdep.
         ///
         /// When a required package is not in the lockfile (e.g. a ROS buildfarm package
@@ -370,6 +382,11 @@ enum Commands {
         /// Allow OpaqueFunction bodies to open files via portable paths
         #[arg(long)]
         apply_opaque_file_access: bool,
+
+        /// Allow cross-include SetLaunchConfiguration propagation.
+        /// See `resolve --allow-cross-include-set-launch-config` for details.
+        #[arg(long)]
+        allow_cross_include_set_launch_config: bool,
 
         /// Allow raw filesystem paths in `<include>` and `<param from>` during resolution.
         /// See `resolve --allow-including-unportable-path` for details.
@@ -536,6 +553,11 @@ enum Commands {
         #[arg(long)]
         apply_opaque_file_access: bool,
 
+        /// Allow cross-include SetLaunchConfiguration propagation.
+        /// See `resolve --allow-cross-include-set-launch-config` for details.
+        #[arg(long)]
+        allow_cross_include_set_launch_config: bool,
+
         /// Allow raw filesystem paths in `<include>` and `<param from>` during resolution.
         /// See `resolve --allow-including-unportable-path` for details.
         #[arg(long)]
@@ -630,6 +652,11 @@ enum Commands {
         /// See `resolve --apply-opaque-file-access` for details.
         #[arg(long)]
         apply_opaque_file_access: bool,
+
+        /// Allow cross-include SetLaunchConfiguration propagation.
+        /// See `resolve --allow-cross-include-set-launch-config` for details.
+        #[arg(long)]
+        allow_cross_include_set_launch_config: bool,
 
         /// Automatically install packages not in the lockfile via rosdep.
         /// See `resolve --rosdep` for details.
@@ -745,6 +772,7 @@ fn main() -> Result<()> {
             allow_including_unportable_path,
             apply_opaque_file_access,
             inline_params,
+            allow_cross_include_set_launch_config,
             flatten,
             flatten_namespaces,
             show_args,
@@ -764,6 +792,7 @@ fn main() -> Result<()> {
                 apply_opaque_file_access,
                 rosdep_fallback: rosdep,
                 inline_params,
+                allow_cross_include_set_launch_config,
             };
             cmd_resolve(
                 &package,
@@ -797,6 +826,7 @@ fn main() -> Result<()> {
             allow_global_arg_cascade,
             apply_launch_arg_defaults,
             apply_opaque_file_access,
+            allow_cross_include_set_launch_config,
             allow_including_unportable_path,
             rosdep,
             build_base,
@@ -814,6 +844,7 @@ fn main() -> Result<()> {
                 apply_opaque_file_access,
                 allow_unportable_paths: allow_including_unportable_path,
                 rosdep_fallback: rosdep,
+                allow_cross_include_set_launch_config,
                 ..Default::default()
             };
             let extra_colcon_args = colcon_flagfile
@@ -933,6 +964,7 @@ fn main() -> Result<()> {
             allow_global_arg_cascade,
             apply_launch_arg_defaults,
             apply_opaque_file_access,
+            allow_cross_include_set_launch_config,
             allow_including_unportable_path,
             rosdep,
             build_base,
@@ -950,6 +982,7 @@ fn main() -> Result<()> {
                 apply_opaque_file_access,
                 allow_unportable_paths: allow_including_unportable_path,
                 rosdep_fallback: rosdep,
+                allow_cross_include_set_launch_config,
                 ..Default::default()
             };
             let extra_colcon_args = colcon_flagfile
@@ -992,6 +1025,7 @@ fn main() -> Result<()> {
             preview,
             allow_including_unportable_path,
             apply_opaque_file_access,
+            allow_cross_include_set_launch_config,
             rosdep,
             strict,
             warn_all,
@@ -1009,6 +1043,7 @@ fn main() -> Result<()> {
                 apply_opaque_file_access,
                 rosdep_fallback: rosdep,
                 inline_params: false, // check suppresses XML anyway
+                allow_cross_include_set_launch_config,
             };
             cmd_resolve(
                 &package,
@@ -1708,6 +1743,23 @@ fn cmd_resolve(
                 eprintln!("    → include tag: add <arg name=\"x\" value=\"$(var x)\"/>");
                 eprintln!("    → Or: --allow-global-arg-cascade  (inherits parent context)");
             }
+            eprintln!();
+            eprintln!("  Flags are intentionally verbose — prefer fixing the launch files.");
+        }
+
+        if !workflow_options.allow_cross_include_set_launch_config
+            && all_errors
+                .iter()
+                .any(|e| e.contains("cross-include side-effect"))
+        {
+            eprintln!();
+            eprintln!(
+                "  hint: LaunchConfiguration set by a child include (cross-include side-effect)."
+            );
+            eprintln!("    → Refactor: move SetLaunchConfiguration to the parent file");
+            eprintln!(
+                "    → Or: --allow-cross-include-set-launch-config  (allows child→parent propagation)"
+            );
             eprintln!();
             eprintln!("  Flags are intentionally verbose — prefer fixing the launch files.");
         }

--- a/crates/launch-plus-core/src/orchestrator.rs
+++ b/crates/launch-plus-core/src/orchestrator.rs
@@ -129,6 +129,19 @@ pub struct ResolveWorkflowOptions {
     ///
     /// Exposed via `--inline-params` in the CLI.
     pub inline_params: bool,
+
+    /// Allow `SetLaunchConfiguration` calls in child include files to propagate
+    /// back to the parent file, patching unresolved `LaunchConfiguration` references.
+    ///
+    /// **Default: `false` (strict mode).**  In strict mode, unresolved `LaunchConfiguration`
+    /// references that depend on child includes are reported as errors.
+    ///
+    /// In real ROS 2, included files share a `LaunchContext` so `SetLaunchConfiguration`
+    /// in a child mutates the parent's context.  This is an anti-pattern but some launch
+    /// trees (e.g. Autoware's `agnocast_env.launch.py`) depend on it.
+    ///
+    /// Exposed via `--allow-cross-include-set-launch-config` in the CLI (intentionally verbose).
+    pub allow_cross_include_set_launch_config: bool,
 }
 
 /// Result of recursive launch file resolution
@@ -193,6 +206,11 @@ pub struct ResolveResult {
     /// Stored here so the renderer can emit them as top-level arg comments when
     /// `--show-args` is active.
     pub initial_args: HashMap<String, String>,
+
+    /// Per-file `SetLaunchConfiguration` values: `(package, share_path) → {name: value}`.
+    /// Used to patch unresolved substitutions in parent files when
+    /// `--allow-cross-include-set-launch-config` is enabled.
+    pub set_launch_configs_by_file: HashMap<(String, PathBuf), HashMap<String, String>>,
 }
 
 impl ResolveResult {
@@ -212,6 +230,7 @@ impl ResolveResult {
             declared_args_by_file: HashMap::new(),
             global_params: Vec::new(),
             initial_args: HashMap::new(),
+            set_launch_configs_by_file: HashMap::new(),
         }
     }
 
@@ -454,6 +473,19 @@ struct PyResolverOutput {
     /// Event handlers detected in the Python launch file.
     #[serde(default)]
     event_handlers: Vec<PyEventHandler>,
+    /// Node fields that contain unresolved `LaunchConfiguration` references.
+    #[serde(default)]
+    unresolved_substitutions: Vec<PyUnresolvedSubstitution>,
+}
+
+#[derive(Debug, serde::Deserialize, Clone)]
+struct PyUnresolvedSubstitution {
+    node_idx: usize,
+    field: String,
+    variable_name: String,
+    full_template: String,
+    #[serde(default)]
+    plugin_idx: Option<usize>,
 }
 
 #[derive(Debug, serde::Deserialize, Clone, PartialEq)]
@@ -710,6 +742,8 @@ fn resolved_launch_to_parsed(resolved: ResolvedLaunch) -> ParsedLaunchFile {
         warnings: resolved.warnings,
         errors,
         infos: resolved.infos,
+        set_launch_configurations: HashMap::new(), // XML uses $(var) inline
+        unresolved_substitutions: Vec::new(),      // XML resolves $(var) at parse time
     }
 }
 
@@ -885,6 +919,18 @@ fn py_output_to_parsed(py_output: PyResolverOutput) -> ParsedLaunchFile {
         })
         .collect();
 
+    let unresolved_substitutions = py_output
+        .unresolved_substitutions
+        .into_iter()
+        .map(|u| crate::resolver::UnresolvedSubstitution {
+            node_idx: u.node_idx,
+            field: u.field,
+            variable_name: u.variable_name,
+            full_template: u.full_template,
+            plugin_idx: u.plugin_idx,
+        })
+        .collect();
+
     ParsedLaunchFile {
         packages: py_output.packages,
         nodes,
@@ -896,6 +942,8 @@ fn py_output_to_parsed(py_output: PyResolverOutput) -> ParsedLaunchFile {
         warnings: Vec::new(), // warnings emitted separately by the caller with py_resolver formatting
         errors: Vec::new(),
         infos: Vec::new(),
+        set_launch_configurations: py_output.set_launch_configurations,
+        unresolved_substitutions,
     }
 }
 
@@ -1000,6 +1048,19 @@ fn process_parsed_file(
     // Record parsed file
     result.parsed_files.push(file_path.to_path_buf());
 
+    // Store this file's SetLaunchConfiguration values so parent files can patch
+    // unresolved substitutions using them.
+    if !parsed.set_launch_configurations.is_empty() {
+        result.set_launch_configs_by_file.insert(
+            (package.to_string(), share_path.to_path_buf()),
+            parsed.set_launch_configurations.clone(),
+        );
+    }
+
+    // Record node base index before adding this file's nodes — needed for
+    // post-hoc patching of unresolved substitutions.
+    let nodes_base = result.nodes.len();
+
     // Set include_chain and source on all nodes, then accumulate.
     // IncludeMarker nodes (from inline resolver) get a chain that includes their own source.
     let source = (package.to_string(), share_path.to_path_buf());
@@ -1029,6 +1090,14 @@ fn process_parsed_file(
         .chain(parsed.declared_arg_defaults.iter())
         .map(|(k, v)| (k.clone(), v.clone()))
         .collect();
+
+    // Save include keys and unresolved substitutions for post-loop patching.
+    let include_keys: Vec<(String, PathBuf)> = parsed
+        .launch_includes
+        .iter()
+        .map(|inc| (inc.package.clone(), inc.share_path.clone()))
+        .collect();
+    let unresolved_substitutions = parsed.unresolved_substitutions;
 
     // Recurse into launch includes
     for include in parsed.launch_includes {
@@ -1127,6 +1196,82 @@ fn process_parsed_file(
                     arg_name
                 ));
             }
+        }
+    }
+
+    // ── Cross-include SetLaunchConfiguration patching ──────────────────────
+    //
+    // If the parent file has unresolved LaunchConfiguration references (e.g.
+    // LaunchConfiguration("container_package") where no SetLaunchConfiguration
+    // was called in the parent), check if any child include set the variable
+    // via SetLaunchConfiguration and patch the parent's node fields.
+    if !unresolved_substitutions.is_empty() {
+        // Collect set_launch_configurations from direct child includes.
+        let mut child_configs: HashMap<String, String> = HashMap::new();
+        for (inc_pkg, inc_path) in &include_keys {
+            if let Some(configs) = result
+                .set_launch_configs_by_file
+                .get(&(inc_pkg.clone(), inc_path.clone()))
+            {
+                child_configs.extend(configs.clone());
+            }
+        }
+
+        for unsub in &unresolved_substitutions {
+            if let Some(value) = child_configs.get(&unsub.variable_name) {
+                if !workflow_options.allow_cross_include_set_launch_config {
+                    // The child *would* provide the value, but the flag is not set.
+                    result.add_error(format!(
+                        "{}://{}: LaunchConfiguration('{}') in node field '{}' is set by a \
+                         child include via SetLaunchConfiguration (cross-include side-effect); \
+                         use --allow-cross-include-set-launch-config to allow this pattern",
+                        package,
+                        share_path.display(),
+                        unsub.variable_name,
+                        unsub.field
+                    ));
+                    continue;
+                }
+
+                // Patch the node field by replacing the sentinel with the actual value.
+                let global_idx = nodes_base + unsub.node_idx;
+                if global_idx < result.nodes.len() {
+                    let sentinel = format!("${{{{unresolved:{}}}}}", unsub.variable_name);
+                    let patched = unsub.full_template.replace(&sentinel, value);
+                    let node = &mut result.nodes[global_idx];
+                    match unsub.field.as_str() {
+                        "package" => {
+                            node.package = patched;
+                            result.direct_packages.insert(value.clone());
+                        }
+                        "executable" => node.executable = patched,
+                        "name" => node.name = Some(patched),
+                        "plugin_package" | "plugin_plugin" => {
+                            // Patch composable plugin fields.
+                            if let Some(pi) = unsub.plugin_idx {
+                                match &mut node.kind {
+                                    NodeKind::Container { plugins }
+                                    | NodeKind::LoadComposable { plugins, .. } => {
+                                        if let Some(plugin) = plugins.get_mut(pi) {
+                                            if unsub.field == "plugin_package" {
+                                                plugin.package = patched.clone();
+                                                result.direct_packages.insert(patched);
+                                            } else {
+                                                plugin.plugin = patched;
+                                            }
+                                        }
+                                    }
+                                    _ => {}
+                                }
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+            }
+            // If no child provides it and the sentinel remains, that's fine —
+            // the sentinel will appear in the output as a visible marker of
+            // an unresolved variable.
         }
     }
 }

--- a/crates/launch-plus-core/src/resolver.rs
+++ b/crates/launch-plus-core/src/resolver.rs
@@ -955,6 +955,24 @@ pub struct LaunchInclude {
 ///
 /// Both `resolved_launch_to_parsed` (XML/YAML) and `py_output_to_parsed` (Python)
 /// produce this type.  The orchestrator's `process_parsed_file` consumes it uniformly.
+/// A node field that could not be resolved because the `LaunchConfiguration` variable
+/// was not set in the current context.  The orchestrator uses these to patch node fields
+/// post-hoc using `set_launch_configurations` from child includes.
+#[derive(Debug, Clone)]
+pub struct UnresolvedSubstitution {
+    /// Index into `ParsedLaunchFile::nodes`.
+    pub node_idx: usize,
+    /// Which field is unresolved (e.g. "package", "executable", "name",
+    /// "plugin_package", "plugin_plugin").
+    pub field: String,
+    /// The `LaunchConfiguration` variable name that was missing.
+    pub variable_name: String,
+    /// The full template string with sentinel (e.g. `${{unresolved:container_package}}`).
+    pub full_template: String,
+    /// For plugin fields, which plugin within the container node.
+    pub plugin_idx: Option<usize>,
+}
+
 #[derive(Debug, Default)]
 pub struct ParsedLaunchFile {
     pub packages: Vec<String>,
@@ -971,6 +989,12 @@ pub struct ParsedLaunchFile {
     pub warnings: Vec<String>,
     pub errors: Vec<String>,
     pub infos: Vec<String>,
+    /// SetLaunchConfiguration calls from this file: {name: value}.
+    /// Used by the orchestrator to patch unresolved substitutions in parent files.
+    pub set_launch_configurations: HashMap<String, String>,
+    /// Node fields that contain unresolved `LaunchConfiguration` references.
+    /// The orchestrator patches these using `set_launch_configurations` from child includes.
+    pub unresolved_substitutions: Vec<UnresolvedSubstitution>,
 }
 
 /// A fully resolved node

--- a/python/launch_plus/py_resolver.py
+++ b/python/launch_plus/py_resolver.py
@@ -233,6 +233,7 @@ _tracked = {
     "include_deps": [],               # [{package, share_path}] — structured include dependencies
     "param_file_deps": [],            # [{package, share_path}] — structured param file dependencies
     "event_handlers": [],              # [{handler_kind, target, target_node, start_state, goal_state, actions}]
+    "unresolved_substitutions": [],    # [{node_idx, field, variable_name, full_template, plugin_idx?}]
 }
 
 # Names of args already recorded in declared_args (first declaration wins).
@@ -241,6 +242,8 @@ _declared_arg_names: set = set()
 # Stack of ROS namespaces pushed by PushRosNamespace actions.
 # Each entry is a resolved string.  Managed by _walk_action; reset in main().
 _namespace_stack: list = []
+
+_UNRESOLVED_RE = re.compile(r'\$\{\{unresolved:(.+?)\}\}')
 
 def _is_substitution(value):
     """Return True if *value* is a launch substitution (not yet resolved to a string)."""
@@ -339,7 +342,10 @@ def _resolve_substitution(sub, context):
             if context is not None and hasattr(s, "perform"):
                 try:
                     result = s.perform(context)
-                    parts.append(str(result) if result is not None else str(s))
+                    if result is None and isinstance(s, _LaunchConfiguration):
+                        parts.append(f"${{{{unresolved:{s._name}}}}}")
+                    else:
+                        parts.append(str(result) if result is not None else str(s))
                 except _PackageNotFetchedError:
                     raise
                 except Exception:
@@ -351,6 +357,8 @@ def _resolve_substitution(sub, context):
         try:
             result = sub.perform(context)
             if result is None:
+                if isinstance(sub, _LaunchConfiguration):
+                    return f"${{{{unresolved:{sub._name}}}}}"
                 return str(sub)  # unresolved — use display name
             return str(result)
         except _PackageNotFetchedError:
@@ -1395,12 +1403,17 @@ def _resolve_node_details(node, context):
         if _is_substitution(raw):
             resolved = _resolve_substitution(raw, context)
             if resolved:
+                m = _UNRESOLVED_RE.search(resolved)
+                if m:
+                    _tracked["unresolved_substitutions"].append({
+                        "node_idx": node._idx,
+                        "field": field,
+                        "variable_name": m.group(1),
+                        "full_template": resolved,
+                    })
                 entry[field] = resolved
-                if field == "package":
-                    # Only track when perform() actually resolved (not display fallback)
-                    performed = raw.perform(context) if context and hasattr(raw, "perform") else None
-                    if performed is not None:
-                        _track_package(resolved)
+                if field == "package" and not m:
+                    _track_package(resolved)
 
     # Namespace: emit raw inputs — Rust computes effective_namespace from these
     ns = _resolve_substitution(node._raw_namespace, context) if node._raw_namespace is not None else None
@@ -1445,10 +1458,10 @@ def _resolve_node_details(node, context):
     entry["env"] = env
 
 
-def _resolve_composable_plugins(descs, context):
+def _resolve_composable_plugins(descs, context, container_node_idx=None):
     """Convert ``_TrackedComposableNode`` descriptions to serialisable plugin dicts."""
     plugins = []
-    for desc in descs:
+    for plugin_idx, desc in enumerate(descs):
         if not isinstance(desc, _TrackedComposableNode):
             # Fallback for real/unknown description objects
             pkg = getattr(desc, "package", None) or getattr(desc, "_package", None)
@@ -1479,15 +1492,31 @@ def _resolve_composable_plugins(descs, context):
         if _is_substitution(desc._raw_package):
             resolved_pkg = _resolve_substitution(desc._raw_package, context)
             if resolved_pkg:
+                m = _UNRESOLVED_RE.search(resolved_pkg)
+                if m and container_node_idx is not None:
+                    _tracked["unresolved_substitutions"].append({
+                        "node_idx": container_node_idx,
+                        "field": "plugin_package",
+                        "variable_name": m.group(1),
+                        "full_template": resolved_pkg,
+                        "plugin_idx": plugin_idx,
+                    })
                 pkg = resolved_pkg
-                # Only track when perform() actually resolved (not display fallback)
-                performed = desc._raw_package.perform(context) if context and hasattr(desc._raw_package, "perform") else None
-                if performed is not None:
+                if not m:
                     _track_package(resolved_pkg)
         plg = desc._plugin
         if _is_substitution(desc._raw_plugin):
             resolved_plg = _resolve_substitution(desc._raw_plugin, context)
             if resolved_plg:
+                m = _UNRESOLVED_RE.search(resolved_plg)
+                if m and container_node_idx is not None:
+                    _tracked["unresolved_substitutions"].append({
+                        "node_idx": container_node_idx,
+                        "field": "plugin_plugin",
+                        "variable_name": m.group(1),
+                        "full_template": resolved_plg,
+                        "plugin_idx": plugin_idx,
+                    })
                 plg = resolved_plg
         nm = desc._name
         if _is_substitution(desc._raw_name):
@@ -1503,119 +1532,6 @@ def _resolve_composable_plugins(descs, context):
         })
     return plugins
 
-
-# ─── Inline Python include resolution ─────────────────────────────────────────
-
-def _inline_resolve_python_launch(launch_file, parent_context, child_args, depth):
-    """Load a Python launch file and walk its actions in the parent context.
-
-    This mirrors real ROS 2 behavior where ``IncludeLaunchDescription``
-    synchronously executes the child, so ``SetLaunchConfiguration`` calls in
-    the child mutate the shared ``LaunchContext``.  The orchestrator still
-    handles the recursive node/include dependency resolution separately.
-    """
-    if depth > 20:
-        _warn(f"Max inline include depth for {launch_file}")
-        return
-
-    # Resolve portable paths — $(find-pkg-share pkg)/rest → real filesystem path.
-    real_path = launch_file
-    parsed = _parse_portable_path(launch_file)
-    if parsed:
-        pkg, rest = parsed
-        try:
-            pkg_share = _resolve_pkg_share(pkg)
-        except _PackageNotFetchedError:
-            raise
-        except Exception:
-            return  # Package not available — orchestrator will resolve later
-        real_path = os.path.join(pkg_share, rest)
-
-    if not os.path.isfile(real_path):
-        return  # File not on disk — orchestrator will fetch and resolve later
-
-    try:
-        spec = importlib.util.spec_from_file_location(
-            f"_inline_launch_{depth}", real_path
-        )
-        if spec is None:
-            _warn(f"cannot load included launch file: {real_path}")
-            return
-        mod = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(mod)
-    except _PackageNotFetchedError:
-        raise
-    except Exception as e:
-        _warn(f"failed to load included launch file {real_path}: {e}")
-        return
-
-    if not hasattr(mod, "generate_launch_description"):
-        return
-
-    # Save tracking state BEFORE generate_launch_description() — constructors
-    # (e.g. _TrackedNode, _TrackedSetParameter) append to _tracked["nodes"]
-    # at construction time.  The Rust orchestrator will resolve this same
-    # child file separately and produce its own tracked entries, so we must
-    # discard everything created by the inline execution.
-    saved_nodes_len = len(_tracked["nodes"])
-    saved_gp_len = len(_tracked["global_params"])
-    saved_deps_len = len(_tracked["include_deps"])
-    saved_pkgs = list(_tracked["packages"])
-    saved_includes_len = len(_tracked["includes"])
-    saved_include_args_keys = set(_tracked["include_args"])
-    saved_param_files_len = len(_tracked["param_files"])
-    saved_param_file_deps_len = len(_tracked["param_file_deps"])
-
-    try:
-        ld = mod.generate_launch_description()
-    except _PackageNotFetchedError:
-        raise
-    except Exception as e:
-        _warn(f"generate_launch_description() failed in {launch_file}: {e}")
-        return
-
-    entities = getattr(ld, "entities", None) or getattr(ld, "_actions", None) or []
-
-    # Apply child launch arguments to the context (parent values take precedence
-    # for identically-named args, but child-only args need their defaults).
-    saved_configs = dict(parent_context._launch_configurations)
-    for k, v in child_args.items():
-        parent_context._launch_configurations[k] = v
-
-    # Pass 1: apply DeclareLaunchArgument defaults (child-only args).
-    for entity in entities:
-        if isinstance(entity, _DeclaredArg):
-            _apply_declared_arg(entity, parent_context)
-
-    # Pass 2: walk actions — SetLaunchConfiguration, OpaqueFunction, etc.
-    # all mutate parent_context directly, which is the desired effect.
-    # Only context mutations survive; tracked state is rolled back.
-    try:
-        _walk_actions(entities, parent_context, depth)
-    except _PackageNotFetchedError:
-        raise
-    finally:
-        del _tracked["nodes"][saved_nodes_len:]
-        del _tracked["global_params"][saved_gp_len:]
-        del _tracked["include_deps"][saved_deps_len:]
-        del _tracked["includes"][saved_includes_len:]
-        for k in list(_tracked["include_args"]):
-            if k not in saved_include_args_keys:
-                del _tracked["include_args"][k]
-        del _tracked["param_files"][saved_param_files_len:]
-        del _tracked["param_file_deps"][saved_param_file_deps_len:]
-        _tracked["packages"][:] = saved_pkgs
-
-    # Restore child-only args that were not SetLaunchConfiguration'd —
-    # child DeclareLaunchArgument defaults should NOT leak into the parent
-    # scope, only SetLaunchConfiguration is a deliberate side-effect.
-    # Keep keys that were either already in the parent or were set via
-    # SetLaunchConfiguration.  Also preserve "global_params" — this is the
-    # accumulation list for SetParameter, not a launch argument.
-    set_configs = set(_tracked["set_launch_configurations"].keys())
-    for k in list(parent_context._launch_configurations):
-        if k not in saved_configs and k not in set_configs and k != "global_params":
-            del parent_context._launch_configurations[k]
 
 
 # ─── Action walker ────────────────────────────────────────────────────────────
@@ -1658,7 +1574,7 @@ def _walk_action(action, context, depth):
             action._detailed = True
             _resolve_node_details(action, context)
             _tracked["nodes"][action._idx]["plugins"] = _resolve_composable_plugins(
-                action._descs, context
+                action._descs, context, container_node_idx=action._idx
             )
         return
 
@@ -1674,7 +1590,7 @@ def _walk_action(action, context, depth):
                     target = _resolve_substitution(action._raw_target, context)
                 if target:
                     entry["target"] = target
-            entry["plugins"] = _resolve_composable_plugins(action._descs, context)
+            entry["plugins"] = _resolve_composable_plugins(action._descs, context, container_node_idx=action._idx)
         return
 
     if isinstance(action, _TrackedPushRosNamespace):
@@ -1702,19 +1618,6 @@ def _walk_action(action, context, depth):
                 action._path = path
                 dep_idx = _track_include(path)
                 _resolve_include_args(path, action._raw_launch_arguments, context, dep_idx)
-
-        # Inline-execute Python includes within the parent context so that
-        # SetLaunchConfiguration side-effects propagate to sibling actions,
-        # just like the real ROS 2 launch system processes includes synchronously.
-        if action._path and action._path.endswith(".py") and context is not None:
-            child_args = {}
-            if action._raw_launch_arguments:
-                for k, v in action._raw_launch_arguments:
-                    k_str = str(k)
-                    resolved = _resolve_substitution(v, context)
-                    v_str = resolved if resolved is not None else str(v)
-                    child_args[k_str] = v_str
-            _inline_resolve_python_launch(action._path, context, child_args, depth + 1)
 
         return
 

--- a/tests/test_py_resolver.py
+++ b/tests/test_py_resolver.py
@@ -1,5 +1,5 @@
 """Tests for py_resolver internals — substitution handling, node tracking,
-and inline Python include resolution."""
+and unresolved substitution tracking."""
 
 import os
 import textwrap
@@ -102,11 +102,11 @@ class TestResolveSubstitution:
         ctx = _make_context({"my_var": "resolved_value"})
         assert R._resolve_substitution(lc, ctx) == "resolved_value"
 
-    def test_unresolved_falls_back_to_str(self):
+    def test_unresolved_falls_back_to_sentinel(self):
         lc = R._LaunchConfiguration("missing")
         ctx = _make_context({})
-        # perform() returns None → _resolve_substitution falls back to str(lc)
-        assert R._resolve_substitution(lc, ctx) == "missing"
+        # perform() returns None → sentinel for LaunchConfiguration
+        assert R._resolve_substitution(lc, ctx) == "${{unresolved:missing}}"
 
     def test_plain_string_passthrough(self):
         assert R._resolve_substitution("hello", None) == "hello"
@@ -130,8 +130,8 @@ class TestResolveSubstitution:
             R._LaunchConfiguration("unresolved_var"),
         ]
         ctx = _make_context({"resolved_var": "abc"})
-        # Unresolved element falls back to str(lc) = variable name
-        assert R._resolve_substitution(parts, ctx) == "abc/unresolved_var"
+        # Unresolved element produces sentinel for LaunchConfiguration
+        assert R._resolve_substitution(parts, ctx) == "abc/${{unresolved:unresolved_var}}"
 
 
 # ─── Node deferred resolution ────────────────────────────────────────────────
@@ -154,9 +154,9 @@ class TestNodeDeferredResolution:
         assert R._tracked["nodes"][node._idx]["package"] == "actual_package"
         assert "actual_package" in R._tracked["packages"]
 
-    def test_tracked_node_unresolved_package_stays_as_name(self):
+    def test_tracked_node_unresolved_package_stays_as_sentinel(self):
         """When the LaunchConfiguration cannot be resolved (not in context),
-        the entry keeps the variable name but does NOT track it as a package."""
+        the entry keeps the sentinel but does NOT track it as a package."""
         ctx = _make_context({})
         node = R._TrackedNode(
             package=R._LaunchConfiguration("unknown_pkg"),
@@ -164,9 +164,9 @@ class TestNodeDeferredResolution:
         )
         R._resolve_node_details(node, ctx)
 
-        # The entry shows the variable name (display fallback from str(lc))
-        assert R._tracked["nodes"][node._idx]["package"] == "unknown_pkg"
-        # But it must NOT be tracked as a real package dependency
+        # The entry shows the sentinel (not the plain variable name)
+        assert R._tracked["nodes"][node._idx]["package"] == "${{unresolved:unknown_pkg}}"
+        # It must NOT be tracked as a real package dependency
         assert "unknown_pkg" not in R._tracked["packages"]
 
     def test_tracked_container_resolves_all_fields(self):
@@ -216,182 +216,87 @@ class TestComposablePluginResolution:
             plugin="foo::Bar",
         )
         plugins = R._resolve_composable_plugins([desc], ctx)
-        assert plugins[0]["package"] == "unknown"  # display fallback
+        assert plugins[0]["package"] == "${{unresolved:unknown}}"  # sentinel
         assert "unknown" not in R._tracked["packages"]
 
 
-# ─── Inline Python include resolution ────────────────────────────────────────
+# ─── Unresolved substitution tracking ────────────────────────────────────────
 
-class TestInlinePythonInclude:
-    def test_set_launch_configuration_propagates(self):
-        """A child Python launch file that calls SetLaunchConfiguration
-        should update the parent context."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            child_path = _write_launch_py(tmpdir, "child.launch.py", """\
-                from launch import LaunchDescription
-                from launch.actions import SetLaunchConfiguration
+class TestUnresolvedSubstitutions:
+    def test_unresolved_launch_config_tracked(self):
+        """Node with LaunchConfiguration("x") for package where x is not
+        in the context should produce an unresolved_substitutions entry."""
+        lc = R._LaunchConfiguration("container_package")
+        node = R._TrackedNode(package=lc, executable="my_exec")
 
-                def generate_launch_description():
-                    return LaunchDescription([
-                        SetLaunchConfiguration("child_var", "child_value"),
-                    ])
-            """)
+        ctx = _make_context({})  # container_package NOT in context
+        R._resolve_node_details(node, ctx)
 
-            ctx = _make_context({"parent_var": "parent_value"})
-            R._inline_resolve_python_launch(child_path, ctx, {}, depth=1)
+        unsubs = R._tracked["unresolved_substitutions"]
+        assert len(unsubs) == 1
+        assert unsubs[0]["node_idx"] == node._idx
+        assert unsubs[0]["field"] == "package"
+        assert unsubs[0]["variable_name"] == "container_package"
+        assert "${{unresolved:container_package}}" in unsubs[0]["full_template"]
 
-            assert ctx._launch_configurations["child_var"] == "child_value"
-            assert ctx._launch_configurations["parent_var"] == "parent_value"
+    def test_no_unresolved_when_variable_set(self):
+        """When the variable IS in the context, no unresolved_substitutions entry."""
+        lc = R._LaunchConfiguration("container_package")
+        node = R._TrackedNode(package=lc, executable="my_exec")
 
-    def test_child_declared_args_do_not_leak(self):
-        """DeclareLaunchArgument defaults from a child file should NOT
-        persist in the parent context (only SetLaunchConfiguration should)."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            child_path = _write_launch_py(tmpdir, "child.launch.py", """\
-                from launch import LaunchDescription
-                from launch.actions import DeclareLaunchArgument
-                from launch.actions import SetLaunchConfiguration
+        ctx = _make_context({"container_package": "rclcpp_components"})
+        R._resolve_node_details(node, ctx)
 
-                def generate_launch_description():
-                    return LaunchDescription([
-                        DeclareLaunchArgument("child_only_arg", default_value="should_not_leak"),
-                        SetLaunchConfiguration("sticky_var", "persists"),
-                    ])
-            """)
+        unsubs = R._tracked["unresolved_substitutions"]
+        assert len(unsubs) == 0
+        # And the node's package should be resolved
+        entry = R._tracked["nodes"][node._idx]
+        assert entry["package"] == "rclcpp_components"
 
-            ctx = _make_context({})
-            R._inline_resolve_python_launch(child_path, ctx, {}, depth=1)
+    def test_unresolved_sentinel_format(self):
+        """The sentinel ${{unresolved:x}} should appear in the node's tracked field."""
+        lc = R._LaunchConfiguration("my_var")
+        node = R._TrackedNode(package=lc, executable="my_exec")
 
-            assert "child_only_arg" not in ctx._launch_configurations
-            assert ctx._launch_configurations["sticky_var"] == "persists"
+        ctx = _make_context({})  # my_var NOT in context
+        R._resolve_node_details(node, ctx)
 
-    def test_child_args_forwarded(self):
-        """launch_arguments passed to the include should be available
-        in the child's context."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            child_path = _write_launch_py(tmpdir, "child.launch.py", """\
-                from launch import LaunchDescription
-                from launch.actions import DeclareLaunchArgument
-                from launch.actions import SetLaunchConfiguration
-                from launch.substitutions import LaunchConfiguration
+        entry = R._tracked["nodes"][node._idx]
+        assert entry["package"] == "${{unresolved:my_var}}"
 
-                def generate_launch_description():
-                    return LaunchDescription([
-                        DeclareLaunchArgument("mode", default_value="default"),
-                        SetLaunchConfiguration("resolved_mode",
-                                               LaunchConfiguration("mode")),
-                    ])
-            """)
+    def test_set_launch_configuration_still_recorded(self):
+        """SetLaunchConfiguration should still be recorded in
+        _tracked['set_launch_configurations']."""
+        slc = R._SetLaunchConfiguration("my_key", "my_value")
 
-            ctx = _make_context({})
-            R._inline_resolve_python_launch(
-                child_path, ctx, {"mode": "custom"}, depth=1
-            )
-
-            assert ctx._launch_configurations["resolved_mode"] == "custom"
-
-    def test_depth_limit_prevents_infinite_recursion(self):
-        """Exceeding the depth limit should warn, not crash."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            child_path = _write_launch_py(tmpdir, "child.launch.py", """\
-                from launch import LaunchDescription
-
-                def generate_launch_description():
-                    return LaunchDescription([])
-            """)
-
-            ctx = _make_context({})
-            R._inline_resolve_python_launch(child_path, ctx, {}, depth=21)
-            # Should not raise; just warns
-            assert any("depth" in w.lower() for w in R._tracked["warnings"])
-
-    def test_missing_file_silently_skipped(self):
-        """A non-existent include file should not raise."""
         ctx = _make_context({})
-        R._inline_resolve_python_launch("/nonexistent/path.py", ctx, {}, depth=1)
-        # No error, no crash
+        R._walk_action(slc, ctx, depth=0)
 
-    def test_inline_include_does_not_duplicate_tracked_nodes(self):
-        """Inline include must NOT create tracked node entries — the Rust
-        orchestrator resolves the child file separately, so any entries
-        created by the inline walk would be duplicates."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            child_path = _write_launch_py(tmpdir, "child.launch.py", """\
-                from launch import LaunchDescription
-                from launch_ros.actions import Node
+        assert R._tracked["set_launch_configurations"]["my_key"] == "my_value"
+        assert ctx._launch_configurations["my_key"] == "my_value"
 
-                def generate_launch_description():
-                    return LaunchDescription([
-                        Node(package="my_pkg", executable="my_exec"),
-                    ])
-            """)
+    def test_unresolved_in_executable_field(self):
+        """Unresolved LaunchConfiguration in executable field should also be tracked."""
+        lc = R._LaunchConfiguration("my_executable")
+        node = R._TrackedNode(package="my_pkg", executable=lc)
 
-            nodes_before = len(R._tracked["nodes"])
-            pkgs_before = list(R._tracked["packages"])
-            ctx = _make_context({})
-            R._inline_resolve_python_launch(child_path, ctx, {}, depth=1)
+        ctx = _make_context({})
+        R._resolve_node_details(node, ctx)
 
-            # No new tracked nodes or packages from the inline walk
-            assert len(R._tracked["nodes"]) == nodes_before
-            assert R._tracked["packages"] == pkgs_before
+        unsubs = R._tracked["unresolved_substitutions"]
+        assert len(unsubs) == 1
+        assert unsubs[0]["field"] == "executable"
+        assert unsubs[0]["variable_name"] == "my_executable"
 
-    def test_inline_include_does_not_duplicate_global_params(self):
-        """SetParameter inside an inline-included child must NOT create
-        tracked global_params entries — only context mutations survive."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            child_path = _write_launch_py(tmpdir, "child.launch.py", """\
-                from launch import LaunchDescription
-                from launch_ros.actions import SetParameter
+    def test_unresolved_not_tracked_as_package(self):
+        """An unresolved LaunchConfiguration for a package field should NOT
+        be tracked in _tracked['packages'] (it's not a real package name)."""
+        lc = R._LaunchConfiguration("container_package")
+        node = R._TrackedNode(package=lc, executable="my_exec")
 
-                def generate_launch_description():
-                    return LaunchDescription([
-                        SetParameter(name="wheel_radius", value="0.383"),
-                    ])
-            """)
+        ctx = _make_context({})
+        R._resolve_node_details(node, ctx)
 
-            gp_before = len(R._tracked["global_params"])
-            ctx = _make_context({})
-            R._inline_resolve_python_launch(child_path, ctx, {}, depth=1)
-
-            # No new tracked global_params
-            assert len(R._tracked["global_params"]) == gp_before
-            # But context should have the global_params for downstream use
-            gp_list = ctx._launch_configurations.get("global_params", [])
-            assert any(name == "wheel_radius" for name, _ in gp_list)
-
-    def test_inline_include_does_not_duplicate_include_deps(self):
-        """Include dependencies discovered during inline walk should NOT
-        be tracked — the Rust orchestrator tracks them when it processes
-        the child file."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            # Create a grandchild that the child includes
-            _write_launch_py(tmpdir, "grandchild.launch.py", """\
-                from launch import LaunchDescription
-
-                def generate_launch_description():
-                    return LaunchDescription([])
-            """)
-
-            child_path = _write_launch_py(tmpdir, "child.launch.py", """\
-                import os
-                from launch import LaunchDescription
-                from launch.actions import IncludeLaunchDescription
-                from launch.launch_description_sources import PythonLaunchDescriptionSource
-
-                def generate_launch_description():
-                    here = os.path.dirname(__file__)
-                    return LaunchDescription([
-                        IncludeLaunchDescription(
-                            PythonLaunchDescriptionSource(
-                                os.path.join(here, "grandchild.launch.py")
-                            ),
-                        ),
-                    ])
-            """)
-
-            deps_before = len(R._tracked["include_deps"])
-            ctx = _make_context({})
-            R._inline_resolve_python_launch(child_path, ctx, {}, depth=1)
-
-            # No new include deps
-            assert len(R._tracked["include_deps"]) == deps_before
+        # The sentinel should not be in packages
+        assert "${{unresolved:container_package}}" not in R._tracked["packages"]
+        assert "container_package" not in R._tracked["packages"]


### PR DESCRIPTION
## Summary
- Remove `_inline_resolve_python_launch` from py_resolver — each invocation is now stateless at include boundaries, matching the XML resolver pattern
- Unresolved `LaunchConfiguration` references produce `${{unresolved:NAME}}` sentinels instead of plain variable names
- Rust orchestrator patches sentinels post-hoc using `set_launch_configurations` from child includes
- New `--allow-cross-include-set-launch-config` flag gates cross-boundary `SetLaunchConfiguration` propagation (intentionally verbose to discourage the anti-pattern)
- Without the flag, cross-include side-effects are reported as errors with a hint suggesting refactoring or opting in

## Context
In ROS 2, `SetLaunchConfiguration` inside an included file mutates the parent's shared `LaunchContext`. This is an anti-pattern but Autoware uses it (e.g., `agnocast_env.launch.py` sets `container_package` via `SetLaunchConfiguration`, and `pointcloud_container.launch.py` consumes it via `LaunchConfiguration("container_package")`).

## Test plan
- [ ] CI passes (pytest + cargo test + clippy)
- [ ] Autoware example without flag → 2 errors for `container_package`/`container_executable` cross-include side-effects
- [ ] Autoware example with `--allow-cross-include-set-launch-config` → resolves correctly, 0 errors
- [ ] Python tests updated: `TestInlinePythonInclude` replaced with `TestUnresolvedSubstitutions` (6 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)