### PR TITLE
feat(resolver): env variable stack tracking with per-node <env> output

### DIFF
--- a/.agents/edge-cases.md
+++ b/.agents/edge-cases.md
@@ -79,7 +79,7 @@ another file or hidden behind a recursive include chain).
 | `<let>` | ✅ Allow — **idiomatic** | Leaked variable is right there in the group; reader can see exactly what propagates |
 | `<arg>` | ✅ Allow — unusual but readable | Arg declaration is visible; reader knows what becomes available |
 | `<node>` | ✅ Allow — neutral | Nodes produce no launch-scope variables; `scoped` attribute has no effect |
-| `<set_env>` / `<unset_env>` | ✅ Allow — neutral | Environment variables are process-global, not launch-scoped; `scoped` is irrelevant |
+| `<set_env>` / `<unset_env>` | ✅ Allow — scoped | Env vars are tracked in `ctx.env`; `scoped=true` groups save/restore env (mutations don't leak); `scoped=false` lets mutations propagate |
 | `<push-ros-namespace>` | ✅ Allow — neutral | Namespace pushes are always group-scoped in our resolver regardless of `scoped` flag; the push does not leak |
 | `<group scoped="true">` (default) | ✅ Allow | Acts as a scoping barrier; nothing inside can leak further |
 | `<group scoped="false">` (nested) | ⚠️ Inherit | Apply the same rules recursively; warn if the nested unscoped group contains `<include>` |
@@ -1145,9 +1145,11 @@ a.launch.xml → b.launch.xml → c.launch.xml → d.launch.xml → e.launch.xml
 ```xml
 <arg name="path" default="$(env CUSTOM_PATH)"/>
 ```
-**Warning:** `Environment variable CUSTOM_PATH has no fallback - may fail if unset`
+**Error** at resolve time if the variable is not in `ctx.env` and no default is provided
+(matching ROS 2 behavior). The parse-time lint (`collect_env_without_fallback`) separately
+flags `$(env VAR)` expressions that lack a default — that's informational, not an error.
 
-vs. safe pattern:
+Safe pattern with fallback:
 ```xml
 <arg name="path" default="$(env CUSTOM_PATH /default/path)"/>
 ```

--- a/.agents/edge-cases.md
+++ b/.agents/edge-cases.md
@@ -1145,9 +1145,11 @@ a.launch.xml → b.launch.xml → c.launch.xml → d.launch.xml → e.launch.xml
 ```xml
 <arg name="path" default="$(env CUSTOM_PATH)"/>
 ```
-**Error** at resolve time if the variable is not in `ctx.env` and no default is provided
-(matching ROS 2 behavior). The parse-time lint (`collect_env_without_fallback`) separately
-flags `$(env VAR)` expressions that lack a default — that's informational, not an error.
+**Error** at resolve time if the variable is not in env overrides (`ctx.env`), not in the
+process environment, and no default is provided (matching ROS 2 behavior). The resolution
+chain is: overrides → process env → default → error. The parse-time lint
+(`collect_env_without_fallback`) separately flags `$(env VAR)` expressions that lack a
+default — that's informational, not an error.
 
 Safe pattern with fallback:
 ```xml

--- a/.agents/milestones.md
+++ b/.agents/milestones.md
@@ -32,13 +32,15 @@ Substitution engine supporting `$(arg ...)`, `$(var ...)`, `$(env ...)`,
 recursively, tracks file and package dependencies, computes effective
 namespaces, and renders resolved XML with source annotations.
 
-Environment variable stack: `<set_env>`/`<unset_env>` (XML) and
-`SetEnvironmentVariable`/`UnsetEnvironmentVariable` (Python) mutate a
-tracked `ctx.env` map initialized from `std::env::vars()` / `os.environ`.
-Scoped groups (`scoped="true"`) save/restore env; unscoped groups let
-mutations propagate.  `$(env X)` reads from the tracked map.  Per-node
-`<env>` children reflect only the diff vs process baseline.  Net-zero check
-reports an error for env mutations leaked from file scope.
+Environment variable override tracking: `<set_env>` (XML) and
+`SetEnvironmentVariable` (Python) add entries to an override-only map
+(`ctx.env` / `_env`) that starts empty.  `$(env X)` checks overrides
+first, then falls back to the real process environment.  Scoped groups
+(`scoped="true"`) save/restore overrides; unscoped groups let mutations
+propagate.  Per-node `<env>` children are exactly the override map —
+process env vars are never copied or exposed.  `<unset_env>` is only
+accepted for override-only vars not in process env; otherwise it errors.
+Net-zero check reports an error for overrides leaked from file scope.
 
 Preview mode emits portable `$(find-pkg-share ...)` tokens; non-preview mode
 resolves to actual AMENT install paths.

--- a/.agents/milestones.md
+++ b/.agents/milestones.md
@@ -32,6 +32,14 @@ Substitution engine supporting `$(arg ...)`, `$(var ...)`, `$(env ...)`,
 recursively, tracks file and package dependencies, computes effective
 namespaces, and renders resolved XML with source annotations.
 
+Environment variable stack: `<set_env>`/`<unset_env>` (XML) and
+`SetEnvironmentVariable`/`UnsetEnvironmentVariable` (Python) mutate a
+tracked `ctx.env` map initialized from `std::env::vars()` / `os.environ`.
+Scoped groups (`scoped="true"`) save/restore env; unscoped groups let
+mutations propagate.  `$(env X)` reads from the tracked map.  Per-node
+`<env>` children reflect only the diff vs process baseline.  Net-zero check
+reports an error for env mutations leaked from file scope.
+
 Preview mode emits portable `$(find-pkg-share ...)` tokens; non-preview mode
 resolves to actual AMENT install paths.
 

--- a/.agents/rules.md
+++ b/.agents/rules.md
@@ -43,6 +43,11 @@ tar = "0.4"           # Archive handling
 - Keep all logic in Rust, Python is just glue
 - Type stubs must match Rust implementation exactly
 
+### None Handling
+- **Never** use `str(x)` then check `== "None"` to detect Python `None`. This conflates the literal string `"None"` with the absence of a value.
+- Check `x is None` **before** stringifying: `if x is None: handle_missing()`, then `name = str(x)`.
+- For optional values from ROS 2 APIs, always guard with `is None` first.
+
 ## Git Rules
 
 ### Commit Messages

--- a/crates/launch-plus-core/src/orchestrator.rs
+++ b/crates/launch-plus-core/src/orchestrator.rs
@@ -1555,8 +1555,6 @@ fn resolve_file_recursive(
     let is_preview = workflow_options.preview;
     let lockfile_pkg_names: Arc<HashSet<String>> =
         Arc::new(lockfile.packages.keys().cloned().collect());
-    let process_env: HashMap<String, String> = std::env::vars().collect();
-    let baseline_env = Arc::new(process_env.clone());
     let mut ctx = SubstitutionContext {
         launch_file_dir: Some(file_path.parent().unwrap_or(Path::new("/")).to_path_buf()),
         launch_file_path: Some(file_path.clone()),
@@ -1570,8 +1568,6 @@ fn resolve_file_recursive(
         preview_mode: workflow_options.preview,
         lockfile_packages: lockfile_pkg_names,
         rosdep_fallback: workflow_options.rosdep_fallback,
-        env: process_env,
-        baseline_env,
         ..Default::default()
     };
     // Build a callback that runs py_resolver inline on Python includes so that

--- a/crates/launch-plus-core/src/orchestrator.rs
+++ b/crates/launch-plus-core/src/orchestrator.rs
@@ -1555,6 +1555,8 @@ fn resolve_file_recursive(
     let is_preview = workflow_options.preview;
     let lockfile_pkg_names: Arc<HashSet<String>> =
         Arc::new(lockfile.packages.keys().cloned().collect());
+    let process_env: HashMap<String, String> = std::env::vars().collect();
+    let baseline_env = Arc::new(process_env.clone());
     let mut ctx = SubstitutionContext {
         launch_file_dir: Some(file_path.parent().unwrap_or(Path::new("/")).to_path_buf()),
         launch_file_path: Some(file_path.clone()),
@@ -1568,6 +1570,8 @@ fn resolve_file_recursive(
         preview_mode: workflow_options.preview,
         lockfile_packages: lockfile_pkg_names,
         rosdep_fallback: workflow_options.rosdep_fallback,
+        env: process_env,
+        baseline_env,
         ..Default::default()
     };
     // Build a callback that runs py_resolver inline on Python includes so that

--- a/crates/launch-plus-core/src/parser/mod.rs
+++ b/crates/launch-plus-core/src/parser/mod.rs
@@ -112,6 +112,7 @@ pub enum LaunchElement {
         namespace: Option<String>,
         condition: Option<Condition>,
         composable_nodes: Vec<ComposableNode>,
+        envs: Vec<Env>,
     },
     /// Load composable nodes into a running container: `<load_composable_node target="...">`
     ///
@@ -461,6 +462,7 @@ fn raw_to_launch(raw: RawElement) -> crate::Result<Option<LaunchElement>> {
             let namespace = raw.get("namespace");
             let condition = raw.condition()?;
             let composable_nodes = extract_composable_nodes(&raw.children)?;
+            let envs = extract_env_children(&raw.children)?;
             Ok(Some(LaunchElement::NodeContainer {
                 pkg,
                 exec,
@@ -468,6 +470,7 @@ fn raw_to_launch(raw: RawElement) -> crate::Result<Option<LaunchElement>> {
                 namespace,
                 condition,
                 composable_nodes,
+                envs,
             }))
         }
         "load_composable_node" => {
@@ -732,4 +735,17 @@ fn extract_composable_nodes(children: &[RawElement]) -> crate::Result<Vec<Compos
     }
 
     Ok(nodes)
+}
+
+/// Extract `<env>` children from a raw element's child list.
+fn extract_env_children(children: &[RawElement]) -> crate::Result<Vec<Env>> {
+    let mut envs = Vec::new();
+    for child in children {
+        if child.tag == "env" {
+            let name = child.require("name")?;
+            let value = child.require("value")?;
+            envs.push(Env { name, value });
+        }
+    }
+    Ok(envs)
 }

--- a/crates/launch-plus-core/src/parser/mod.rs
+++ b/crates/launch-plus-core/src/parser/mod.rs
@@ -462,7 +462,7 @@ fn raw_to_launch(raw: RawElement) -> crate::Result<Option<LaunchElement>> {
             let namespace = raw.get("namespace");
             let condition = raw.condition()?;
             let composable_nodes = extract_composable_nodes(&raw.children)?;
-            let envs = extract_env_children(&raw.children)?;
+            let (_, _, envs) = extract_node_children(&raw.children)?;
             Ok(Some(LaunchElement::NodeContainer {
                 pkg,
                 exec,
@@ -735,17 +735,4 @@ fn extract_composable_nodes(children: &[RawElement]) -> crate::Result<Vec<Compos
     }
 
     Ok(nodes)
-}
-
-/// Extract `<env>` children from a raw element's child list.
-fn extract_env_children(children: &[RawElement]) -> crate::Result<Vec<Env>> {
-    let mut envs = Vec::new();
-    for child in children {
-        if child.tag == "env" {
-            let name = child.require("name")?;
-            let value = child.require("value")?;
-            envs.push(Env { name, value });
-        }
-    }
-    Ok(envs)
 }

--- a/crates/launch-plus-core/src/resolver.rs
+++ b/crates/launch-plus-core/src/resolver.rs
@@ -5021,8 +5021,13 @@ mod tests {
 
     #[test]
     fn test_resolve_env_unset_without_default_errors() {
+        let var = "LAUNCH_PLUS_TEST_UNSET_8f3a2b";
+        assert!(
+            std::env::var_os(var).is_none(),
+            "precondition: {var} must not be set in the process environment"
+        );
         let ctx = SubstitutionContext::default();
-        let result = resolve_substitutions("$(env LAUNCH_PLUS_TEST_UNSET_8f3a2b)", &ctx);
+        let result = resolve_substitutions(&format!("$(env {var})"), &ctx);
         assert!(result.is_err());
     }
 
@@ -5147,8 +5152,13 @@ mod tests {
 
     #[test]
     fn test_resolve_undefined_env_errors() {
+        let var = "DEFINITELY_NOT_A_REAL_VAR_12345";
+        assert!(
+            std::env::var_os(var).is_none(),
+            "precondition: {var} must not be set in the process environment"
+        );
         let ctx = SubstitutionContext::default();
-        let result = resolve_substitutions("$(env DEFINITELY_NOT_A_REAL_VAR_12345)", &ctx);
+        let result = resolve_substitutions(&format!("$(env {var})"), &ctx);
         assert!(result.is_err());
     }
 

--- a/crates/launch-plus-core/src/resolver.rs
+++ b/crates/launch-plus-core/src/resolver.rs
@@ -167,14 +167,12 @@ pub struct SubstitutionContext {
     /// When `true`, missing packages are not treated as errors because `--rosdep`
     /// may install them later.  The portable form is kept silently.
     pub rosdep_fallback: bool,
-    /// Full environment variable map.  Initialized from `std::env::vars()` at the
-    /// resolver entry point, then mutated by `<set_env>`/`<unset_env>` actions.
-    /// `$(env X)` reads from this map.  Scoped groups clone/restore it.
+    /// Environment variable overrides.  Starts empty; mutated by
+    /// `<set_env>`/`<unset_env>` actions.  `$(env X)` checks this map first,
+    /// then falls back to the real process environment.  Scoped groups
+    /// clone/restore it.  Per-node `<env>` output is exactly this map
+    /// (no baseline diff needed).
     pub env: HashMap<String, String>,
-    /// Frozen snapshot of the process environment at init time.  Used to compute
-    /// per-node env diffs (only env vars that differ from the baseline are emitted
-    /// as `<env>` children in the resolved XML).
-    pub baseline_env: Arc<HashMap<String, String>>,
 }
 
 impl Default for SubstitutionContext {
@@ -191,8 +189,21 @@ impl Default for SubstitutionContext {
             lockfile_packages: Arc::new(HashSet::new()),
             rosdep_fallback: false,
             env: HashMap::new(),
-            baseline_env: Arc::new(HashMap::new()),
         }
+    }
+}
+
+impl SubstitutionContext {
+    /// Return the current env overrides as a sorted `BTreeMap`.
+    ///
+    /// Since `env` only contains explicit overrides (set via `<set_env>` /
+    /// `<unset_env>`), this is exactly the per-node `<env>` output — no
+    /// baseline diff is needed.
+    pub fn env_overrides(&self) -> BTreeMap<String, String> {
+        self.env
+            .iter()
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect()
     }
 }
 
@@ -577,9 +588,16 @@ fn resolve_substitutions_inner(
                 result.push_str(&value);
             }
             Substitution::Env { name, default } => {
-                let value = ctx.env.get(&name).cloned().or(default).ok_or_else(|| {
-                    crate::Error::LaunchParse(format!("environment variable not set: {}", name))
-                })?;
+                // Check overrides first, then real process env, then default.
+                let value = ctx
+                    .env
+                    .get(&name)
+                    .cloned()
+                    .or_else(|| std::env::var(&name).ok())
+                    .or(default)
+                    .ok_or_else(|| {
+                        crate::Error::LaunchParse(format!("environment variable not set: {}", name))
+                    })?;
                 result.push_str(&value);
             }
             Substitution::FindPkgShare(pkg) => {
@@ -1239,22 +1257,12 @@ pub fn resolve_launch(
             .or_insert_with(|| v.clone());
     }
 
-    // Net-zero check: error on env vars that leaked (set/changed but not restored).
+    // Net-zero check: any remaining overrides at file scope are leaked env mutations.
     for (k, v) in &ctx.env {
-        if ctx.baseline_env.get(k.as_str()) != Some(v) {
-            result.errors.push(format!(
-                "env var '{}' was set to '{}' but not restored (leaked from file scope)",
-                k, v
-            ));
-        }
-    }
-    for k in ctx.baseline_env.keys() {
-        if !ctx.env.contains_key(k) {
-            result.errors.push(format!(
-                "env var '{}' was unset but not restored (leaked from file scope)",
-                k
-            ));
-        }
+        result.errors.push(format!(
+            "env var '{}' was set to '{}' but not restored (leaked from file scope)",
+            k, v
+        ));
     }
 
     Ok(result)
@@ -1513,7 +1521,6 @@ fn resolve_element(
                         lockfile_packages: ctx.lockfile_packages.clone(),
                         rosdep_fallback: ctx.rosdep_fallback,
                         env: ctx.env.clone(),
-                        baseline_env: ctx.baseline_env.clone(),
                     };
                     resolve_elements(children, &mut scoped_ctx, result, options, include_stack)?;
                     // Propagate newly declared args (with defaults) from the scoped context
@@ -1814,7 +1821,6 @@ fn resolve_element(
                         lockfile_packages: ctx.lockfile_packages.clone(),
                         rosdep_fallback: ctx.rosdep_fallback,
                         env: ctx.env.clone(),
-                        baseline_env: ctx.baseline_env.clone(),
                     };
 
                     let nodes_before_xml = result.nodes.len();
@@ -1904,12 +1910,7 @@ fn resolve_element(
                 let resolved_remaps = resolve_remaps(remaps, ctx, result)?;
 
                 // Resolve envs: start with inherited env diff, then node-local overrides
-                let mut merged_envs: BTreeMap<String, String> = ctx
-                    .env
-                    .iter()
-                    .filter(|(k, v)| ctx.baseline_env.get(k.as_str()) != Some(*v))
-                    .map(|(k, v)| (k.clone(), v.clone()))
-                    .collect();
+                let mut merged_envs = ctx.env_overrides();
                 for env in envs {
                     let name_val = resolve_substitutions(&env.name, ctx)?.propagate_into(result);
                     let env_val = resolve_substitutions(&env.value, ctx)?.propagate_into(result);
@@ -2010,12 +2011,7 @@ fn resolve_element(
                 let (resolved_params, resolved_param_files) =
                     resolve_params(params, ctx, result, options)?;
                 let resolved_remaps = resolve_remaps(remaps, ctx, result)?;
-                let mut merged_envs: BTreeMap<String, String> = ctx
-                    .env
-                    .iter()
-                    .filter(|(k, v)| ctx.baseline_env.get(k.as_str()) != Some(*v))
-                    .map(|(k, v)| (k.clone(), v.clone()))
-                    .collect();
+                let mut merged_envs = ctx.env_overrides();
                 for env in envs {
                     let name_val = resolve_substitutions(&env.name, ctx)?.propagate_into(result);
                     let env_val = resolve_substitutions(&env.value, ctx)?.propagate_into(result);
@@ -2205,7 +2201,18 @@ fn resolve_element(
             };
             if should_unset {
                 let name_val = resolve_substitutions(name, ctx)?.propagate_into(result);
-                if ctx.env.remove(&name_val).is_none() {
+                if std::env::var(&name_val).is_ok() {
+                    // In process env (cases 2 & 3) — can't unset baseline.
+                    result.errors.push(format!(
+                        "unset_env: '{}' exists in the process env and cannot be unset. \
+                         Use <set_env name=\"{}\" value=\"\"/> or a scoped group instead",
+                        name_val, name_val
+                    ));
+                } else if ctx.env.contains_key(&name_val) {
+                    // Case 1: override-only, no baseline to expose — safe to remove.
+                    ctx.env.remove(&name_val);
+                } else {
+                    // Case 4: not set anywhere.
                     result.errors.push(format!(
                         "unset_env: environment variable '{}' is not set",
                         name_val
@@ -2259,12 +2266,7 @@ fn resolve_element(
                 }
 
                 // Compute inherited env diff for the container process.
-                let container_env: BTreeMap<String, String> = ctx
-                    .env
-                    .iter()
-                    .filter(|(k, v)| ctx.baseline_env.get(k.as_str()) != Some(*v))
-                    .map(|(k, v)| (k.clone(), v.clone()))
-                    .collect();
+                let container_env = ctx.env_overrides();
 
                 // Emit the container process as a node with its plugins.
                 result.nodes.push(ResolvedNode {
@@ -2335,15 +2337,8 @@ fn resolve_element(
                     ctx.namespace_stack.pop();
                 }
 
-                // Compute inherited env diff for composable nodes loaded into the container.
-                let composable_env: BTreeMap<String, String> = ctx
-                    .env
-                    .iter()
-                    .filter(|(k, v)| ctx.baseline_env.get(k.as_str()) != Some(*v))
-                    .map(|(k, v)| (k.clone(), v.clone()))
-                    .collect();
-
-                // A LoadComposableNode is not itself a process; package/executable are empty.
+                // A LoadComposableNode is not itself a process — it runs inside
+                // the container's process, so it has no env of its own.
                 result.nodes.push(ResolvedNode {
                     package: String::new(),
                     executable: String::new(),
@@ -2353,7 +2348,7 @@ fn resolve_element(
                     namespace_stack: ctx.namespace_stack.clone(),
                     parameters: BTreeMap::new(),
                     remappings: vec![],
-                    env: composable_env,
+                    env: BTreeMap::new(),
                     source: None,
                     include_chain: vec![],
                     kind: NodeKind::LoadComposable {
@@ -2907,7 +2902,7 @@ pub fn render_resolved_xml(
                 );
             }
             NodeKind::LoadComposable { target, plugins } => {
-                render_load_composable_node(node, target, plugins, &node_ind, &child_ind, &mut out);
+                render_load_composable_node(target, plugins, &node_ind, &child_ind, &mut out);
             }
             NodeKind::IncludeMarker => unreachable!("markers handled above"),
             NodeKind::Log { message } => {
@@ -3340,14 +3335,13 @@ fn render_container_node(
 
 /// Emit a `<load_composable_node>` element with `<composable_node>` children.
 fn render_load_composable_node(
-    node: &ResolvedNode,
     target: &str,
     plugins: &[ComposablePlugin],
     node_ind: &str,
     child_ind: &str,
     out: &mut String,
 ) {
-    if plugins.is_empty() && node.env.is_empty() {
+    if plugins.is_empty() {
         return;
     }
     out.push_str(&format!("{}<load_composable_node", node_ind));
@@ -3355,14 +3349,6 @@ fn render_load_composable_node(
         out.push_str(&format!(" target=\"{}\"", xml_escape(target)));
     }
     out.push_str(">\n");
-    for (name, value) in &node.env {
-        out.push_str(&format!(
-            "{}<env name=\"{}\" value=\"{}\"/>\n",
-            child_ind,
-            xml_escape(name),
-            xml_escape(value)
-        ));
-    }
     for plugin in plugins {
         render_composable_plugin(plugin, child_ind, out);
     }
@@ -7726,9 +7712,6 @@ launch:
         "#;
         let launch = parse_launch_xml(xml, Path::new("/test.launch.xml")).unwrap();
         let mut ctx = SubstitutionContext::default();
-        let baseline: HashMap<String, String> = [("PATH".into(), "/usr/bin".into())].into();
-        ctx.env = baseline.clone();
-        ctx.baseline_env = Arc::new(baseline);
         let options = ResolveOptions::default();
         let result = resolve_launch(&launch, HashMap::new(), &mut ctx, &options).unwrap();
         let node = result
@@ -7797,6 +7780,7 @@ launch:
 
     #[test]
     fn test_unset_env_nonexistent_errors() {
+        // <unset_env> on a var that doesn't exist anywhere → "not set" error.
         let xml = r#"
             <launch>
                 <unset_env name="NONEXISTENT"/>
@@ -7847,5 +7831,125 @@ launch:
         let options = ResolveOptions::default();
         let result = resolve_launch(&launch, HashMap::new(), &mut ctx, &options).unwrap();
         assert!(!result.errors.iter().any(|e| e.contains("SCOPED")));
+    }
+
+    #[test]
+    fn test_env_overrides_returns_set_vars() {
+        let mut ctx = SubstitutionContext::default();
+        ctx.env.insert("NEW".into(), "val".into());
+        let overrides = ctx.env_overrides();
+        assert_eq!(overrides.get("NEW"), Some(&"val".to_string()));
+    }
+
+    #[test]
+    fn test_env_overrides_empty_when_no_overrides() {
+        let ctx = SubstitutionContext::default();
+        assert!(ctx.env_overrides().is_empty());
+    }
+
+    #[test]
+    fn test_unset_env_override_only_accepted() {
+        // <set_env> then <unset_env> on a var NOT in process env → case 1: accepted.
+        // The override is removed, so the node sees no env overrides.
+        let xml = r#"
+            <launch>
+                <set_env name="OVERRIDE_ONLY_VAR_12345" value="hello"/>
+                <unset_env name="OVERRIDE_ONLY_VAR_12345"/>
+                <node pkg="p" exec="e"/>
+            </launch>
+        "#;
+        let launch = parse_launch_xml(xml, Path::new("/test.launch.xml")).unwrap();
+        let mut ctx = SubstitutionContext::default();
+        let options = ResolveOptions::default();
+        let result = resolve_launch(&launch, HashMap::new(), &mut ctx, &options).unwrap();
+        let node = result
+            .nodes
+            .iter()
+            .find(|n| matches!(n.kind, NodeKind::Node))
+            .unwrap();
+        assert_eq!(node.env.get("OVERRIDE_ONLY_VAR_12345"), None);
+        assert!(
+            !result
+                .errors
+                .iter()
+                .any(|e| e.contains("OVERRIDE_ONLY_VAR_12345"))
+        );
+    }
+
+    #[test]
+    fn test_load_composable_node_env_is_empty() {
+        let xml = r#"
+            <launch>
+                <set_env name="FOO" value="bar"/>
+                <load_composable_node target="my_container">
+                    <composable_node pkg="p" plugin="p::N"/>
+                </load_composable_node>
+            </launch>
+        "#;
+        let launch = parse_launch_xml(xml, Path::new("/test.launch.xml")).unwrap();
+        let mut ctx = SubstitutionContext::default();
+        let options = ResolveOptions::default();
+        let result = resolve_launch(&launch, HashMap::new(), &mut ctx, &options).unwrap();
+        let lcn = result
+            .nodes
+            .iter()
+            .find(|n| matches!(n.kind, NodeKind::LoadComposable { .. }))
+            .unwrap();
+        assert!(
+            lcn.env.is_empty(),
+            "LoadComposableNode should have empty env"
+        );
+    }
+
+    #[test]
+    fn test_net_zero_error_includes_value() {
+        // Override-only values are user-set, not process secrets — safe to show.
+        let xml = r#"
+            <launch>
+                <set_env name="MY_KEY" value="my_value"/>
+            </launch>
+        "#;
+        let launch = parse_launch_xml(xml, Path::new("/test.launch.xml")).unwrap();
+        let mut ctx = SubstitutionContext::default();
+        let options = ResolveOptions::default();
+        let result = resolve_launch(&launch, HashMap::new(), &mut ctx, &options).unwrap();
+        let err = result
+            .errors
+            .iter()
+            .find(|e| e.contains("MY_KEY") && e.contains("leaked"))
+            .expect("should have leaked error for MY_KEY");
+        assert!(
+            err.contains("my_value"),
+            "error message should contain the override value"
+        );
+    }
+
+    #[test]
+    fn test_process_env_never_exposed_in_node() {
+        // Nodes should only contain explicit overrides, never process env vars.
+        // PATH is virtually always set in the process environment.
+        let xml = r#"
+            <launch>
+                <set_env name="MY_OVERRIDE" value="val"/>
+                <node pkg="p" exec="e"/>
+            </launch>
+        "#;
+        let launch = parse_launch_xml(xml, Path::new("/test.launch.xml")).unwrap();
+        let mut ctx = SubstitutionContext::default();
+        let options = ResolveOptions::default();
+        let result = resolve_launch(&launch, HashMap::new(), &mut ctx, &options).unwrap();
+        let node = result
+            .nodes
+            .iter()
+            .find(|n| matches!(n.kind, NodeKind::Node))
+            .unwrap();
+        // Only the explicit override should appear.
+        assert_eq!(node.env.len(), 1);
+        assert_eq!(node.env.get("MY_OVERRIDE"), Some(&"val".to_string()));
+        // Process env vars like PATH must never leak into node env.
+        assert!(
+            !node.env.contains_key("PATH"),
+            "process env var PATH must not appear in node env"
+        );
     }
 }

--- a/crates/launch-plus-core/src/resolver.rs
+++ b/crates/launch-plus-core/src/resolver.rs
@@ -80,11 +80,6 @@ pub enum NodeKind {
     /// in the include chain are opened persistently so that sibling real nodes share the
     /// correct group context.  Excluded from semantic comparison.
     IncludeMarker,
-    /// A `<set_env name="..." value="..."/>` statement.  Affects the OS environment of
-    /// all subsequently-launched processes.  Excluded from semantic comparison.
-    SetEnv { name: String, value: String },
-    /// A `<unset_env name="..."/>` statement.  Excluded from semantic comparison.
-    UnsetEnv { name: String },
     /// A `<log message="..."/>` action.  Excluded from semantic comparison.
     Log { message: String },
     /// A `<set_parameter name="..." value="..."/>` statement.  Sets a ROS parameter
@@ -172,6 +167,14 @@ pub struct SubstitutionContext {
     /// When `true`, missing packages are not treated as errors because `--rosdep`
     /// may install them later.  The portable form is kept silently.
     pub rosdep_fallback: bool,
+    /// Full environment variable map.  Initialized from `std::env::vars()` at the
+    /// resolver entry point, then mutated by `<set_env>`/`<unset_env>` actions.
+    /// `$(env X)` reads from this map.  Scoped groups clone/restore it.
+    pub env: HashMap<String, String>,
+    /// Frozen snapshot of the process environment at init time.  Used to compute
+    /// per-node env diffs (only env vars that differ from the baseline are emitted
+    /// as `<env>` children in the resolved XML).
+    pub baseline_env: Arc<HashMap<String, String>>,
 }
 
 impl Default for SubstitutionContext {
@@ -187,6 +190,8 @@ impl Default for SubstitutionContext {
             preview_mode: false,
             lockfile_packages: Arc::new(HashSet::new()),
             rosdep_fallback: false,
+            env: HashMap::new(),
+            baseline_env: Arc::new(HashMap::new()),
         }
     }
 }
@@ -572,7 +577,7 @@ fn resolve_substitutions_inner(
                 result.push_str(&value);
             }
             Substitution::Env { name, default } => {
-                let value = std::env::var(&name).ok().or(default).ok_or_else(|| {
+                let value = ctx.env.get(&name).cloned().or(default).ok_or_else(|| {
                     crate::Error::LaunchParse(format!("environment variable not set: {}", name))
                 })?;
                 result.push_str(&value);
@@ -1076,8 +1081,6 @@ pub fn semantic_eq(a: &[ResolvedNode], b: &[ResolvedNode]) -> bool {
         !matches!(
             n.kind,
             NodeKind::IncludeMarker
-                | NodeKind::SetEnv { .. }
-                | NodeKind::UnsetEnv { .. }
                 | NodeKind::SetParameter { .. }
                 | NodeKind::SetRemap { .. }
                 | NodeKind::Log { .. }
@@ -1234,6 +1237,24 @@ pub fn resolve_launch(
             .declared_arg_defaults
             .entry(k.clone())
             .or_insert_with(|| v.clone());
+    }
+
+    // Net-zero check: error on env vars that leaked (set/changed but not restored).
+    for (k, v) in &ctx.env {
+        if ctx.baseline_env.get(k.as_str()) != Some(v) {
+            result.errors.push(format!(
+                "env var '{}' was set to '{}' but not restored (leaked from file scope)",
+                k, v
+            ));
+        }
+    }
+    for k in ctx.baseline_env.keys() {
+        if !ctx.env.contains_key(k) {
+            result.errors.push(format!(
+                "env var '{}' was unset but not restored (leaked from file scope)",
+                k
+            ));
+        }
     }
 
     Ok(result)
@@ -1491,6 +1512,8 @@ fn resolve_element(
                         preview_mode: ctx.preview_mode,
                         lockfile_packages: ctx.lockfile_packages.clone(),
                         rosdep_fallback: ctx.rosdep_fallback,
+                        env: ctx.env.clone(),
+                        baseline_env: ctx.baseline_env.clone(),
                     };
                     resolve_elements(children, &mut scoped_ctx, result, options, include_stack)?;
                     // Propagate newly declared args (with defaults) from the scoped context
@@ -1790,6 +1813,8 @@ fn resolve_element(
                         preview_mode: ctx.preview_mode,
                         lockfile_packages: ctx.lockfile_packages.clone(),
                         rosdep_fallback: ctx.rosdep_fallback,
+                        env: ctx.env.clone(),
+                        baseline_env: ctx.baseline_env.clone(),
                     };
 
                     let nodes_before_xml = result.nodes.len();
@@ -1878,12 +1903,17 @@ fn resolve_element(
                     resolve_params(params, ctx, result, options)?;
                 let resolved_remaps = resolve_remaps(remaps, ctx, result)?;
 
-                // Resolve envs
-                let mut resolved_envs = BTreeMap::new();
+                // Resolve envs: start with inherited env diff, then node-local overrides
+                let mut merged_envs: BTreeMap<String, String> = ctx
+                    .env
+                    .iter()
+                    .filter(|(k, v)| ctx.baseline_env.get(k.as_str()) != Some(*v))
+                    .map(|(k, v)| (k.clone(), v.clone()))
+                    .collect();
                 for env in envs {
                     let name_val = resolve_substitutions(&env.name, ctx)?.propagate_into(result);
                     let env_val = resolve_substitutions(&env.value, ctx)?.propagate_into(result);
-                    resolved_envs.insert(name_val, env_val);
+                    merged_envs.insert(name_val, env_val);
                 }
 
                 // Resolve output / args / respawn / respawn_delay
@@ -1917,7 +1947,7 @@ fn resolve_element(
                     namespace_stack: ctx.namespace_stack.clone(),
                     parameters: resolved_params,
                     remappings: resolved_remaps,
-                    env: resolved_envs,
+                    env: merged_envs,
                     source: None,          // stamped by the orchestrator
                     include_chain: vec![], // stamped by the orchestrator
                     kind: NodeKind::Node,
@@ -1980,11 +2010,16 @@ fn resolve_element(
                 let (resolved_params, resolved_param_files) =
                     resolve_params(params, ctx, result, options)?;
                 let resolved_remaps = resolve_remaps(remaps, ctx, result)?;
-                let mut resolved_envs = BTreeMap::new();
+                let mut merged_envs: BTreeMap<String, String> = ctx
+                    .env
+                    .iter()
+                    .filter(|(k, v)| ctx.baseline_env.get(k.as_str()) != Some(*v))
+                    .map(|(k, v)| (k.clone(), v.clone()))
+                    .collect();
                 for env in envs {
                     let name_val = resolve_substitutions(&env.name, ctx)?.propagate_into(result);
                     let env_val = resolve_substitutions(&env.value, ctx)?.propagate_into(result);
-                    resolved_envs.insert(name_val, env_val);
+                    merged_envs.insert(name_val, env_val);
                 }
                 let resolved_output = if let Some(o) = output {
                     Some(resolve_substitutions(o, ctx)?.propagate_into(result))
@@ -2016,7 +2051,7 @@ fn resolve_element(
                     namespace_stack: ctx.namespace_stack.clone(),
                     parameters: resolved_params,
                     remappings: resolved_remaps,
-                    env: resolved_envs,
+                    env: merged_envs,
                     source: None,
                     include_chain: vec![],
                     kind: NodeKind::LifecycleNode,
@@ -2156,13 +2191,7 @@ fn resolve_element(
             if should_set {
                 let name_val = resolve_substitutions(name, ctx)?.propagate_into(result);
                 let env_val = resolve_substitutions(value, ctx)?.propagate_into(result);
-                result.nodes.push(ResolvedNode {
-                    kind: NodeKind::SetEnv {
-                        name: name_val,
-                        value: env_val,
-                    },
-                    ..Default::default()
-                });
+                ctx.env.insert(name_val, env_val);
             }
         }
 
@@ -2176,10 +2205,12 @@ fn resolve_element(
             };
             if should_unset {
                 let name_val = resolve_substitutions(name, ctx)?.propagate_into(result);
-                result.nodes.push(ResolvedNode {
-                    kind: NodeKind::UnsetEnv { name: name_val },
-                    ..Default::default()
-                });
+                if ctx.env.remove(&name_val).is_none() {
+                    result.errors.push(format!(
+                        "unset_env: environment variable '{}' is not set",
+                        name_val
+                    ));
+                }
             }
         }
 
@@ -2227,6 +2258,14 @@ fn resolve_element(
                     }
                 }
 
+                // Compute inherited env diff for the container process.
+                let container_env: BTreeMap<String, String> = ctx
+                    .env
+                    .iter()
+                    .filter(|(k, v)| ctx.baseline_env.get(k.as_str()) != Some(*v))
+                    .map(|(k, v)| (k.clone(), v.clone()))
+                    .collect();
+
                 // Emit the container process as a node with its plugins.
                 result.nodes.push(ResolvedNode {
                     package: pkg_val,
@@ -2237,7 +2276,7 @@ fn resolve_element(
                     namespace_stack: ctx.namespace_stack.clone(),
                     parameters: BTreeMap::new(),
                     remappings: vec![],
-                    env: BTreeMap::new(),
+                    env: container_env,
                     source: None,
                     include_chain: vec![],
                     kind: NodeKind::Container { plugins },
@@ -2296,6 +2335,14 @@ fn resolve_element(
                     ctx.namespace_stack.pop();
                 }
 
+                // Compute inherited env diff for composable nodes loaded into the container.
+                let composable_env: BTreeMap<String, String> = ctx
+                    .env
+                    .iter()
+                    .filter(|(k, v)| ctx.baseline_env.get(k.as_str()) != Some(*v))
+                    .map(|(k, v)| (k.clone(), v.clone()))
+                    .collect();
+
                 // A LoadComposableNode is not itself a process; package/executable are empty.
                 result.nodes.push(ResolvedNode {
                     package: String::new(),
@@ -2306,7 +2353,7 @@ fn resolve_element(
                     namespace_stack: ctx.namespace_stack.clone(),
                     parameters: BTreeMap::new(),
                     remappings: vec![],
-                    env: BTreeMap::new(),
+                    env: composable_env,
                     source: None,
                     include_chain: vec![],
                     kind: NodeKind::LoadComposable {
@@ -2860,24 +2907,9 @@ pub fn render_resolved_xml(
                 );
             }
             NodeKind::LoadComposable { target, plugins } => {
-                render_load_composable_node(target, plugins, &node_ind, &child_ind, &mut out);
+                render_load_composable_node(node, target, plugins, &node_ind, &child_ind, &mut out);
             }
             NodeKind::IncludeMarker => unreachable!("markers handled above"),
-            NodeKind::SetEnv { name, value } => {
-                out.push_str(&format!(
-                    "{}<set_env name=\"{}\" value=\"{}\"/>\n",
-                    node_ind,
-                    xml_escape(name),
-                    xml_escape(value)
-                ));
-            }
-            NodeKind::UnsetEnv { name } => {
-                out.push_str(&format!(
-                    "{}<unset_env name=\"{}\"/>\n",
-                    node_ind,
-                    xml_escape(name)
-                ));
-            }
             NodeKind::Log { message } => {
                 out.push_str(&format!(
                     "{}<log message=\"{}\"/>\n",
@@ -3284,12 +3316,21 @@ fn render_container_node(
             tag.push_str(&format!(" namespace=\"{}\"", xml_escape(ns)));
         }
     }
-    if plugins.is_empty() {
+    let has_children = !plugins.is_empty() || !node.env.is_empty();
+    if !has_children {
         tag.push_str("/>\n");
         out.push_str(&tag);
     } else {
         tag.push_str(">\n");
         out.push_str(&tag);
+        for (name, value) in &node.env {
+            out.push_str(&format!(
+                "{}<env name=\"{}\" value=\"{}\"/>\n",
+                child_ind,
+                xml_escape(name),
+                xml_escape(value)
+            ));
+        }
         for plugin in plugins {
             render_composable_plugin(plugin, child_ind, out);
         }
@@ -3299,13 +3340,14 @@ fn render_container_node(
 
 /// Emit a `<load_composable_node>` element with `<composable_node>` children.
 fn render_load_composable_node(
+    node: &ResolvedNode,
     target: &str,
     plugins: &[ComposablePlugin],
     node_ind: &str,
     child_ind: &str,
     out: &mut String,
 ) {
-    if plugins.is_empty() {
+    if plugins.is_empty() && node.env.is_empty() {
         return;
     }
     out.push_str(&format!("{}<load_composable_node", node_ind));
@@ -3313,6 +3355,14 @@ fn render_load_composable_node(
         out.push_str(&format!(" target=\"{}\"", xml_escape(target)));
     }
     out.push_str(">\n");
+    for (name, value) in &node.env {
+        out.push_str(&format!(
+            "{}<env name=\"{}\" value=\"{}\"/>\n",
+            child_ind,
+            xml_escape(name),
+            xml_escape(value)
+        ));
+    }
     for plugin in plugins {
         render_composable_plugin(plugin, child_ind, out);
     }
@@ -4919,21 +4969,13 @@ mod tests {
     }
 
     #[test]
-    #[allow(unsafe_code)]
     fn test_resolve_env() {
-        // Set a test env var
-        // SAFETY: This test runs in a single thread and the var is unique to this test
-        unsafe {
-            std::env::set_var("TEST_LAUNCH_VAR", "test_value");
-        }
-        let ctx = SubstitutionContext::default();
+        let mut ctx = SubstitutionContext::default();
+        ctx.env
+            .insert("TEST_LAUNCH_VAR".to_string(), "test_value".to_string());
 
         let result = resolve_substitutions("$(env TEST_LAUNCH_VAR)", &ctx).unwrap();
         assert_eq!(result.value, "test_value");
-
-        unsafe {
-            std::env::remove_var("TEST_LAUNCH_VAR");
-        }
     }
 
     #[test]
@@ -4943,6 +4985,13 @@ mod tests {
         // Unset var should use default
         let result = resolve_substitutions("$(env NONEXISTENT_VAR fallback)", &ctx).unwrap();
         assert_eq!(result.value, "fallback");
+    }
+
+    #[test]
+    fn test_resolve_env_unset_without_default_errors() {
+        let ctx = SubstitutionContext::default();
+        let result = resolve_substitutions("$(env NONEXISTENT_VAR)", &ctx);
+        assert!(result.is_err());
     }
 
     #[test]
@@ -5066,14 +5115,8 @@ mod tests {
 
     #[test]
     #[allow(unsafe_code)]
-    fn test_resolve_error_undefined_env() {
+    fn test_resolve_undefined_env_errors() {
         let ctx = SubstitutionContext::default();
-
-        // Make sure this var doesn't exist
-        // SAFETY: This test runs in a single thread and the var is unique to this test
-        unsafe {
-            std::env::remove_var("DEFINITELY_NOT_A_REAL_VAR_12345");
-        }
         let result = resolve_substitutions("$(env DEFINITELY_NOT_A_REAL_VAR_12345)", &ctx);
         assert!(result.is_err());
     }
@@ -7669,5 +7712,140 @@ launch:
         assert!(rendered.contains("<on_process_exit target=\"can_rx\">"));
         assert!(rendered.contains("<emit_event event=\"shutdown\"/>"));
         assert!(rendered.contains("</on_process_exit>"));
+    }
+
+    // ─── Environment Variable Stack Tests ────────────────────────────────
+
+    #[test]
+    fn test_set_env_inherits_to_node() {
+        let xml = r#"
+            <launch>
+                <set_env name="FOO" value="bar"/>
+                <node pkg="p" exec="e"/>
+            </launch>
+        "#;
+        let launch = parse_launch_xml(xml, Path::new("/test.launch.xml")).unwrap();
+        let mut ctx = SubstitutionContext::default();
+        let baseline: HashMap<String, String> = [("PATH".into(), "/usr/bin".into())].into();
+        ctx.env = baseline.clone();
+        ctx.baseline_env = Arc::new(baseline);
+        let options = ResolveOptions::default();
+        let result = resolve_launch(&launch, HashMap::new(), &mut ctx, &options).unwrap();
+        let node = result
+            .nodes
+            .iter()
+            .find(|n| matches!(n.kind, NodeKind::Node))
+            .unwrap();
+        assert_eq!(node.env.get("FOO"), Some(&"bar".to_string()));
+        // set_env leaks → net-zero error expected
+        assert!(
+            result
+                .errors
+                .iter()
+                .any(|e| e.contains("FOO") && e.contains("leaked"))
+        );
+    }
+
+    #[test]
+    fn test_scoped_group_env_isolation() {
+        let xml = r#"
+            <launch>
+                <group scoped="true">
+                    <set_env name="SCOPED_VAR" value="inner"/>
+                    <node pkg="inner_pkg" exec="inner_exec"/>
+                </group>
+                <node pkg="outer_pkg" exec="outer_exec"/>
+            </launch>
+        "#;
+        let launch = parse_launch_xml(xml, Path::new("/test.launch.xml")).unwrap();
+        let mut ctx = SubstitutionContext::default();
+        let options = ResolveOptions::default();
+        let result = resolve_launch(&launch, HashMap::new(), &mut ctx, &options).unwrap();
+        let nodes: Vec<_> = result
+            .nodes
+            .iter()
+            .filter(|n| matches!(n.kind, NodeKind::Node))
+            .collect();
+        assert_eq!(nodes.len(), 2);
+        // Inner node should have SCOPED_VAR
+        assert_eq!(nodes[0].env.get("SCOPED_VAR"), Some(&"inner".to_string()));
+        // Outer node should NOT have SCOPED_VAR (scoped group restored env)
+        assert_eq!(nodes[1].env.get("SCOPED_VAR"), None);
+    }
+
+    #[test]
+    fn test_env_substitution_reads_from_ctx_env() {
+        let xml = r#"
+            <launch>
+                <set_env name="MY_VAR" value="hello"/>
+                <node pkg="p" exec="e">
+                    <param name="p" value="$(env MY_VAR)"/>
+                </node>
+            </launch>
+        "#;
+        let launch = parse_launch_xml(xml, Path::new("/test.launch.xml")).unwrap();
+        let mut ctx = SubstitutionContext::default();
+        let options = ResolveOptions::default();
+        let result = resolve_launch(&launch, HashMap::new(), &mut ctx, &options).unwrap();
+        let node = result
+            .nodes
+            .iter()
+            .find(|n| matches!(n.kind, NodeKind::Node))
+            .unwrap();
+        assert_eq!(node.parameters.get("p"), Some(&"hello".to_string()));
+    }
+
+    #[test]
+    fn test_unset_env_nonexistent_errors() {
+        let xml = r#"
+            <launch>
+                <unset_env name="NONEXISTENT"/>
+            </launch>
+        "#;
+        let launch = parse_launch_xml(xml, Path::new("/test.launch.xml")).unwrap();
+        let mut ctx = SubstitutionContext::default();
+        let options = ResolveOptions::default();
+        let result = resolve_launch(&launch, HashMap::new(), &mut ctx, &options).unwrap();
+        assert!(
+            result
+                .errors
+                .iter()
+                .any(|e| e.contains("NONEXISTENT") && e.contains("not set"))
+        );
+    }
+
+    #[test]
+    fn test_net_zero_error_on_leaked_env() {
+        let xml = r#"
+            <launch>
+                <set_env name="LEAKED" value="val"/>
+            </launch>
+        "#;
+        let launch = parse_launch_xml(xml, Path::new("/test.launch.xml")).unwrap();
+        let mut ctx = SubstitutionContext::default();
+        let options = ResolveOptions::default();
+        let result = resolve_launch(&launch, HashMap::new(), &mut ctx, &options).unwrap();
+        assert!(
+            result
+                .errors
+                .iter()
+                .any(|e| e.contains("LEAKED") && e.contains("leaked"))
+        );
+    }
+
+    #[test]
+    fn test_net_zero_no_error_when_scoped() {
+        let xml = r#"
+            <launch>
+                <group scoped="true">
+                    <set_env name="SCOPED" value="val"/>
+                </group>
+            </launch>
+        "#;
+        let launch = parse_launch_xml(xml, Path::new("/test.launch.xml")).unwrap();
+        let mut ctx = SubstitutionContext::default();
+        let options = ResolveOptions::default();
+        let result = resolve_launch(&launch, HashMap::new(), &mut ctx, &options).unwrap();
+        assert!(!result.errors.iter().any(|e| e.contains("SCOPED")));
     }
 }

--- a/crates/launch-plus-core/src/resolver.rs
+++ b/crates/launch-plus-core/src/resolver.rs
@@ -2359,6 +2359,14 @@ fn resolve_element(
 
                 // A LoadComposableNode is not itself a process — it runs inside
                 // the container's process, so it has no env of its own.
+                if !ctx.env.is_empty() {
+                    result.warnings.push(format!(
+                        "load_composable_node: env overrides ({}) are active but \
+                         will not apply — composable nodes run inside the container's \
+                         process. Consider setting env on the container instead",
+                        ctx.env.keys().cloned().collect::<Vec<_>>().join(", ")
+                    ));
+                }
                 result.nodes.push(ResolvedNode {
                     package: String::new(),
                     executable: String::new(),
@@ -7917,6 +7925,14 @@ launch:
         assert!(
             lcn.env.is_empty(),
             "LoadComposableNode should have empty env"
+        );
+        // Should warn that env overrides won't apply to composable nodes.
+        assert!(
+            result
+                .warnings
+                .iter()
+                .any(|w| w.contains("load_composable_node") && w.contains("FOO")),
+            "should warn about active env overrides on load_composable_node"
         );
     }
 

--- a/crates/launch-plus-core/src/resolver.rs
+++ b/crates/launch-plus-core/src/resolver.rs
@@ -1833,6 +1833,26 @@ fn resolve_element(
                         include_stack,
                     )?;
                     include_stack.pop();
+                    // Net-zero check for included file: env overrides that differ
+                    // from the parent snapshot are leaked by the included file.
+                    for (k, v) in &include_ctx.env {
+                        if ctx.env.get(k) != Some(v) {
+                            result.errors.push(format!(
+                                "env var '{}' was set to '{}' but not restored \
+                                 (leaked from included file)",
+                                k, v
+                            ));
+                        }
+                    }
+                    for k in ctx.env.keys() {
+                        if !include_ctx.env.contains_key(k) {
+                            result.errors.push(format!(
+                                "env var '{}' was unset but not restored \
+                                 (leaked from included file)",
+                                k
+                            ));
+                        }
+                    }
                     // Inject a marker if the included XML added no nodes at all.
                     if result.nodes.len() == nodes_before_xml {
                         if let Some(file_dep) =
@@ -5100,7 +5120,6 @@ mod tests {
     }
 
     #[test]
-    #[allow(unsafe_code)]
     fn test_resolve_undefined_env_errors() {
         let ctx = SubstitutionContext::default();
         let result = resolve_substitutions("$(env DEFINITELY_NOT_A_REAL_VAR_12345)", &ctx);

--- a/crates/launch-plus-core/src/resolver.rs
+++ b/crates/launch-plus-core/src/resolver.rs
@@ -171,8 +171,9 @@ pub struct SubstitutionContext {
     /// `<set_env>`/`<unset_env>` actions.  `$(env X)` checks this map first,
     /// then falls back to the real process environment.  Scoped groups
     /// clone/restore it.  Per-node `<env>` output is exactly this map
-    /// (no baseline diff needed).
-    pub env: HashMap<String, String>,
+    /// (no baseline diff needed).  Uses `BTreeMap` for stable key order
+    /// in rendered output and error messages.
+    pub env: BTreeMap<String, String>,
 }
 
 impl Default for SubstitutionContext {
@@ -188,22 +189,19 @@ impl Default for SubstitutionContext {
             preview_mode: false,
             lockfile_packages: Arc::new(HashSet::new()),
             rosdep_fallback: false,
-            env: HashMap::new(),
+            env: BTreeMap::new(),
         }
     }
 }
 
 impl SubstitutionContext {
-    /// Return the current env overrides as a sorted `BTreeMap`.
+    /// Return the current env overrides.
     ///
-    /// Since `env` only contains explicit overrides (set via `<set_env>` /
-    /// `<unset_env>`), this is exactly the per-node `<env>` output — no
-    /// baseline diff is needed.
+    /// Since `env` is a `BTreeMap` and only contains explicit overrides
+    /// (set via `<set_env>` / `<unset_env>`), this is exactly the per-node
+    /// `<env>` output — no diff or re-sorting needed.
     pub fn env_overrides(&self) -> BTreeMap<String, String> {
-        self.env
-            .iter()
-            .map(|(k, v)| (k.clone(), v.clone()))
-            .collect()
+        self.env.clone()
     }
 }
 

--- a/crates/launch-plus-core/src/resolver.rs
+++ b/crates/launch-plus-core/src/resolver.rs
@@ -591,7 +591,7 @@ fn resolve_substitutions_inner(
                     .env
                     .get(&name)
                     .cloned()
-                    .or_else(|| std::env::var(&name).ok())
+                    .or_else(|| std::env::var_os(&name).and_then(|v| v.into_string().ok()))
                     .or(default)
                     .ok_or_else(|| {
                         crate::Error::LaunchParse(format!("environment variable not set: {}", name))
@@ -2219,7 +2219,7 @@ fn resolve_element(
             };
             if should_unset {
                 let name_val = resolve_substitutions(name, ctx)?.propagate_into(result);
-                if std::env::var(&name_val).is_ok() {
+                if std::env::var_os(&name_val).is_some() {
                     // In process env (cases 2 & 3) — can't unset baseline.
                     result.errors.push(format!(
                         "unset_env: '{}' exists in the process env and cannot be unset. \
@@ -5002,7 +5002,7 @@ mod tests {
     #[test]
     fn test_resolve_env_unset_without_default_errors() {
         let ctx = SubstitutionContext::default();
-        let result = resolve_substitutions("$(env NONEXISTENT_VAR)", &ctx);
+        let result = resolve_substitutions("$(env LAUNCH_PLUS_TEST_UNSET_8f3a2b)", &ctx);
         assert!(result.is_err());
     }
 
@@ -7808,7 +7808,7 @@ launch:
         // <unset_env> on a var that doesn't exist anywhere → "not set" error.
         let xml = r#"
             <launch>
-                <unset_env name="NONEXISTENT"/>
+                <unset_env name="LAUNCH_PLUS_TEST_UNSET_9c4d7e"/>
             </launch>
         "#;
         let launch = parse_launch_xml(xml, Path::new("/test.launch.xml")).unwrap();
@@ -7819,7 +7819,7 @@ launch:
             result
                 .errors
                 .iter()
-                .any(|e| e.contains("NONEXISTENT") && e.contains("not set"))
+                .any(|e| e.contains("LAUNCH_PLUS_TEST_UNSET_9c4d7e") && e.contains("not set"))
         );
     }
 

--- a/crates/launch-plus-core/src/resolver.rs
+++ b/crates/launch-plus-core/src/resolver.rs
@@ -2246,6 +2246,7 @@ fn resolve_element(
             namespace,
             condition,
             composable_nodes,
+            envs,
         } => {
             let should_include = if let Some(cond) = condition {
                 let (include, cond_sub) = evaluate_condition(cond, ctx)?;
@@ -2283,8 +2284,15 @@ fn resolve_element(
                     }
                 }
 
-                // Compute inherited env diff for the container process.
-                let container_env = ctx.env_overrides();
+                // Compute inherited env + node-local <env> children.
+                let mut container_env = ctx.env_overrides();
+                for env_entry in envs {
+                    let env_name =
+                        resolve_substitutions(&env_entry.name, ctx)?.propagate_into(result);
+                    let env_value =
+                        resolve_substitutions(&env_entry.value, ctx)?.propagate_into(result);
+                    container_env.insert(env_name, env_value);
+                }
 
                 // Emit the container process as a node with its plugins.
                 result.nodes.push(ResolvedNode {
@@ -3624,6 +3632,7 @@ fn collect_arg_var_refs_in_elem(elem: &LaunchElement, refs: &mut HashSet<String>
             namespace,
             condition,
             composable_nodes,
+            envs,
         } => {
             scan_str_for_arg_var_refs(pkg, refs);
             scan_str_for_arg_var_refs(exec, refs);
@@ -3645,6 +3654,10 @@ fn collect_arg_var_refs_in_elem(elem: &LaunchElement, refs: &mut HashSet<String>
                 if let Some(c) = &cn.condition {
                     scan_str_for_arg_var_refs(&c.expr, refs);
                 }
+            }
+            for env_entry in envs {
+                scan_str_for_arg_var_refs(&env_entry.name, refs);
+                scan_str_for_arg_var_refs(&env_entry.value, refs);
             }
         }
         LaunchElement::LoadComposableNode {
@@ -3949,6 +3962,7 @@ fn collect_env_no_fallback_in_elem(elem: &LaunchElement, names: &mut Vec<String>
             namespace,
             condition,
             composable_nodes,
+            envs,
         } => {
             scan_str_for_env_no_fallback(pkg, names);
             scan_str_for_env_no_fallback(exec, names);
@@ -3970,6 +3984,10 @@ fn collect_env_no_fallback_in_elem(elem: &LaunchElement, names: &mut Vec<String>
                 if let Some(c) = &cn.condition {
                     scan_str_for_env_no_fallback(&c.expr, names);
                 }
+            }
+            for env_entry in envs {
+                scan_str_for_env_no_fallback(&env_entry.name, names);
+                scan_str_for_env_no_fallback(&env_entry.value, names);
             }
         }
         LaunchElement::LoadComposableNode {

--- a/crates/launch-plus-core/src/resolver.rs
+++ b/crates/launch-plus-core/src/resolver.rs
@@ -1262,6 +1262,8 @@ pub fn resolve_launch(
             k, v
         ));
     }
+    // Clear leaked overrides so callers don't inherit stale env state.
+    ctx.env.clear();
 
     Ok(result)
 }

--- a/example/autoware/resolved.launch.xml
+++ b/example/autoware/resolved.launch.xml
@@ -36,7 +36,9 @@
   <group>
     <!-- arg name="container_name" value="pointcloud_container" -->
     <!-- arg name="use_multithread" value="true" -->
-    <node_container pkg="rclcpp_components" exec="component_container_mt" name="pointcloud_container"/>
+    <node_container pkg="agnocast_components" exec="agnocast_component_container_cie" name="pointcloud_container">
+      <env name="LD_PRELOAD" value="/opt/ros/humble/lib/libagnocast_heaphook.so"/>
+    </node_container>
     <!-- source: autoware_agnocast_wrapper://launch/agnocast_env.launch.py -->
       <!-- arg name="agnocast_heaphook_path" default="/opt/ros/humble/lib/libagnocast_heaphook.so" -->
       <!-- arg name="use_multithread" default="false" -->

--- a/example/autoware/test-autoware.sh
+++ b/example/autoware/test-autoware.sh
@@ -97,6 +97,10 @@ if [[ -d /opt/acados/lib ]]; then
     export LD_LIBRARY_PATH="/opt/acados/lib:${LD_LIBRARY_PATH:-}"
 fi
 
+# ── Agnocast environment ────────────────────────────────────────────────────
+
+export ENABLE_AGNOCAST="${ENABLE_AGNOCAST:-1}"
+
 # ── Step 1: Preview resolve (portable paths, no expand) ──────────────────────
 
 echo "==> Step 1: Preview resolve"

--- a/python/launch_plus/py_resolver.py
+++ b/python/launch_plus/py_resolver.py
@@ -340,6 +340,31 @@ def _track_param_file(path):
             _tracked["param_file_deps"].append(entry)
 
 
+def _to_str(value, context=None):
+    """Coerce a str, substitution object, or None to str.
+
+    - ``None`` → ``None`` (caller decides how to handle missing values)
+    - ``str``  → returned as-is
+    - object with ``.perform()`` → call it; fall back to ``str(value)`` on
+      failure or ``None`` result
+    - anything else → ``str(value)``
+
+    This is the single choke-point for "expecting a string but might receive a
+    ROS 2 substitution object" conversions.
+    """
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return value
+    if hasattr(value, "perform"):
+        try:
+            res = value.perform(context)
+            return res if res is not None else str(value)
+        except Exception:
+            return str(value)
+    return str(value)
+
+
 def _resolve_substitution(sub, context):
     """Resolve a substitution, list-of-substitutions, or plain string to str."""
     value, _fallback = _resolve_substitution_ex(sub, context)
@@ -1939,16 +1964,11 @@ def _walk_action(action, context, depth):
             except Exception as e:
                 _warn(f"SetEnvironmentVariable condition evaluation failed: {e}")
                 return
-        if action._name is None:
-            _error("SetEnvironmentVariable: name is None — skipping")
-            return
-        resolved = _resolve_substitution(action._name, context)
-        name = resolved if resolved is not None else str(action._name)
+        name = _to_str(action._name, context)
         if not name:
-            _error("SetEnvironmentVariable: resolved name is empty — skipping")
+            _error("SetEnvironmentVariable: resolved name is empty or None — skipping")
             return
-        resolved_val = _resolve_substitution(action._value, context)
-        value = resolved_val if resolved_val is not None else ""
+        value = _to_str(action._value, context) or ""
         _env[name] = value
         return
 
@@ -1963,13 +1983,9 @@ def _walk_action(action, context, depth):
             except Exception as e:
                 _warn(f"UnsetEnvironmentVariable condition evaluation failed: {e}")
                 return
-        if action._name is None:
-            _error("UnsetEnvironmentVariable: name is None — skipping")
-            return
-        resolved = _resolve_substitution(action._name, context)
-        name = resolved if resolved is not None else str(action._name)
+        name = _to_str(action._name, context)
         if not name:
-            _error("UnsetEnvironmentVariable: resolved name is empty — skipping")
+            _error("UnsetEnvironmentVariable: resolved name is empty or None — skipping")
             return
         if name in os.environ:
             # In process env (cases 2 & 3) — can't unset baseline.
@@ -2214,15 +2230,9 @@ def _build_patched_launch_substitutions():
             self._default = kw.get("default_value", "")
         def perform(self, context=None):
             # Resolve name to string (may be a substitution object).
-            name = self._name
-            if hasattr(name, "perform"):
-                try:
-                    res = name.perform(context)
-                    name = res if res is not None else str(self._name)
-                except Exception:
-                    name = str(self._name)
-            name = str(name) if name is not None else ""
-            return _env.get(name, os.environ.get(name, self._default))
+            name = _to_str(self._name, context) or ""
+            default = _to_str(self._default, context) if hasattr(self._default, "perform") else self._default
+            return _env.get(name, os.environ.get(name, default if default is not None else ""))
         def __str__(self):
             # Avoid calling perform() without context — return the raw name.
             return str(self._name) if self._name is not None else ""

--- a/python/launch_plus/py_resolver.py
+++ b/python/launch_plus/py_resolver.py
@@ -1940,6 +1940,9 @@ def _walk_action(action, context, depth):
                 _warn(f"SetEnvironmentVariable condition evaluation failed: {e}")
                 return
         name = _resolve_substitution(action._name, context) or str(action._name)
+        if not name or name == "None":
+            _error("SetEnvironmentVariable: resolved name is empty or None — skipping")
+            return
         value = _resolve_substitution(action._value, context) or ""
         _env[name] = value
         return
@@ -2192,7 +2195,16 @@ def _build_patched_launch_substitutions():
     mod.FindPackageShare = _TrackedFindPackageShare
     mod.PathJoinSubstitution = _TrackedPathJoinSubstitution
     mod.LaunchConfiguration = _LaunchConfiguration
-    mod.EnvironmentVariable = lambda name, **kw: _env.get(name, os.environ.get(name, kw.get("default_value", "")))
+    class _DeferredEnvironmentVariable:
+        """Deferred substitution: reads _env at perform() time, not construction."""
+        def __init__(self, name, **kw):
+            self._name = name
+            self._default = kw.get("default_value", "")
+        def perform(self, context=None):
+            return _env.get(self._name, os.environ.get(self._name, self._default))
+        def __str__(self):
+            return self.perform()
+    mod.EnvironmentVariable = _DeferredEnvironmentVariable
     mod.TextSubstitution = lambda text="", **kw: str(text)
     mod.PythonExpression = lambda expression=None, **kw: None
     mod.ThisLaunchFileDir = lambda: Path(__file__).parent

--- a/python/launch_plus/py_resolver.py
+++ b/python/launch_plus/py_resolver.py
@@ -2221,6 +2221,7 @@ def _build_patched_launch_ros_descriptions():
 def _build_patched_launch_substitutions():
     """Always-stub: avoids recursion since we also patch top-level `launch`."""
     mod = types.ModuleType("launch.substitutions")
+    mod.__path__ = []  # mark as package so submodule imports work
     mod.FindPackageShare = _TrackedFindPackageShare
     mod.PathJoinSubstitution = _TrackedPathJoinSubstitution
     mod.LaunchConfiguration = _LaunchConfiguration
@@ -2250,6 +2251,15 @@ def _build_patched_launch_substitutions():
     mod.TextSubstitution = lambda text="", **kw: str(text)
     mod.PythonExpression = lambda expression=None, **kw: None
     mod.ThisLaunchFileDir = lambda: Path(__file__).parent
+    return mod
+
+def _build_patched_launch_substitutions_environment_variable():
+    """Submodule stub for ``from launch.substitutions.environment_variable import ...``."""
+    parent = sys.modules.get("launch.substitutions")
+    if parent is None:
+        parent = _build_patched_launch_substitutions()
+    mod = types.ModuleType("launch.substitutions.environment_variable")
+    mod.EnvironmentVariable = parent.EnvironmentVariable
     return mod
 
 def _build_patched_launch_actions():
@@ -2508,6 +2518,7 @@ class _PatchingFinder(importlib.abc.MetaPathFinder):
         "launch_ros.parameter_descriptions": _build_patched_launch_ros_parameter_descriptions,
         "launch_ros.utilities": _build_patched_launch_ros_utilities,
         "launch.substitutions": _build_patched_launch_substitutions,
+        "launch.substitutions.environment_variable": _build_patched_launch_substitutions_environment_variable,
         "launch.actions": _build_patched_launch_actions,
         "launch.event_handlers": _build_patched_launch_event_handlers,
         "launch.conditions": _build_patched_launch_conditions,

--- a/python/launch_plus/py_resolver.py
+++ b/python/launch_plus/py_resolver.py
@@ -242,6 +242,13 @@ _declared_arg_names: set = set()
 # Each entry is a resolved string.  Managed by _walk_action; reset in main().
 _namespace_stack: list = []
 
+# Full environment variable map, initialized from os.environ in main().
+# Mutated by SetEnvironmentVariable / UnsetEnvironmentVariable.
+# Scoped groups clone/restore this.
+_env: dict = {}
+# Frozen baseline snapshot for computing per-node env diffs.
+_env_baseline: dict = {}
+
 def _is_substitution(value):
     """Return True if *value* is a launch substitution (not yet resolved to a string).
 
@@ -1089,6 +1096,20 @@ class _TrackedGroupAction:
     """Stores GroupAction's child actions so the walker can recurse into them."""
     def __init__(self, actions=None, **kwargs):
         self._actions = list(actions or [])
+        self._scoped = kwargs.get("scoped", True)
+
+class _TrackedSetEnvironmentVariable:
+    """Tracks SetEnvironmentVariable: mutates _env in _walk_action."""
+    def __init__(self, name=None, value=None, **kwargs):
+        self._name = name
+        self._value = value
+        self._condition = kwargs.get("condition")
+
+class _TrackedUnsetEnvironmentVariable:
+    """Tracks UnsetEnvironmentVariable: removes from _env in _walk_action."""
+    def __init__(self, name=None, **kwargs):
+        self._name = name
+        self._condition = kwargs.get("condition")
 
 class _TrackedSetParameter:
     """Mirrors launch_ros SetParameter: accumulates (name, value) into context['global_params'].
@@ -1431,6 +1452,11 @@ def _make_launch_context(args_dict):
 
 # ─── Node detail resolution helpers ──────────────────────────────────────────
 
+def _compute_env_diff():
+    """Return env vars that differ from the process baseline."""
+    return {k: v for k, v in _env.items() if _env_baseline.get(k) != v}
+
+
 def _resolve_node_details(node, context):
     """Fill in deferred details (package, executable, name, namespace, params, remaps, env).
 
@@ -1478,8 +1504,8 @@ def _resolve_node_details(node, context):
             remaps.append([src or str(r[0]), dst or str(r[1])])
     entry["remappings"] = remaps
 
-    # Env vars: accept list-of-tuples or dict
-    env = {}
+    # Env vars: start with inherited env diff, then node-local overrides
+    env = _compute_env_diff()
     raw_env = node._raw_env
     if isinstance(raw_env, dict):
         for k, v in raw_env.items():
@@ -1619,6 +1645,7 @@ def _inline_resolve_python_launch(launch_file, parent_context, child_args, depth
     saved_declared_arg_names = set(_declared_arg_names)
     saved_event_handlers_len = len(_tracked["event_handlers"])
     saved_namespace_depth = len(_namespace_stack)
+    saved_env = dict(_env)
 
     # Snapshot parent context BEFORE generate_launch_description() so we can
     # fully restore it after the inline walk.  Only deliberate side-effects
@@ -1677,6 +1704,8 @@ def _inline_resolve_python_launch(launch_file, parent_context, child_args, depth
         _declared_arg_names.update(saved_declared_arg_names)
         del _tracked["event_handlers"][saved_event_handlers_len:]
         del _namespace_stack[saved_namespace_depth:]
+        _env.clear()
+        _env.update(saved_env)
 
     # Restore child-only args that were not SetLaunchConfiguration'd —
     # child DeclareLaunchArgument defaults should NOT leak into the parent
@@ -1899,12 +1928,43 @@ def _walk_action(action, context, depth):
                 _error(f"OpaqueFunction failed: {e}")
         return
 
-    # GroupAction: walk child actions; restore namespace stack depth afterwards
-    # (any PushRosNamespace pushed inside the group must not leak to siblings)
+    # SetEnvironmentVariable: mutate the env map (respects condition)
+    if isinstance(action, _TrackedSetEnvironmentVariable):
+        if action._condition is not None and context is not None:
+            try:
+                if not action._condition.evaluate(context):
+                    return
+            except Exception:
+                return
+        name = _resolve_substitution(action._name, context) or str(action._name)
+        value = _resolve_substitution(action._value, context) or ""
+        _env[name] = value
+        return
+
+    # UnsetEnvironmentVariable: remove from env map (respects condition)
+    if isinstance(action, _TrackedUnsetEnvironmentVariable):
+        if action._condition is not None and context is not None:
+            try:
+                if not action._condition.evaluate(context):
+                    return
+            except Exception:
+                return
+        name = _resolve_substitution(action._name, context) or str(action._name)
+        if name not in _env:
+            _error(f"unset_env: environment variable '{name}' is not set")
+        else:
+            del _env[name]
+        return
+
+    # GroupAction: walk child actions; scoped groups save/restore env + namespace
     if isinstance(action, _TrackedGroupAction):
         depth_before = len(_namespace_stack)
+        saved_env = dict(_env) if action._scoped else None
         _walk_actions(action._actions, context, depth + 1)
         del _namespace_stack[depth_before:]
+        if saved_env is not None:
+            _env.clear()
+            _env.update(saved_env)
         return
 
     if isinstance(action, _TimerAction):
@@ -2108,7 +2168,7 @@ def _build_patched_launch_substitutions():
     mod.FindPackageShare = _TrackedFindPackageShare
     mod.PathJoinSubstitution = _TrackedPathJoinSubstitution
     mod.LaunchConfiguration = _LaunchConfiguration
-    mod.EnvironmentVariable = lambda name, **kw: os.environ.get(name, "")
+    mod.EnvironmentVariable = lambda name, **kw: _env.get(name, kw.get("default_value", ""))
     mod.TextSubstitution = lambda text="", **kw: str(text)
     mod.PythonExpression = lambda expression=None, **kw: None
     mod.ThisLaunchFileDir = lambda: Path(__file__).parent
@@ -2129,7 +2189,8 @@ def _build_patched_launch_actions():
     mod.Shutdown = _TrackedShutdown
     mod.PushLaunchConfigurations = lambda *a, **kw: None
     mod.PopLaunchConfigurations = lambda *a, **kw: None
-    mod.SetEnvironmentVariable = lambda *a, **kw: None
+    mod.SetEnvironmentVariable = _TrackedSetEnvironmentVariable
+    mod.UnsetEnvironmentVariable = _TrackedUnsetEnvironmentVariable
     mod.ExecuteProcess = _TrackedExecutable
     mod.ExecuteLocal = lambda *a, **kw: None
     mod.OnProcessExit = _TrackedOnProcessExit
@@ -2426,6 +2487,10 @@ def main():
     # before falling back to AMENT_PREFIX_PATH or hardcoded paths.
     global _package_shares, _namespace_stack, _apply_opaque_file_access
     _namespace_stack = []
+    _env.clear()
+    _env.update(os.environ)
+    _env_baseline.clear()
+    _env_baseline.update(os.environ)
     if len(sys.argv) > 3:
         try:
             _package_shares = json.loads(sys.argv[3])
@@ -2533,6 +2598,14 @@ def main():
         _walk_actions(entities, ctx)
     except _PackageNotFetchedError:
         pass  # Absorbed; package already in _packages_to_fetch
+
+    # Net-zero check: error on env vars that leaked from file scope.
+    for k, v in _env.items():
+        if _env_baseline.get(k) != v:
+            _error(f"env var '{k}' was set to '{v}' but not restored (leaked from file scope)")
+    for k in _env_baseline:
+        if k not in _env:
+            _error(f"env var '{k}' was unset but not restored (leaked from file scope)")
 
     if _packages_to_fetch:
         _tracked["packages_to_fetch"] = sorted(_packages_to_fetch)

--- a/python/launch_plus/py_resolver.py
+++ b/python/launch_plus/py_resolver.py
@@ -1096,6 +1096,7 @@ class _TrackedGroupAction:
     def __init__(self, actions=None, **kwargs):
         self._actions = list(actions or [])
         self._scoped = kwargs.get("scoped", True)
+        self._condition = kwargs.get("condition")
 
 class _TrackedSetEnvironmentVariable:
     """Tracks SetEnvironmentVariable: mutates _env in _walk_action."""
@@ -1933,7 +1934,10 @@ def _walk_action(action, context, depth):
             try:
                 if not action._condition.evaluate(context):
                     return
-            except Exception:
+            except _PackageNotFetchedError:
+                raise
+            except Exception as e:
+                _warn(f"SetEnvironmentVariable condition evaluation failed: {e}")
                 return
         name = _resolve_substitution(action._name, context) or str(action._name)
         value = _resolve_substitution(action._value, context) or ""
@@ -1946,7 +1950,10 @@ def _walk_action(action, context, depth):
             try:
                 if not action._condition.evaluate(context):
                     return
-            except Exception:
+            except _PackageNotFetchedError:
+                raise
+            except Exception as e:
+                _warn(f"UnsetEnvironmentVariable condition evaluation failed: {e}")
                 return
         name = _resolve_substitution(action._name, context) or str(action._name)
         if name in os.environ:
@@ -1966,6 +1973,15 @@ def _walk_action(action, context, depth):
 
     # GroupAction: walk child actions; scoped groups save/restore env + namespace
     if isinstance(action, _TrackedGroupAction):
+        if action._condition is not None and context is not None:
+            try:
+                if not action._condition.evaluate(context):
+                    return
+            except _PackageNotFetchedError:
+                raise
+            except Exception as e:
+                _warn(f"GroupAction condition evaluation failed: {e}")
+                return
         depth_before = len(_namespace_stack)
         saved_env = dict(_env) if action._scoped else None
         _walk_actions(action._actions, context, depth + 1)

--- a/python/launch_plus/py_resolver.py
+++ b/python/launch_plus/py_resolver.py
@@ -242,12 +242,11 @@ _declared_arg_names: set = set()
 # Each entry is a resolved string.  Managed by _walk_action; reset in main().
 _namespace_stack: list = []
 
-# Full environment variable map, initialized from os.environ in main().
-# Mutated by SetEnvironmentVariable / UnsetEnvironmentVariable.
+# Environment variable overrides.  Starts empty; mutated by
+# SetEnvironmentVariable / UnsetEnvironmentVariable.  EnvironmentVariable
+# substitution checks this first, then falls back to os.environ.
 # Scoped groups clone/restore this.
 _env: dict = {}
-# Frozen baseline snapshot for computing per-node env diffs.
-_env_baseline: dict = {}
 
 def _is_substitution(value):
     """Return True if *value* is a launch substitution (not yet resolved to a string).
@@ -1452,9 +1451,9 @@ def _make_launch_context(args_dict):
 
 # ─── Node detail resolution helpers ──────────────────────────────────────────
 
-def _compute_env_diff():
-    """Return env vars that differ from the process baseline."""
-    return {k: v for k, v in _env.items() if _env_baseline.get(k) != v}
+def _env_overrides():
+    """Return a copy of the current env overrides for per-node output."""
+    return dict(_env)
 
 
 def _resolve_node_details(node, context):
@@ -1505,7 +1504,7 @@ def _resolve_node_details(node, context):
     entry["remappings"] = remaps
 
     # Env vars: start with inherited env diff, then node-local overrides
-    env = _compute_env_diff()
+    env = _env_overrides()
     raw_env = node._raw_env
     if isinstance(raw_env, dict):
         for k, v in raw_env.items():
@@ -1950,10 +1949,19 @@ def _walk_action(action, context, depth):
             except Exception:
                 return
         name = _resolve_substitution(action._name, context) or str(action._name)
-        if name not in _env:
-            _error(f"unset_env: environment variable '{name}' is not set")
-        else:
+        if name in os.environ:
+            # In process env (cases 2 & 3) — can't unset baseline.
+            _error(
+                f"unset_env: '{name}' exists in the process env and cannot be unset. "
+                f"Use SetEnvironmentVariable(name=\"{name}\", value=\"\") "
+                "or a scoped group instead"
+            )
+        elif name in _env:
+            # Case 1: override-only, no baseline to expose — safe to remove.
             del _env[name]
+        else:
+            # Case 4: not set anywhere.
+            _error(f"unset_env: environment variable '{name}' is not set")
         return
 
     # GroupAction: walk child actions; scoped groups save/restore env + namespace
@@ -2168,7 +2176,7 @@ def _build_patched_launch_substitutions():
     mod.FindPackageShare = _TrackedFindPackageShare
     mod.PathJoinSubstitution = _TrackedPathJoinSubstitution
     mod.LaunchConfiguration = _LaunchConfiguration
-    mod.EnvironmentVariable = lambda name, **kw: _env.get(name, kw.get("default_value", ""))
+    mod.EnvironmentVariable = lambda name, **kw: _env.get(name, os.environ.get(name, kw.get("default_value", "")))
     mod.TextSubstitution = lambda text="", **kw: str(text)
     mod.PythonExpression = lambda expression=None, **kw: None
     mod.ThisLaunchFileDir = lambda: Path(__file__).parent
@@ -2488,9 +2496,6 @@ def main():
     global _package_shares, _namespace_stack, _apply_opaque_file_access
     _namespace_stack = []
     _env.clear()
-    _env.update(os.environ)
-    _env_baseline.clear()
-    _env_baseline.update(os.environ)
     if len(sys.argv) > 3:
         try:
             _package_shares = json.loads(sys.argv[3])
@@ -2599,13 +2604,9 @@ def main():
     except _PackageNotFetchedError:
         pass  # Absorbed; package already in _packages_to_fetch
 
-    # Net-zero check: error on env vars that leaked from file scope.
+    # Net-zero check: any remaining overrides are leaked env mutations.
     for k, v in _env.items():
-        if _env_baseline.get(k) != v:
-            _error(f"env var '{k}' was set to '{v}' but not restored (leaked from file scope)")
-    for k in _env_baseline:
-        if k not in _env:
-            _error(f"env var '{k}' was unset but not restored (leaked from file scope)")
+        _error(f"env var '{k}' was set to '{v}' but not restored (leaked from file scope)")
 
     if _packages_to_fetch:
         _tracked["packages_to_fetch"] = sorted(_packages_to_fetch)

--- a/python/launch_plus/py_resolver.py
+++ b/python/launch_plus/py_resolver.py
@@ -1939,9 +1939,12 @@ def _walk_action(action, context, depth):
             except Exception as e:
                 _warn(f"SetEnvironmentVariable condition evaluation failed: {e}")
                 return
+        if action._name is None:
+            _error("SetEnvironmentVariable: name is None — skipping")
+            return
         name = _resolve_substitution(action._name, context) or str(action._name)
-        if not name or name == "None":
-            _error("SetEnvironmentVariable: resolved name is empty or None — skipping")
+        if not name:
+            _error("SetEnvironmentVariable: resolved name is empty — skipping")
             return
         value = _resolve_substitution(action._value, context) or ""
         _env[name] = value
@@ -1958,9 +1961,12 @@ def _walk_action(action, context, depth):
             except Exception as e:
                 _warn(f"UnsetEnvironmentVariable condition evaluation failed: {e}")
                 return
+        if action._name is None:
+            _error("UnsetEnvironmentVariable: name is None — skipping")
+            return
         name = _resolve_substitution(action._name, context) or str(action._name)
-        if not name or name == "None":
-            _error("UnsetEnvironmentVariable: resolved name is empty or None — skipping")
+        if not name:
+            _error("UnsetEnvironmentVariable: resolved name is empty — skipping")
             return
         if name in os.environ:
             # In process env (cases 2 & 3) — can't unset baseline.

--- a/python/launch_plus/py_resolver.py
+++ b/python/launch_plus/py_resolver.py
@@ -341,16 +341,15 @@ def _track_param_file(path):
 
 
 def _to_str(value, context=None):
-    """Coerce a str, substitution object, or None to str.
+    """Coerce a str, substitution object, or None to ``str | None``.
 
     - ``None`` → ``None`` (caller decides how to handle missing values)
     - ``str``  → returned as-is
-    - object with ``.perform()`` → call it; fall back to ``str(value)`` on
-      failure or ``None`` result
+    - object with ``.perform()`` → call it; ``None`` result stays ``None``,
+      non-``None`` result is coerced to ``str``; on exception → ``str(value)``
     - anything else → ``str(value)``
 
-    This is the single choke-point for "expecting a string but might receive a
-    ROS 2 substitution object" conversions.
+    Every non-``None`` return value is guaranteed to be ``str``.
     """
     if value is None:
         return None
@@ -359,7 +358,7 @@ def _to_str(value, context=None):
     if hasattr(value, "perform"):
         try:
             res = value.perform(context)
-            return res if res is not None else str(value)
+            return str(res) if res is not None else None
         except Exception:
             return str(value)
     return str(value)
@@ -2229,10 +2228,10 @@ def _build_patched_launch_substitutions():
             self._name = name
             self._default = kw.get("default_value", "")
         def perform(self, context=None):
-            # Resolve name to string (may be a substitution object).
+            # Resolve name and default to concrete strings.
             name = _to_str(self._name, context) or ""
-            default = _to_str(self._default, context) if hasattr(self._default, "perform") else self._default
-            return _env.get(name, os.environ.get(name, default if default is not None else ""))
+            default = _to_str(self._default, context) or ""
+            return _env.get(name, os.environ.get(name, default))
         def __str__(self):
             # Avoid calling perform() without context — return the raw name.
             return str(self._name) if self._name is not None else ""

--- a/python/launch_plus/py_resolver.py
+++ b/python/launch_plus/py_resolver.py
@@ -1942,11 +1942,13 @@ def _walk_action(action, context, depth):
         if action._name is None:
             _error("SetEnvironmentVariable: name is None — skipping")
             return
-        name = _resolve_substitution(action._name, context) or str(action._name)
+        resolved = _resolve_substitution(action._name, context)
+        name = resolved if resolved is not None else str(action._name)
         if not name:
             _error("SetEnvironmentVariable: resolved name is empty — skipping")
             return
-        value = _resolve_substitution(action._value, context) or ""
+        resolved_val = _resolve_substitution(action._value, context)
+        value = resolved_val if resolved_val is not None else ""
         _env[name] = value
         return
 
@@ -1964,7 +1966,8 @@ def _walk_action(action, context, depth):
         if action._name is None:
             _error("UnsetEnvironmentVariable: name is None — skipping")
             return
-        name = _resolve_substitution(action._name, context) or str(action._name)
+        resolved = _resolve_substitution(action._name, context)
+        name = resolved if resolved is not None else str(action._name)
         if not name:
             _error("UnsetEnvironmentVariable: resolved name is empty — skipping")
             return
@@ -2214,7 +2217,8 @@ def _build_patched_launch_substitutions():
             name = self._name
             if hasattr(name, "perform"):
                 try:
-                    name = name.perform(context) or str(self._name)
+                    res = name.perform(context)
+                    name = res if res is not None else str(self._name)
                 except Exception:
                     name = str(self._name)
             name = str(name) if name is not None else ""

--- a/python/launch_plus/py_resolver.py
+++ b/python/launch_plus/py_resolver.py
@@ -359,6 +359,8 @@ def _to_str(value, context=None):
         try:
             res = value.perform(context)
             return str(res) if res is not None else None
+        except _PackageNotFetchedError:
+            raise
         except Exception:
             return str(value)
     return str(value)
@@ -2222,16 +2224,25 @@ def _build_patched_launch_substitutions():
     mod.FindPackageShare = _TrackedFindPackageShare
     mod.PathJoinSubstitution = _TrackedPathJoinSubstitution
     mod.LaunchConfiguration = _LaunchConfiguration
+    _SENTINEL = object()
     class _DeferredEnvironmentVariable:
         """Deferred substitution: reads _env at perform() time, not construction."""
         def __init__(self, name, **kw):
             self._name = name
-            self._default = kw.get("default_value", "")
+            self._default = kw.get("default_value", _SENTINEL)
         def perform(self, context=None):
-            # Resolve name and default to concrete strings.
+            # Resolve name to a concrete string via _to_str.
             name = _to_str(self._name, context) or ""
-            default = _to_str(self._default, context) or ""
-            return _env.get(name, os.environ.get(name, default))
+            # Look up in override env, then process env.
+            if name in _env:
+                return _env[name]
+            if name in os.environ:
+                return os.environ[name]
+            # No match — use default if provided, otherwise error.
+            if self._default is not _SENTINEL:
+                return _to_str(self._default, context) or ""
+            _error(f"EnvironmentVariable: '{name}' is not set and no default was provided")
+            return ""
         def __str__(self):
             # Avoid calling perform() without context — return the raw name.
             return str(self._name) if self._name is not None else ""

--- a/python/launch_plus/py_resolver.py
+++ b/python/launch_plus/py_resolver.py
@@ -1959,6 +1959,9 @@ def _walk_action(action, context, depth):
                 _warn(f"UnsetEnvironmentVariable condition evaluation failed: {e}")
                 return
         name = _resolve_substitution(action._name, context) or str(action._name)
+        if not name or name == "None":
+            _error("UnsetEnvironmentVariable: resolved name is empty or None — skipping")
+            return
         if name in os.environ:
             # In process env (cases 2 & 3) — can't unset baseline.
             _error(
@@ -2201,9 +2204,18 @@ def _build_patched_launch_substitutions():
             self._name = name
             self._default = kw.get("default_value", "")
         def perform(self, context=None):
-            return _env.get(self._name, os.environ.get(self._name, self._default))
+            # Resolve name to string (may be a substitution object).
+            name = self._name
+            if hasattr(name, "perform"):
+                try:
+                    name = name.perform(context) or str(self._name)
+                except Exception:
+                    name = str(self._name)
+            name = str(name) if name is not None else ""
+            return _env.get(name, os.environ.get(name, self._default))
         def __str__(self):
-            return self.perform()
+            # Avoid calling perform() without context — return the raw name.
+            return str(self._name) if self._name is not None else ""
     mod.EnvironmentVariable = _DeferredEnvironmentVariable
     mod.TextSubstitution = lambda text="", **kw: str(text)
     mod.PythonExpression = lambda expression=None, **kw: None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,7 +43,6 @@ def _reset_py_resolver_state():
     R._apply_opaque_file_access = False
     R._preview_mode = True
     R._env.clear()
-    R._env_baseline.clear()
 
     yield
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,6 +42,8 @@ def _reset_py_resolver_state():
     R._lockfile_packages.clear()
     R._apply_opaque_file_access = False
     R._preview_mode = True
+    R._env.clear()
+    R._env_baseline.clear()
 
     yield
 

--- a/tests/test_py_resolver.py
+++ b/tests/test_py_resolver.py
@@ -482,3 +482,108 @@ class TestInlinePythonInclude:
 
             # No new include deps
             assert len(R._tracked["include_deps"]) == deps_before
+
+
+# ─── Environment Variable Stack ──────────────────────────────────────────────
+
+class TestEnvStack:
+    """Tests for SetEnvironmentVariable / UnsetEnvironmentVariable tracking,
+    env inheritance to nodes, and group scoping."""
+
+    def test_set_env_inherits_to_node(self):
+        """SetEnvironmentVariable then Node → node's env includes the var."""
+        ctx = _make_context()
+        set_env = R._TrackedSetEnvironmentVariable(name="FOO", value="bar")
+        node = R._TrackedNode(package="p", executable="e", name="n")
+        R._walk_action(set_env, ctx, 0)
+        R._walk_action(node, ctx, 0)
+        entry = R._tracked["nodes"][node._idx]
+        assert entry["env"]["FOO"] == "bar"
+
+    def test_unset_env_removes_from_node(self):
+        """SetEnv then UnsetEnv → node's env does NOT include the var."""
+        ctx = _make_context()
+        R._walk_action(R._TrackedSetEnvironmentVariable(name="FOO", value="bar"), ctx, 0)
+        R._walk_action(R._TrackedUnsetEnvironmentVariable(name="FOO"), ctx, 0)
+        node = R._TrackedNode(package="p", executable="e", name="n")
+        R._walk_action(node, ctx, 0)
+        entry = R._tracked["nodes"][node._idx]
+        assert "FOO" not in entry["env"]
+
+    def test_unset_env_nonexistent_errors(self):
+        """UnsetEnvironmentVariable for a var never set → error."""
+        ctx = _make_context()
+        R._walk_action(R._TrackedUnsetEnvironmentVariable(name="NONEXISTENT"), ctx, 0)
+        assert any("NONEXISTENT" in e for e in R._tracked["errors"])
+
+    def test_group_scoped_env_does_not_leak(self):
+        """GroupAction(scoped=True) → env mutations don't leak to siblings."""
+        ctx = _make_context()
+        group = R._TrackedGroupAction(
+            actions=[R._TrackedSetEnvironmentVariable(name="SCOPED_VAR", value="val")],
+            scoped=True,
+        )
+        R._walk_action(group, ctx, 0)
+        node = R._TrackedNode(package="p", executable="e", name="n")
+        R._walk_action(node, ctx, 0)
+        entry = R._tracked["nodes"][node._idx]
+        assert "SCOPED_VAR" not in entry["env"]
+
+    def test_group_unscoped_env_leaks(self):
+        """GroupAction(scoped=False) → env mutations leak to siblings."""
+        ctx = _make_context()
+        group = R._TrackedGroupAction(
+            actions=[R._TrackedSetEnvironmentVariable(name="LEAKED_VAR", value="val")],
+            scoped=False,
+        )
+        R._walk_action(group, ctx, 0)
+        node = R._TrackedNode(package="p", executable="e", name="n")
+        R._walk_action(node, ctx, 0)
+        entry = R._tracked["nodes"][node._idx]
+        assert entry["env"]["LEAKED_VAR"] == "val"
+
+    def test_node_local_env_overrides_inherited(self):
+        """Node-local env overrides inherited env for the same key."""
+        ctx = _make_context()
+        R._walk_action(R._TrackedSetEnvironmentVariable(name="FOO", value="inherited"), ctx, 0)
+        node = R._TrackedNode(
+            package="p", executable="e", name="n",
+            env=[("FOO", "local")],
+        )
+        R._walk_action(node, ctx, 0)
+        entry = R._tracked["nodes"][node._idx]
+        assert entry["env"]["FOO"] == "local"
+
+    def test_inline_include_env_rollback(self):
+        """Env set by inline-included child does NOT leak to parent."""
+        import tempfile, textwrap
+        with tempfile.TemporaryDirectory() as d:
+            child_path = os.path.join(d, "child.launch.py")
+            with open(child_path, "w") as f:
+                f.write(textwrap.dedent("""\
+                    from launch import LaunchDescription
+                    from launch.actions import SetEnvironmentVariable
+                    def generate_launch_description():
+                        return LaunchDescription([
+                            SetEnvironmentVariable(name="CHILD_VAR", value="child_val"),
+                        ])
+                """))
+            ctx = _make_context()
+            R._inline_resolve_python_launch(child_path, ctx, {}, depth=1)
+            assert "CHILD_VAR" not in R._env
+
+    def test_env_diff_excludes_baseline(self):
+        """Only env vars that differ from baseline appear in the diff."""
+        R._env_baseline["EXISTING"] = "original"
+        R._env["EXISTING"] = "original"
+        R._env["NEW_VAR"] = "new_val"
+        diff = R._compute_env_diff()
+        assert "EXISTING" not in diff
+        assert diff["NEW_VAR"] == "new_val"
+
+    def test_env_diff_includes_changed_baseline(self):
+        """An env var changed from its baseline value appears in the diff."""
+        R._env_baseline["CHANGED"] = "old"
+        R._env["CHANGED"] = "new"
+        diff = R._compute_env_diff()
+        assert diff["CHANGED"] == "new"

--- a/tests/test_py_resolver.py
+++ b/tests/test_py_resolver.py
@@ -500,21 +500,22 @@ class TestEnvStack:
         entry = R._tracked["nodes"][node._idx]
         assert entry["env"]["FOO"] == "bar"
 
-    def test_unset_env_removes_from_node(self):
-        """SetEnv then UnsetEnv → node's env does NOT include the var."""
-        ctx = _make_context()
-        R._walk_action(R._TrackedSetEnvironmentVariable(name="FOO", value="bar"), ctx, 0)
-        R._walk_action(R._TrackedUnsetEnvironmentVariable(name="FOO"), ctx, 0)
-        node = R._TrackedNode(package="p", executable="e", name="n")
-        R._walk_action(node, ctx, 0)
-        entry = R._tracked["nodes"][node._idx]
-        assert "FOO" not in entry["env"]
-
     def test_unset_env_nonexistent_errors(self):
-        """UnsetEnvironmentVariable for a var never set → error."""
+        """UnsetEnvironmentVariable on a var that doesn't exist → 'not set' error."""
         ctx = _make_context()
-        R._walk_action(R._TrackedUnsetEnvironmentVariable(name="NONEXISTENT"), ctx, 0)
-        assert any("NONEXISTENT" in e for e in R._tracked["errors"])
+        R._walk_action(R._TrackedUnsetEnvironmentVariable(name="NONEXISTENT_VAR_12345"), ctx, 0)
+        errors = R._tracked.get("errors", [])
+        assert any("NONEXISTENT_VAR_12345" in e and "not set" in e for e in errors)
+
+    def test_unset_env_override_only_accepted(self):
+        """UnsetEnv on an override-only var (not in process env) → accepted."""
+        ctx = _make_context()
+        R._walk_action(R._TrackedSetEnvironmentVariable(name="OVERRIDE_ONLY_12345", value="val"), ctx, 0)
+        assert "OVERRIDE_ONLY_12345" in R._env
+        R._walk_action(R._TrackedUnsetEnvironmentVariable(name="OVERRIDE_ONLY_12345"), ctx, 0)
+        assert "OVERRIDE_ONLY_12345" not in R._env
+        errors = R._tracked.get("errors", [])
+        assert not any("OVERRIDE_ONLY_12345" in e for e in errors)
 
     def test_group_scoped_env_does_not_leak(self):
         """GroupAction(scoped=True) → env mutations don't leak to siblings."""
@@ -572,18 +573,37 @@ class TestEnvStack:
             R._inline_resolve_python_launch(child_path, ctx, {}, depth=1)
             assert "CHILD_VAR" not in R._env
 
-    def test_env_diff_excludes_baseline(self):
-        """Only env vars that differ from baseline appear in the diff."""
-        R._env_baseline["EXISTING"] = "original"
-        R._env["EXISTING"] = "original"
+    def test_env_overrides_returns_only_overrides(self):
+        """_env_overrides() returns only explicitly set vars, not process env."""
         R._env["NEW_VAR"] = "new_val"
-        diff = R._compute_env_diff()
-        assert "EXISTING" not in diff
-        assert diff["NEW_VAR"] == "new_val"
+        overrides = R._env_overrides()
+        assert overrides["NEW_VAR"] == "new_val"
+        # Process env vars should NOT appear in overrides
+        assert "PATH" not in overrides or "PATH" in R._env
 
-    def test_env_diff_includes_changed_baseline(self):
-        """An env var changed from its baseline value appears in the diff."""
-        R._env_baseline["CHANGED"] = "old"
-        R._env["CHANGED"] = "new"
-        diff = R._compute_env_diff()
-        assert diff["CHANGED"] == "new"
+    def test_env_overrides_empty_when_no_overrides(self):
+        """Empty overrides when nothing has been set."""
+        assert R._env_overrides() == {}
+
+    def test_net_zero_error_includes_value(self):
+        """Net-zero leak error includes the override value (safe, user-set)."""
+        R._env["MY_KEY"] = "my_value"
+        # Simulate the net-zero check inline (same logic as main())
+        errors = []
+        for k, v in R._env.items():
+            errors.append(f"env var '{k}' was set to '{v}' but not restored (leaked from file scope)")
+        err = [e for e in errors if "MY_KEY" in e]
+        assert len(err) == 1
+        assert "my_value" in err[0]
+
+    def test_process_env_never_exposed_in_node(self):
+        """Node env should only contain overrides, never process env vars."""
+        ctx = _make_context()
+        R._walk_action(R._TrackedSetEnvironmentVariable(name="MY_OVERRIDE", value="val"), ctx, 0)
+        node = R._TrackedNode(package="p", executable="e", name="n")
+        R._walk_action(node, ctx, 0)
+        entry = R._tracked["nodes"][node._idx]
+        # Only the explicit override should appear.
+        assert entry["env"] == {"MY_OVERRIDE": "val"}
+        # Process env vars like PATH must never leak.
+        assert "PATH" not in entry["env"]

--- a/tests/test_py_resolver.py
+++ b/tests/test_py_resolver.py
@@ -578,8 +578,10 @@ class TestEnvStack:
         R._env["NEW_VAR"] = "new_val"
         overrides = R._env_overrides()
         assert overrides["NEW_VAR"] == "new_val"
-        # Process env vars should NOT appear in overrides
-        assert "PATH" not in overrides or "PATH" in R._env
+        # Process env vars must NOT appear in overrides.
+        import os
+        assert "PATH" in os.environ, "PATH should exist in process env for this test"
+        assert "PATH" not in overrides
 
     def test_env_overrides_empty_when_no_overrides(self):
         """Empty overrides when nothing has been set."""

--- a/tests/test_py_resolver.py
+++ b/tests/test_py_resolver.py
@@ -502,20 +502,26 @@ class TestEnvStack:
 
     def test_unset_env_nonexistent_errors(self):
         """UnsetEnvironmentVariable on a var that doesn't exist → 'not set' error."""
+        import uuid
+        name = f"NONEXISTENT_VAR_{uuid.uuid4().hex[:8]}"
+        assert name not in os.environ, f"precondition: {name} must not be in process env"
         ctx = _make_context()
-        R._walk_action(R._TrackedUnsetEnvironmentVariable(name="NONEXISTENT_VAR_12345"), ctx, 0)
+        R._walk_action(R._TrackedUnsetEnvironmentVariable(name=name), ctx, 0)
         errors = R._tracked.get("errors", [])
-        assert any("NONEXISTENT_VAR_12345" in e and "not set" in e for e in errors)
+        assert any(name in e and "not set" in e for e in errors)
 
     def test_unset_env_override_only_accepted(self):
         """UnsetEnv on an override-only var (not in process env) → accepted."""
+        import uuid
+        name = f"OVERRIDE_ONLY_{uuid.uuid4().hex[:8]}"
+        assert name not in os.environ, f"precondition: {name} must not be in process env"
         ctx = _make_context()
-        R._walk_action(R._TrackedSetEnvironmentVariable(name="OVERRIDE_ONLY_12345", value="val"), ctx, 0)
-        assert "OVERRIDE_ONLY_12345" in R._env
-        R._walk_action(R._TrackedUnsetEnvironmentVariable(name="OVERRIDE_ONLY_12345"), ctx, 0)
-        assert "OVERRIDE_ONLY_12345" not in R._env
+        R._walk_action(R._TrackedSetEnvironmentVariable(name=name, value="val"), ctx, 0)
+        assert name in R._env
+        R._walk_action(R._TrackedUnsetEnvironmentVariable(name=name), ctx, 0)
+        assert name not in R._env
         errors = R._tracked.get("errors", [])
-        assert not any("OVERRIDE_ONLY_12345" in e for e in errors)
+        assert not any(name in e for e in errors)
 
     def test_group_scoped_env_does_not_leak(self):
         """GroupAction(scoped=True) → env mutations don't leak to siblings."""


### PR DESCRIPTION
## Summary

Adds environment variable stack tracking and per-node `<env>` output to both the Python and Rust/XML resolvers (Issue #27).

### Override-only model
- `ctx.env` / `_env` starts **empty** — only explicit `<set_env>` / `SetEnvironmentVariable` overrides are tracked
- `$(env X)` checks overrides first, falls back to the real process environment
- Process env vars are **never** copied into the resolver state or exposed in output
- Per-node `<env>` children are exactly the override map — no baseline diff needed

### `<unset_env>` semantics
- Override-only var (not in process env): accepted — safely removes the override
- Process env var: **error** — can't unset baseline; use `<set_env value=""/>` or scoped group
- Nonexistent var: **error** — variable is not set

### Scoping
- `<group scoped="true">` / `GroupAction(scoped=True)`: clones/restores env overrides
- `<group scoped="false">` / unscoped: mutations leak (matching ROS 2 behavior)

### Net-zero check
- Any remaining env overrides at file scope boundary = leaked mutation error
- Override values are included in error messages (safe — user-set, not process secrets)
- Included files also get a net-zero check against the parent snapshot

### Other
- `LoadComposableNode` env is always empty (enforced, not a process)
- Warning emitted when env overrides are active at `<load_composable_node>` (overrides won't apply)
- `env_overrides()` / `_env_overrides()` extracted as single helper for all node types
- `render_container_node` now emits `<env>` children

## Test plan
- [x] 204 Rust tests pass (`cargo test --workspace`)
- [x] 58 Python tests pass (`pytest tests/`)
- [x] `test_process_env_never_exposed_in_node` verifies process env isolation
- [x] `test_set_env_inherits_to_node`, `test_scoped_group_env_isolation`, `test_unset_env_*` cover all unset cases
- [x] `test_net_zero_error_on_leaked_env`, `test_net_zero_no_error_when_scoped` verify leak detection
- [x] `test_load_composable_node_env_is_empty` enforces empty env + warns on active overrides
- [x] Autoware example produces `<env name="LD_PRELOAD" .../>` on `pointcloud_container` with `ENABLE_AGNOCAST=1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)