### PR TITLE
feat: replace colcon with native cmake/setuptools build backend

### DIFF
--- a/.agents/context.md
+++ b/.agents/context.md
@@ -521,7 +521,7 @@ launch-plus build autoware_launch autoware.launch.xml \
 
 ### Mode: test
 
-Same pipeline as `build`, but `DependencyMode::All` is used so `test_depend` packages are
+Same pipeline as `build`, but `DependencyMode::BuildAndTest` is used so `test_depend` packages are
 included in the build set.  These packages are never visited during launch-graph traversal
 and are fetched on demand by `fetch_plan_packages`.
 

--- a/.agents/context.md
+++ b/.agents/context.md
@@ -46,7 +46,7 @@ Key insight: **A launch file IS a build target** that declares its dependencies 
 │  │   ├── conditional  - if/unless evaluation                        │
 │  │   └── flattener    - inline all includes                         │
 │  ├── fetcher      - partial git clone (sparse-checkout)             │
-│  ├── builder      - selective colcon build (subprocess)             │
+│  ├── builder      - native cmake/setuptools build backend          │
 │  └── executor     - process spawning & lifecycle (OUR implementation)│
 ├─────────────────────────────────────────────────────────────────────┤
 │  Python Bindings (PyO3)                                             │
@@ -97,7 +97,7 @@ and direct consumption of resolved launch structures.
      - lockfile.packages[pkg].repo → lockfile.repos[repo]
      - sparse-checkout only needed directories
         ↓
-   [builder] colcon build --packages-select <needed>  (skip if mode=resolve)
+   [builder] native cmake/setuptools build (skip if mode=resolve)
         ↓
    [launcher] ros2 launch <package> <launch_file>     (only if mode=run)
 ```
@@ -396,7 +396,7 @@ launch-plus/
 │   │   │   ├── indexer.rs
 │   │   │   ├── resolver.rs
 │   │   │   ├── fetcher.rs
-│   │   │   ├── builder.rs
+│   │   │   ├── builder/          # native build backend
 │   │   │   └── launcher.rs
 │   │   └── Cargo.toml
 │   └── launch-plus-cli/          # Rust CLI (optional standalone)
@@ -428,7 +428,7 @@ launch-plus/
 - **PyO3/Maturin**: Rust → Python bindings
 - **Python**: Thin CLI layer, ros2 verb integration
 - **Git sparse-checkout**: Partial cloning
-- **colcon**: Build orchestration (called as subprocess)
+- **cmake/make**: Direct build invocation for ament_cmake packages
 
 ## ROS 2 Integration
 
@@ -503,12 +503,10 @@ Fetches and builds only the packages required to run the launch target:
 3. **Fetch** any plan packages not yet on disk (e.g. pure build deps not reached by the
    launch graph traversal)
 4. **Verify** on-disk `package.xml` dependencies match the lockfile for every build package
-5. **Build**: `colcon build --base-paths <src> --build-base <build> --install-base <install>
-   [flagfile tokens] --packages-select <packages>`
+5. **Build**: native cmake/setuptools backend builds each package in topological order
+   using a greedy parallel scheduler
 
-Extra colcon arguments (e.g. `--symlink-install`, `--cmake-args`, `--executor parallel`,
-`--allow-overriding`) are supplied via a **flagfile** (`--colcon-flagfile <path>`):
-one shell token per line, `#` comments allowed.  See `example/colcon-flags.example.txt`.
+Build options are passed directly as CLI flags:
 
 ```bash
 launch-plus build autoware_launch autoware.launch.xml \
@@ -516,8 +514,12 @@ launch-plus build autoware_launch autoware.launch.xml \
   --allow-global-arg-cascade --apply-launch-arg-defaults \
   --lockfile manifest.lock.repos --src src \
   --dirty \
-  --colcon-flagfile colcon-flags.txt
+  --symlink-install \
+  --cmake-args -DCMAKE_BUILD_TYPE=Release
 ```
+
+`BUILD_TESTING` is managed automatically (`OFF` for build, `ON` for test);
+manually passing `-DBUILD_TESTING=...` via `--cmake-args` is rejected with an error.
 
 ### Mode: test
 
@@ -525,8 +527,8 @@ Same pipeline as `build`, but `DependencyMode::BuildAndTest` is used so `test_de
 included in the build set.  These packages are never visited during launch-graph traversal
 and are fetched on demand by `fetch_plan_packages`.
 
-The `test` command currently builds the full test dependency set; running `colcon test` is
-a planned future step (M6+).
+The `test` command currently builds the full test dependency set with `BUILD_TESTING=ON`;
+running `ctest`/`pytest` is a planned future step.
 
 ```bash
 launch-plus test autoware_launch autoware.launch.xml \
@@ -534,7 +536,7 @@ launch-plus test autoware_launch autoware.launch.xml \
   --allow-global-arg-cascade --apply-launch-arg-defaults \
   --lockfile manifest.lock.repos --src src \
   --dirty \
-  --colcon-flagfile colcon-flags.txt
+  --symlink-install
 ```
 
 ### Mode: run (default)

--- a/.agents/milestones.md
+++ b/.agents/milestones.md
@@ -64,10 +64,13 @@ XML and Python launch files.  Manages the fetch-on-demand retry loop for
 expansion into a flat `ParsedLaunchFile` intermediate representation.
 
 ### Builder
-Selective colcon build driven by resolved launch dependencies.
+Native build backend driven by resolved launch dependencies.
 `plan_build_from_packages` computes the transitive dependency closure from
 on-disk `package.xml` files, fetches any missing packages, and
-`execute_build` drives `colcon build --packages-select <exact list>`.
+`execute_build` runs a greedy parallel scheduler that invokes cmake/make
+(ament_cmake) or setup.py/pip (ament_python) directly — no colcon required.
+`BUILD_TESTING` is automatically set to `OFF` (for `build`) or `ON` (for `test`);
+manual `-DBUILD_TESTING=...` via `--cmake-args` is rejected with an error.
 
 ### CLI
 Full command set: `index`, `update`, `fetch`, `clean`, `resolve`, `check`,
@@ -78,10 +81,6 @@ Full command set: `index`, `update`, `fetch`, `clean`, `resolve`, `check`,
 ### Executor
 Process spawning, lifecycle management, and signal handling for running
 resolved launch graphs directly.
-
-### Direct CMake Builds
-Replace colcon with direct CMake/ament_cmake invocations for finer control
-over the build process.
 
 ### CI Integration
 GitHub Actions workflow for automated testing and release.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,7 +61,7 @@ cargo fmt --all -- --check
 ### Integration test (Autoware)
 
 The Autoware example includes a self-contained integration test. Requires a
-sourced ROS 2 environment and `colcon`.
+sourced ROS 2 environment, `cmake`, and `make`.
 
 ```bash
 cd example/autoware

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ The pre-generated output files are included for reference:
 - [`example/autoware/resolved.launch.xml`](example/autoware/resolved.launch.xml)
 - [`example/autoware/resolver.log`](example/autoware/resolver.log)
 
-To build the resolved packages (requires a sourced ROS 2 environment and `colcon`):
+To build the resolved packages (requires a sourced ROS 2 environment, `cmake`, and `make`):
 
 ```bash
 cargo run --bin launch-plus -- build -d autoware_launch autoware.launch.xml \
@@ -133,7 +133,7 @@ cargo run --bin launch-plus -- build -d autoware_launch autoware.launch.xml \
   --apply-opaque-file-access \
   --allow-including-unportable-path \
   --rosdep \
-  --colcon-flagfile colcon-flags.txt
+  --symlink-install
 ```
 
 ### Use your own project
@@ -154,7 +154,7 @@ See the [Getting Started guide](docs/getting-started.md) for a full walkthrough.
 | `update` | Re-resolve refs and update lockfile SHAs |
 | `resolve` | Resolve and flatten a launch file to XML (no build) |
 | `check` | Like `resolve` but exits non-zero on warnings/errors |
-| `build` | Resolve, fetch dependencies, and run `colcon build` |
+| `build` | Resolve, fetch dependencies, and build with native cmake/setuptools backend |
 | `build-pkg` | Build package(s) by name with transitive dependency fetching |
 | `test` | Like `build` but includes `test_depend` packages |
 | `fetch` | Sparse-checkout specific packages from the lockfile |

--- a/crates/launch-plus-cli/src/main.rs
+++ b/crates/launch-plus-cli/src/main.rs
@@ -394,11 +394,11 @@ enum Commands {
         log_base: String,
 
         /// Extra arguments passed to cmake (e.g. -DCMAKE_BUILD_TYPE=Release)
-        #[arg(long, num_args = 1..)]
+        #[arg(long, num_args = 1.., allow_hyphen_values = true)]
         cmake_args: Vec<String>,
 
         /// Extra arguments passed to make
-        #[arg(long, num_args = 1..)]
+        #[arg(long, num_args = 1.., allow_hyphen_values = true)]
         make_args: Vec<String>,
 
         /// Use symlink install instead of copying files
@@ -472,11 +472,11 @@ enum Commands {
         log_base: String,
 
         /// Extra arguments passed to cmake
-        #[arg(long, num_args = 1..)]
+        #[arg(long, num_args = 1.., allow_hyphen_values = true)]
         cmake_args: Vec<String>,
 
         /// Extra arguments passed to make
-        #[arg(long, num_args = 1..)]
+        #[arg(long, num_args = 1.., allow_hyphen_values = true)]
         make_args: Vec<String>,
 
         /// Use symlink install instead of copying files
@@ -578,11 +578,11 @@ enum Commands {
         log_base: String,
 
         /// Extra arguments passed to cmake
-        #[arg(long, num_args = 1..)]
+        #[arg(long, num_args = 1.., allow_hyphen_values = true)]
         cmake_args: Vec<String>,
 
         /// Extra arguments passed to make
-        #[arg(long, num_args = 1..)]
+        #[arg(long, num_args = 1.., allow_hyphen_values = true)]
         make_args: Vec<String>,
 
         /// Use symlink install instead of copying files

--- a/crates/launch-plus-cli/src/main.rs
+++ b/crates/launch-plus-cli/src/main.rs
@@ -965,7 +965,7 @@ fn main() -> Result<()> {
             if let Some(n) = parallel_workers {
                 build_options.parallel_workers = n;
             }
-            execute_build(&plan, &build_options)?;
+            execute_build(&plan, &build_options, &parsed_lockfile)?;
         }
         Commands::Test {
             package,
@@ -1597,7 +1597,7 @@ fn run_build(
         }
     }
 
-    execute_build(&plan, &build_options).with_context(|| "build failed")?;
+    execute_build(&plan, &build_options, &lockfile).with_context(|| "build failed")?;
 
     Ok(())
 }

--- a/crates/launch-plus-cli/src/main.rs
+++ b/crates/launch-plus-cli/src/main.rs
@@ -320,7 +320,7 @@ enum Commands {
     /// Fetch and build packages for a launcher (target-focused, Bazel-like)
     ///
     /// Resolves the launch file, computes the transitive build-dependency closure
-    /// (build_depend + `<depend>`), and invokes colcon with the exact package list.
+    /// (build_depend + `<depend>`), and builds packages directly using cmake/setuptools.
     #[command(override_usage = "launch-plus build [OPTIONS] <PACKAGE> <LAUNCHER> [ARG]...")]
     Build {
         /// Package name
@@ -381,48 +381,51 @@ enum Commands {
         #[arg(long)]
         rosdep: bool,
 
-        /// Colcon build output directory
+        /// Build output directory
         #[arg(long, default_value = "build")]
         build_base: String,
 
-        /// Colcon install prefix
+        /// Install prefix
         #[arg(long, default_value = "install")]
         install_base: String,
 
-        /// Colcon log directory
+        /// Log directory
         #[arg(long, default_value = "log")]
         log_base: String,
 
-        /// Path to a colcon flagfile (one token per line, # comments allowed).
-        ///
-        /// The file contents are inserted verbatim into `colcon build` before
-        /// `--packages-select`.  This lets you pass any colcon flag without
-        /// requiring a dedicated launch-plus CLI option, e.g.:
-        ///
-        ///   --symlink-install
-        ///   --cmake-force-configure
-        ///   --cmake-args
-        ///   -DCMAKE_BUILD_TYPE=Release
-        ///   -DCMAKE_CXX_FLAGS=-w
-        ///   --parallel-workers
-        ///   8
-        #[arg(long, value_name = "FILE")]
-        colcon_flagfile: Option<String>,
+        /// Extra arguments passed to cmake (e.g. -DCMAKE_BUILD_TYPE=Release)
+        #[arg(long, num_args = 1..)]
+        cmake_args: Vec<String>,
 
-        /// Print the colcon command without running it
+        /// Extra arguments passed to make
+        #[arg(long, num_args = 1..)]
+        make_args: Vec<String>,
+
+        /// Use symlink install instead of copying files
+        #[arg(long)]
+        symlink_install: bool,
+
+        /// Maximum number of parallel build workers (default: available CPUs)
+        #[arg(long)]
+        parallel_workers: Option<usize>,
+
+        /// Continue building independent packages after a failure
+        #[arg(long)]
+        continue_on_error: bool,
+
+        /// Print the build commands without running them
         #[arg(long)]
         dry_run: bool,
     },
 
     /// Build package(s) by name with automatic transitive dependency fetching
     ///
-    /// Unlike `colcon build --packages-select`, this fetches all transitive
-    /// build dependencies from the lockfile before invoking colcon, so you
+    /// Fetches all transitive build dependencies from the lockfile, so you
     /// don't need to manually ensure every dependency is on disk.
     ///
     /// The seed packages are expanded transitively using on-disk `package.xml`
-    /// build/exec dependencies, missing packages are fetched from the lockfile,
-    /// and the result is built in topological order via colcon.
+    /// build dependencies, missing packages are fetched from the lockfile,
+    /// and the result is built in topological order.
     #[command(
         name = "build-pkg",
         override_usage = "launch-plus build-pkg [OPTIONS] <PACKAGES>..."
@@ -456,36 +459,52 @@ enum Commands {
         #[arg(long)]
         shallow: bool,
 
-        /// Colcon build output directory
+        /// Build output directory
         #[arg(long, default_value = "build")]
         build_base: String,
 
-        /// Colcon install prefix
+        /// Install prefix
         #[arg(long, default_value = "install")]
         install_base: String,
 
-        /// Colcon log directory
+        /// Log directory
         #[arg(long, default_value = "log")]
         log_base: String,
 
-        /// Path to a colcon flagfile (one token per line, # comments allowed).
-        /// See `build --colcon-flagfile` for details.
-        #[arg(long, value_name = "FILE")]
-        colcon_flagfile: Option<String>,
+        /// Extra arguments passed to cmake
+        #[arg(long, num_args = 1..)]
+        cmake_args: Vec<String>,
+
+        /// Extra arguments passed to make
+        #[arg(long, num_args = 1..)]
+        make_args: Vec<String>,
+
+        /// Use symlink install instead of copying files
+        #[arg(long)]
+        symlink_install: bool,
+
+        /// Maximum number of parallel build workers (default: available CPUs)
+        #[arg(long)]
+        parallel_workers: Option<usize>,
+
+        /// Continue building independent packages after a failure
+        #[arg(long)]
+        continue_on_error: bool,
 
         /// Automatically install external dependencies via rosdep.
         /// See `build --rosdep` for details.
         #[arg(long)]
         rosdep: bool,
 
-        /// Print the colcon command without running it
+        /// Print the build commands without running them
         #[arg(long)]
         dry_run: bool,
     },
 
     /// Fetch, build, and run tests for a launcher
     ///
-    /// Like `build` but also includes test_depend packages in the build set.
+    /// Like `build` but also includes test_depend packages in the build set
+    /// and sets BUILD_TESTING=ON.
     #[command(override_usage = "launch-plus test [OPTIONS] <PACKAGE> <LAUNCHER> [ARG]...")]
     Test {
         /// Package name
@@ -546,24 +565,39 @@ enum Commands {
         #[arg(long)]
         rosdep: bool,
 
-        /// Colcon build output directory
+        /// Build output directory
         #[arg(long, default_value = "build")]
         build_base: String,
 
-        /// Colcon install prefix
+        /// Install prefix
         #[arg(long, default_value = "install")]
         install_base: String,
 
-        /// Colcon log directory
+        /// Log directory
         #[arg(long, default_value = "log")]
         log_base: String,
 
-        /// Path to a colcon flagfile (one token per line, # comments allowed).
-        /// See `build --colcon-flagfile` for details.
-        #[arg(long, value_name = "FILE")]
-        colcon_flagfile: Option<String>,
+        /// Extra arguments passed to cmake
+        #[arg(long, num_args = 1..)]
+        cmake_args: Vec<String>,
 
-        /// Print the colcon command without running it
+        /// Extra arguments passed to make
+        #[arg(long, num_args = 1..)]
+        make_args: Vec<String>,
+
+        /// Use symlink install instead of copying files
+        #[arg(long)]
+        symlink_install: bool,
+
+        /// Maximum number of parallel build workers (default: available CPUs)
+        #[arg(long)]
+        parallel_workers: Option<usize>,
+
+        /// Continue building independent packages after a failure
+        #[arg(long)]
+        continue_on_error: bool,
+
+        /// Print the build commands without running them
         #[arg(long)]
         dry_run: bool,
     },
@@ -802,7 +836,11 @@ fn main() -> Result<()> {
             build_base,
             install_base,
             log_base,
-            colcon_flagfile,
+            cmake_args,
+            make_args,
+            symlink_install,
+            parallel_workers,
+            continue_on_error,
             dry_run,
         } => {
             let workspace_state = parse_workspace_state(clean, dirty)?;
@@ -816,11 +854,18 @@ fn main() -> Result<()> {
                 rosdep_fallback: rosdep,
                 ..Default::default()
             };
-            let extra_colcon_args = colcon_flagfile
-                .as_deref()
-                .map(read_colcon_flagfile)
-                .transpose()?
-                .unwrap_or_default();
+            let mut build_options = BuildOptions {
+                dry_run,
+                cmake_args,
+                make_args,
+                symlink_install,
+                continue_on_error,
+                test_mode: false,
+                ..Default::default()
+            };
+            if let Some(n) = parallel_workers {
+                build_options.parallel_workers = n;
+            }
             run_build(
                 &package,
                 &launcher,
@@ -832,10 +877,7 @@ fn main() -> Result<()> {
                 &build_base,
                 &install_base,
                 &log_base,
-                BuildOptions {
-                    dry_run,
-                    extra_colcon_args,
-                },
+                build_options,
                 false, // test_mode
                 verbose,
                 shallow,
@@ -851,7 +893,11 @@ fn main() -> Result<()> {
             build_base,
             install_base,
             log_base,
-            colcon_flagfile,
+            cmake_args,
+            make_args,
+            symlink_install,
+            parallel_workers,
+            continue_on_error,
             rosdep,
             dry_run,
         } => {
@@ -890,12 +936,6 @@ fn main() -> Result<()> {
                 false, // test_mode
             )?;
 
-            let extra_colcon_args = colcon_flagfile
-                .as_deref()
-                .map(read_colcon_flagfile)
-                .transpose()?
-                .unwrap_or_default();
-
             tracing::info!(
                 "Building {} packages (from {} seed): {:?}",
                 plan.packages.len(),
@@ -913,13 +953,19 @@ fn main() -> Result<()> {
                     .with_context(|| "failed to install external build dependencies via rosdep")?;
             }
 
-            execute_build(
-                &plan,
-                &BuildOptions {
-                    dry_run,
-                    extra_colcon_args,
-                },
-            )?;
+            let mut build_options = BuildOptions {
+                dry_run,
+                cmake_args,
+                make_args,
+                symlink_install,
+                continue_on_error,
+                test_mode: false,
+                ..Default::default()
+            };
+            if let Some(n) = parallel_workers {
+                build_options.parallel_workers = n;
+            }
+            execute_build(&plan, &build_options)?;
         }
         Commands::Test {
             package,
@@ -938,7 +984,11 @@ fn main() -> Result<()> {
             build_base,
             install_base,
             log_base,
-            colcon_flagfile,
+            cmake_args,
+            make_args,
+            symlink_install,
+            parallel_workers,
+            continue_on_error,
             dry_run,
         } => {
             let workspace_state = parse_workspace_state(clean, dirty)?;
@@ -952,11 +1002,18 @@ fn main() -> Result<()> {
                 rosdep_fallback: rosdep,
                 ..Default::default()
             };
-            let extra_colcon_args = colcon_flagfile
-                .as_deref()
-                .map(read_colcon_flagfile)
-                .transpose()?
-                .unwrap_or_default();
+            let mut build_options = BuildOptions {
+                dry_run,
+                cmake_args,
+                make_args,
+                symlink_install,
+                continue_on_error,
+                test_mode: true,
+                ..Default::default()
+            };
+            if let Some(n) = parallel_workers {
+                build_options.parallel_workers = n;
+            }
             run_build(
                 &package,
                 &launcher,
@@ -968,10 +1025,7 @@ fn main() -> Result<()> {
                 &build_base,
                 &install_base,
                 &log_base,
-                BuildOptions {
-                    dry_run,
-                    extra_colcon_args,
-                },
+                build_options,
                 true, // test_mode
                 verbose,
                 shallow,
@@ -1454,57 +1508,7 @@ fn parse_workspace_state(clean: bool, dirty: bool) -> Result<WorkspaceState> {
     }
 }
 
-/// Read a colcon flagfile and return the tokens as a `Vec<String>`.
-///
-/// Format: one token per line; lines starting with `#` (after trimming) are
-/// comments and are ignored; blank lines are ignored.
-///
-/// The following flags are always managed by launch-plus and must **not** appear
-/// in the flagfile (an error is returned if they do):
-/// - `--packages-*` (e.g. `--packages-select`, `--packages-up-to`, `--packages-skip`)
-/// - `--base-paths`, `--build-base`, `--install-base`, `--log-base`
-///
-/// Example file:
-/// ```text
-/// # Build settings
-/// --symlink-install
-/// --cmake-force-configure
-/// --cmake-args
-/// -DCMAKE_BUILD_TYPE=Release
-/// -DCMAKE_CXX_FLAGS=-w
-/// --parallel-workers
-/// 8
-/// ```
-fn read_colcon_flagfile(path: &str) -> Result<Vec<String>> {
-    let content = fs::read_to_string(path)
-        .with_context(|| format!("failed to read colcon flagfile: {path}"))?;
-    let tokens: Vec<String> = content
-        .lines()
-        .map(str::trim)
-        .filter(|l| !l.is_empty() && !l.starts_with('#'))
-        .map(str::to_string)
-        .collect();
-
-    // Reject flags that conflict with arguments launch-plus always manages.
-    for token in &tokens {
-        if token.starts_with("--packages-")
-            || token == "--base-paths"
-            || token == "--build-base"
-            || token == "--install-base"
-            || token == "--log-base"
-        {
-            anyhow::bail!(
-                "colcon flagfile {path:?}: '{}' conflicts with a launch-plus-managed \
-                 argument; remove it from the flagfile",
-                token
-            );
-        }
-    }
-
-    Ok(tokens)
-}
-
-/// Execute the build/test command: resolve → plan → colcon build
+/// Execute the build/test command: resolve → plan → build
 #[allow(clippy::too_many_arguments)]
 fn run_build(
     package: &str,
@@ -1593,7 +1597,7 @@ fn run_build(
         }
     }
 
-    execute_build(&plan, &build_options).with_context(|| "colcon build failed")?;
+    execute_build(&plan, &build_options).with_context(|| "build failed")?;
 
     Ok(())
 }

--- a/crates/launch-plus-core/src/builder/ament_cmake.rs
+++ b/crates/launch-plus-core/src/builder/ament_cmake.rs
@@ -1,1 +1,441 @@
 //! ament_cmake build backend: cmake configure / make / make install for a single package.
+//!
+//! Implements the three-step build process that ament_cmake packages use:
+//! 1. **Configure**: `cmake` with install prefix, BUILD_TESTING, and user args
+//! 2. **Build**: `make -jN` with user args
+//! 3. **Install**: `make install`
+//!
+//! The caller (scheduler) is responsible for setting up the build environment
+//! (CMAKE_PREFIX_PATH, etc.) via [`super::environment::build_env_for_package`].
+
+use std::collections::HashMap;
+use std::fs;
+use std::io::{BufRead, BufReader};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::sync::atomic::{AtomicBool, Ordering};
+
+/// Everything a per-package build function needs.
+///
+/// Shared between `ament_cmake` and `ament_python` backends.
+#[derive(Debug)]
+pub struct PackageBuildContext {
+    /// Package name (e.g. `autoware_cmake`).
+    pub pkg_name: String,
+    /// Absolute path to the package source directory.
+    pub src_dir: PathBuf,
+    /// Per-package build directory (e.g. `build/autoware_cmake/`).
+    pub build_dir: PathBuf,
+    /// Per-package install prefix (e.g. `install/autoware_cmake/`).
+    pub install_dir: PathBuf,
+    /// Per-package log directory (e.g. `log/<timestamp>/autoware_cmake/`).
+    pub log_dir: PathBuf,
+    /// Environment variables to set for child processes.
+    /// These override (not append to) the inherited environment.
+    pub env: HashMap<String, String>,
+    /// Build options from the user.
+    pub options: BuildOptionsRef,
+    /// Global SIGINT flag — checked before spawning each subprocess.
+    pub interrupted: &'static AtomicBool,
+}
+
+/// The subset of [`super::BuildOptions`] needed by backends, passed by value.
+#[derive(Debug, Clone)]
+pub struct BuildOptionsRef {
+    pub parallel_workers: usize,
+    pub cmake_args: Vec<String>,
+    pub make_args: Vec<String>,
+    pub symlink_install: bool,
+    pub test_mode: bool,
+    pub dry_run: bool,
+}
+
+impl From<&super::BuildOptions> for BuildOptionsRef {
+    fn from(opts: &super::BuildOptions) -> Self {
+        Self {
+            parallel_workers: opts.parallel_workers,
+            cmake_args: opts.cmake_args.clone(),
+            make_args: opts.make_args.clone(),
+            symlink_install: opts.symlink_install,
+            test_mode: opts.test_mode,
+            dry_run: opts.dry_run,
+        }
+    }
+}
+
+/// Build an ament_cmake package: configure → build → install.
+///
+/// Returns `Ok(())` on success, or an appropriate [`crate::Error`] on failure.
+pub fn build_ament_cmake(ctx: &PackageBuildContext) -> crate::Result<()> {
+    // Create build and log directories.
+    fs::create_dir_all(&ctx.build_dir)?;
+    fs::create_dir_all(&ctx.log_dir)?;
+
+    // Validate: reject user-specified BUILD_TESTING.
+    validate_cmake_args(&ctx.options.cmake_args)?;
+
+    // Step 1: cmake configure
+    configure(ctx)?;
+
+    // Step 2: make
+    build(ctx)?;
+
+    // Step 3: make install
+    install(ctx)?;
+
+    Ok(())
+}
+
+/// Reject `-DBUILD_TESTING=...` in user cmake_args — we control it via `--test-mode`.
+fn validate_cmake_args(cmake_args: &[String]) -> crate::Result<()> {
+    for arg in cmake_args {
+        let upper = arg.to_uppercase();
+        if upper.starts_with("-DBUILD_TESTING=") || upper.starts_with("-DBUILD_TESTING:") {
+            return Err(crate::Error::InvalidBuildFlag {
+                detail: format!(
+                    "BUILD_TESTING is managed by launch-plus (use --test-mode). \
+                     Remove '{arg}' from --cmake-args."
+                ),
+            });
+        }
+    }
+    Ok(())
+}
+
+/// Step 1: cmake configure.
+fn configure(ctx: &PackageBuildContext) -> crate::Result<()> {
+    let build_testing = if ctx.options.test_mode { "ON" } else { "OFF" };
+
+    let mut args = vec![
+        format!(
+            "-DCMAKE_INSTALL_PREFIX={}",
+            ctx.install_dir.to_string_lossy()
+        ),
+        format!("-DBUILD_TESTING={build_testing}"),
+    ];
+
+    // Symlink install: ament_cmake supports this via a cmake variable.
+    if ctx.options.symlink_install {
+        args.push("-DCMAKE_INSTALL_SYMLINKS=ON".to_string());
+    }
+
+    // User cmake args.
+    args.extend(ctx.options.cmake_args.iter().cloned());
+
+    // Source directory last.
+    args.push(ctx.src_dir.to_string_lossy().into_owned());
+
+    run_command(ctx, "cmake", &args, Some(&ctx.build_dir), "configure")
+}
+
+/// Step 2: make (parallel build).
+fn build(ctx: &PackageBuildContext) -> crate::Result<()> {
+    let mut args = vec![format!("-j{}", ctx.options.parallel_workers)];
+
+    // User make args.
+    args.extend(ctx.options.make_args.iter().cloned());
+
+    run_command(ctx, "make", &args, Some(&ctx.build_dir), "build")
+}
+
+/// Step 3: make install.
+fn install(ctx: &PackageBuildContext) -> crate::Result<()> {
+    run_command(
+        ctx,
+        "make",
+        &["install".to_string()],
+        Some(&ctx.build_dir),
+        "install",
+    )
+}
+
+/// Run a subprocess with environment overrides, logging, and SIGINT awareness.
+///
+/// * `step_name` is used for log file naming and error messages (e.g. "configure", "build").
+/// * stdout and stderr are tee'd to `<log_dir>/<step_name>_stdout.log` / `_stderr.log`.
+/// * If `ctx.options.dry_run`, prints the command and returns without executing.
+fn run_command(
+    ctx: &PackageBuildContext,
+    program: &str,
+    args: &[String],
+    working_dir: Option<&Path>,
+    step_name: &str,
+) -> crate::Result<()> {
+    // Check for interruption before spawning.
+    if ctx.interrupted.load(Ordering::SeqCst) {
+        return Err(crate::Error::BuildInterrupted);
+    }
+
+    let cmd_str = format!(
+        "{} {}",
+        program,
+        args.iter()
+            .map(|a| shell_escape(a))
+            .collect::<Vec<_>>()
+            .join(" ")
+    );
+
+    if ctx.options.dry_run {
+        let dir_str = working_dir
+            .map(|d| d.to_string_lossy().into_owned())
+            .unwrap_or_else(|| ".".to_string());
+        println!("[{}] (in {}) {}", ctx.pkg_name, dir_str, cmd_str);
+        return Ok(());
+    }
+
+    tracing::debug!("[{}] {}: {}", ctx.pkg_name, step_name, cmd_str);
+
+    let mut cmd = Command::new(program);
+    cmd.args(args);
+
+    if let Some(dir) = working_dir {
+        cmd.current_dir(dir);
+    }
+
+    // Merge environment: start with inherited env, override with computed vars.
+    for (key, val) in &ctx.env {
+        cmd.env(key, val);
+    }
+
+    // Capture stdout and stderr via pipes for logging.
+    cmd.stdout(Stdio::piped());
+    cmd.stderr(Stdio::piped());
+
+    let mut child = cmd.spawn().map_err(|e| crate::Error::BuildFailed {
+        package: ctx.pkg_name.clone(),
+        detail: format!("{step_name}: failed to spawn '{program}': {e}"),
+    })?;
+
+    // Tee stdout/stderr to log files in background threads.
+    let stdout_log = ctx.log_dir.join(format!("{step_name}_stdout.log"));
+    let stderr_log = ctx.log_dir.join(format!("{step_name}_stderr.log"));
+
+    let stdout_pipe = child.stdout.take();
+    let stderr_pipe = child.stderr.take();
+
+    let pkg_name = ctx.pkg_name.clone();
+    let step = step_name.to_string();
+
+    // Use scoped threads so we don't need 'static lifetimes.
+    let status = std::thread::scope(|s| {
+        // Stdout reader thread.
+        let stdout_handle = stdout_pipe.map(|pipe| s.spawn(move || tee_to_file(pipe, &stdout_log)));
+
+        // Stderr reader thread.
+        let stderr_handle = stderr_pipe.map(|pipe| {
+            let pkg = pkg_name.clone();
+            let step = step.clone();
+            s.spawn(move || tee_to_file_with_prefix(pipe, &stderr_log, &pkg, &step))
+        });
+
+        let status = child.wait().map_err(|e| crate::Error::BuildFailed {
+            package: pkg_name.clone(),
+            detail: format!("{step}: failed to wait for '{program}': {e}"),
+        });
+
+        // Wait for tee threads.
+        if let Some(h) = stdout_handle {
+            let _ = h.join();
+        }
+        if let Some(h) = stderr_handle {
+            let _ = h.join();
+        }
+
+        status
+    })?;
+
+    // Check for interruption after child exits.
+    if ctx.interrupted.load(Ordering::SeqCst) {
+        return Err(crate::Error::BuildInterrupted);
+    }
+
+    if !status.success() {
+        let code = status
+            .code()
+            .map(|c| c.to_string())
+            .unwrap_or_else(|| "signal".to_string());
+        return Err(crate::Error::BuildFailed {
+            package: ctx.pkg_name.clone(),
+            detail: format!(
+                "{step_name} failed (exit code {code}). \
+                 See logs: {}",
+                ctx.log_dir.to_string_lossy()
+            ),
+        });
+    }
+
+    Ok(())
+}
+
+/// Read from `reader` line-by-line, writing each line to `log_path`.
+fn tee_to_file(reader: impl std::io::Read, log_path: &Path) {
+    let file = match fs::File::create(log_path) {
+        Ok(f) => f,
+        Err(e) => {
+            tracing::warn!("Failed to create log file {}: {e}", log_path.display());
+            return;
+        }
+    };
+    let mut writer = std::io::BufWriter::new(file);
+    let buf = BufReader::new(reader);
+    for line in buf.lines() {
+        match line {
+            Ok(line) => {
+                use std::io::Write;
+                let _ = writeln!(writer, "{line}");
+            }
+            Err(_) => break,
+        }
+    }
+}
+
+/// Read from `reader` line-by-line, writing to `log_path` and emitting
+/// non-empty lines as tracing warnings (stderr from build tools often
+/// contains warnings that are useful to surface).
+fn tee_to_file_with_prefix(
+    reader: impl std::io::Read,
+    log_path: &Path,
+    _pkg_name: &str,
+    _step_name: &str,
+) {
+    let file = match fs::File::create(log_path) {
+        Ok(f) => f,
+        Err(e) => {
+            tracing::warn!("Failed to create log file {}: {e}", log_path.display());
+            return;
+        }
+    };
+    let mut writer = std::io::BufWriter::new(file);
+    let buf = BufReader::new(reader);
+    for line in buf.lines() {
+        match line {
+            Ok(line) => {
+                use std::io::Write;
+                let _ = writeln!(writer, "{line}");
+                // Don't spam terminal with every stderr line — the log file has everything.
+                // Only surface via tracing at trace level.
+                if !line.is_empty() {
+                    tracing::trace!("{line}");
+                }
+            }
+            Err(_) => break,
+        }
+    }
+}
+
+/// Minimal shell escaping for display purposes (not security-critical).
+fn shell_escape(s: &str) -> String {
+    if s.contains(' ') || s.contains('\'') || s.contains('"') || s.contains('\\') || s.is_empty() {
+        format!("'{}'", s.replace('\'', "'\\''"))
+    } else {
+        s.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_validate_cmake_args_rejects_build_testing() {
+        let args = vec!["-DBUILD_TESTING=ON".to_string()];
+        let result = validate_cmake_args(&args);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("BUILD_TESTING"));
+    }
+
+    #[test]
+    fn test_validate_cmake_args_rejects_case_insensitive() {
+        let args = vec!["-Dbuild_testing=OFF".to_string()];
+        let result = validate_cmake_args(&args);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_validate_cmake_args_rejects_typed() {
+        // cmake typed variable: -DBUILD_TESTING:BOOL=ON
+        let args = vec!["-DBUILD_TESTING:BOOL=ON".to_string()];
+        let result = validate_cmake_args(&args);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_validate_cmake_args_allows_other() {
+        let args = vec![
+            "-DCMAKE_BUILD_TYPE=Release".to_string(),
+            "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON".to_string(),
+        ];
+        let result = validate_cmake_args(&args);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_shell_escape() {
+        assert_eq!(shell_escape("simple"), "simple");
+        assert_eq!(shell_escape("has space"), "'has space'");
+        assert_eq!(shell_escape(""), "''");
+        assert_eq!(shell_escape("it's"), "'it'\\''s'");
+    }
+
+    #[test]
+    fn test_dry_run_does_not_execute() {
+        use tempfile::TempDir;
+
+        let tmp = TempDir::new().unwrap();
+        let ctx = PackageBuildContext {
+            pkg_name: "test_pkg".to_string(),
+            src_dir: tmp.path().join("src"),
+            build_dir: tmp.path().join("build"),
+            install_dir: tmp.path().join("install"),
+            log_dir: tmp.path().join("log"),
+            env: HashMap::new(),
+            options: BuildOptionsRef {
+                parallel_workers: 4,
+                cmake_args: vec![],
+                make_args: vec![],
+                symlink_install: false,
+                test_mode: false,
+                dry_run: true,
+            },
+            interrupted: &DUMMY_INTERRUPTED,
+        };
+
+        // Should succeed without actually running cmake (which isn't installed in test env).
+        let result = build_ament_cmake(&ctx);
+        assert!(result.is_ok());
+    }
+
+    static DUMMY_INTERRUPTED: AtomicBool = AtomicBool::new(false);
+
+    #[test]
+    fn test_interrupted_prevents_execution() {
+        use tempfile::TempDir;
+
+        static TEST_INTERRUPTED: AtomicBool = AtomicBool::new(true);
+
+        let tmp = TempDir::new().unwrap();
+        let ctx = PackageBuildContext {
+            pkg_name: "test_pkg".to_string(),
+            src_dir: tmp.path().join("src"),
+            build_dir: tmp.path().join("build"),
+            install_dir: tmp.path().join("install"),
+            log_dir: tmp.path().join("log"),
+            env: HashMap::new(),
+            options: BuildOptionsRef {
+                parallel_workers: 4,
+                cmake_args: vec![],
+                make_args: vec![],
+                symlink_install: false,
+                test_mode: false,
+                dry_run: false,
+            },
+            interrupted: &TEST_INTERRUPTED,
+        };
+
+        let result = build_ament_cmake(&ctx);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("interrupted"));
+    }
+}

--- a/crates/launch-plus-core/src/builder/ament_cmake.rs
+++ b/crates/launch-plus-core/src/builder/ament_cmake.rs
@@ -128,23 +128,40 @@ fn configure(ctx: &PackageBuildContext) -> crate::Result<()> {
     run_command(ctx, "cmake", &args, Some(&ctx.build_dir), "configure")
 }
 
-/// Step 2: make (parallel build).
+/// Step 2: cmake --build (parallel build).
+///
+/// Uses `cmake --build` instead of bare `make` for portability and to handle
+/// edge cases like empty builds (no targets) gracefully.
 fn build(ctx: &PackageBuildContext) -> crate::Result<()> {
-    let mut args = vec![format!("-j{}", ctx.options.parallel_workers)];
+    let mut args = vec![
+        "--build".to_string(),
+        ctx.build_dir.to_string_lossy().into_owned(),
+        "--parallel".to_string(),
+        ctx.options.parallel_workers.to_string(),
+    ];
 
-    // User make args.
-    args.extend(ctx.options.make_args.iter().cloned());
+    // Pass make-specific args after `--`.
+    if !ctx.options.make_args.is_empty() {
+        args.push("--".to_string());
+        args.extend(ctx.options.make_args.iter().cloned());
+    }
 
-    run_command(ctx, "make", &args, Some(&ctx.build_dir), "build")
+    run_command(ctx, "cmake", &args, None, "build")
 }
 
-/// Step 3: make install.
+/// Step 3: cmake --install.
+///
+/// Uses `cmake --install` instead of `make install` — handles empty builds
+/// (where cmake produced no install rules) without error.
 fn install(ctx: &PackageBuildContext) -> crate::Result<()> {
     run_command(
         ctx,
-        "make",
-        &["install".to_string()],
-        Some(&ctx.build_dir),
+        "cmake",
+        &[
+            "--install".to_string(),
+            ctx.build_dir.to_string_lossy().into_owned(),
+        ],
+        None,
         "install",
     )
 }

--- a/crates/launch-plus-core/src/builder/ament_cmake.rs
+++ b/crates/launch-plus-core/src/builder/ament_cmake.rs
@@ -1,0 +1,1 @@
+//! ament_cmake build backend: cmake configure / make / make install for a single package.

--- a/crates/launch-plus-core/src/builder/ament_cmake.rs
+++ b/crates/launch-plus-core/src/builder/ament_cmake.rs
@@ -221,12 +221,9 @@ pub fn run_command(
         // Stdout reader thread.
         let stdout_handle = stdout_pipe.map(|pipe| s.spawn(move || tee_to_file(pipe, &stdout_log)));
 
-        // Stderr reader thread.
-        let stderr_handle = stderr_pipe.map(|pipe| {
-            let pkg = pkg_name.clone();
-            let step = step.clone();
-            s.spawn(move || tee_to_file_with_prefix(pipe, &stderr_log, &pkg, &step))
-        });
+        // Stderr reader thread — tee to both log file and terminal.
+        let stderr_handle =
+            stderr_pipe.map(|pipe| s.spawn(move || tee_to_file_and_stderr(pipe, &stderr_log)));
 
         let status = child.wait().map_err(|e| crate::Error::BuildFailed {
             package: pkg_name.clone(),
@@ -289,15 +286,9 @@ fn tee_to_file(reader: impl std::io::Read, log_path: &Path) {
     }
 }
 
-/// Read from `reader` line-by-line, writing to `log_path` and emitting
-/// non-empty lines as tracing warnings (stderr from build tools often
-/// contains warnings that are useful to surface).
-fn tee_to_file_with_prefix(
-    reader: impl std::io::Read,
-    log_path: &Path,
-    _pkg_name: &str,
-    _step_name: &str,
-) {
+/// Read from `reader` line-by-line, writing to `log_path` and forwarding
+/// every line to stderr so build errors/warnings are immediately visible.
+fn tee_to_file_and_stderr(reader: impl std::io::Read, log_path: &Path) {
     let file = match fs::File::create(log_path) {
         Ok(f) => f,
         Err(e) => {
@@ -312,11 +303,7 @@ fn tee_to_file_with_prefix(
             Ok(line) => {
                 use std::io::Write;
                 let _ = writeln!(writer, "{line}");
-                // Don't spam terminal with every stderr line — the log file has everything.
-                // Only surface via tracing at trace level.
-                if !line.is_empty() {
-                    tracing::trace!("{line}");
-                }
+                eprintln!("{line}");
             }
             Err(_) => break,
         }

--- a/crates/launch-plus-core/src/builder/ament_cmake.rs
+++ b/crates/launch-plus-core/src/builder/ament_cmake.rs
@@ -154,7 +154,7 @@ fn install(ctx: &PackageBuildContext) -> crate::Result<()> {
 /// * `step_name` is used for log file naming and error messages (e.g. "configure", "build").
 /// * stdout and stderr are tee'd to `<log_dir>/<step_name>_stdout.log` / `_stderr.log`.
 /// * If `ctx.options.dry_run`, prints the command and returns without executing.
-fn run_command(
+pub fn run_command(
     ctx: &PackageBuildContext,
     program: &str,
     args: &[String],

--- a/crates/launch-plus-core/src/builder/ament_python.rs
+++ b/crates/launch-plus-core/src/builder/ament_python.rs
@@ -1,1 +1,230 @@
-//! ament_python build backend: setuptools/pip build for a single package.
+//! ament_python build backend: Python package build and install.
+//!
+//! Handles two installation modes:
+//! - **Regular install**: `python3 setup.py install --prefix=<install_dir>`
+//! - **Symlink install**: `python3 setup.py develop --prefix=<install_dir>`
+//!
+//! Also copies `package.xml` into the install tree for ament indexing.
+
+use std::fs;
+
+use super::ament_cmake::{PackageBuildContext, run_command};
+
+/// Build an ament_python package.
+///
+/// Steps:
+/// 1. Install Python package via setup.py (or pip for pyproject.toml-only)
+/// 2. Copy `package.xml` to `share/<pkg>/` in the install tree
+pub fn build_ament_python(ctx: &PackageBuildContext) -> crate::Result<()> {
+    fs::create_dir_all(&ctx.build_dir)?;
+    fs::create_dir_all(&ctx.log_dir)?;
+
+    // Determine build entry point.
+    let has_setup_py = ctx.src_dir.join("setup.py").exists();
+    let has_setup_cfg = ctx.src_dir.join("setup.cfg").exists();
+    let has_pyproject = ctx.src_dir.join("pyproject.toml").exists();
+
+    if has_setup_py {
+        // Classic setuptools path.
+        if ctx.options.symlink_install {
+            setup_py_develop(ctx)?;
+        } else {
+            setup_py_install(ctx)?;
+        }
+    } else if has_setup_cfg || has_pyproject {
+        // Modern Python packaging — use pip install.
+        pip_install(ctx)?;
+    } else {
+        return Err(crate::Error::BuildFailed {
+            package: ctx.pkg_name.clone(),
+            detail: "no setup.py, setup.cfg, or pyproject.toml found".to_string(),
+        });
+    }
+
+    // Copy package.xml to share/<pkg>/ so ament can index it.
+    copy_package_xml(ctx)?;
+
+    Ok(())
+}
+
+/// `python3 setup.py install --prefix=<install_dir> --record <build_dir>/install_manifest.txt`
+fn setup_py_install(ctx: &PackageBuildContext) -> crate::Result<()> {
+    let record_file = ctx.build_dir.join("install_manifest.txt");
+    let args = vec![
+        "setup.py".to_string(),
+        "install".to_string(),
+        format!("--prefix={}", ctx.install_dir.to_string_lossy()),
+        format!("--record={}", record_file.to_string_lossy()),
+    ];
+
+    run_command(ctx, "python3", &args, Some(&ctx.src_dir), "install")
+}
+
+/// `python3 setup.py develop --prefix=<install_dir>` (symlink install)
+fn setup_py_develop(ctx: &PackageBuildContext) -> crate::Result<()> {
+    let args = vec![
+        "setup.py".to_string(),
+        "develop".to_string(),
+        format!("--prefix={}", ctx.install_dir.to_string_lossy()),
+    ];
+
+    run_command(ctx, "python3", &args, Some(&ctx.src_dir), "develop")
+}
+
+/// `pip3 install --prefix=<install_dir> --no-deps --no-build-isolation .`
+///
+/// Used for modern Python packages that use pyproject.toml or setup.cfg
+/// without setup.py.
+fn pip_install(ctx: &PackageBuildContext) -> crate::Result<()> {
+    let mut args = vec![
+        "install".to_string(),
+        format!("--prefix={}", ctx.install_dir.to_string_lossy()),
+        "--no-deps".to_string(),
+        "--no-build-isolation".to_string(),
+    ];
+
+    if ctx.options.symlink_install {
+        args.push("--editable".to_string());
+    }
+
+    args.push(".".to_string());
+
+    run_command(ctx, "pip3", &args, Some(&ctx.src_dir), "pip-install")
+}
+
+/// Copy `package.xml` from source to `<install_dir>/share/<pkg>/package.xml`.
+///
+/// This is needed for ament to discover the package after installation.
+fn copy_package_xml(ctx: &PackageBuildContext) -> crate::Result<()> {
+    let src_xml = ctx.src_dir.join("package.xml");
+    if !src_xml.exists() {
+        // Not all Python packages have package.xml (though ROS 2 ones should).
+        return Ok(());
+    }
+
+    let dest_dir = ctx.install_dir.join("share").join(&ctx.pkg_name);
+    fs::create_dir_all(&dest_dir)?;
+    let dest_xml = dest_dir.join("package.xml");
+
+    if ctx.options.symlink_install {
+        // Create symlink instead of copy.
+        #[cfg(unix)]
+        {
+            // Remove existing symlink/file if present.
+            if dest_xml.exists() || dest_xml.is_symlink() {
+                fs::remove_file(&dest_xml)?;
+            }
+            std::os::unix::fs::symlink(&src_xml, &dest_xml)?;
+        }
+        #[cfg(not(unix))]
+        {
+            fs::copy(&src_xml, &dest_xml)?;
+        }
+    } else {
+        fs::copy(&src_xml, &dest_xml)?;
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+    use std::path::Path;
+    use std::sync::atomic::AtomicBool;
+
+    use super::super::ament_cmake::BuildOptionsRef;
+
+    static DUMMY_INTERRUPTED: AtomicBool = AtomicBool::new(false);
+
+    fn make_ctx(tmp: &Path) -> PackageBuildContext {
+        PackageBuildContext {
+            pkg_name: "test_py_pkg".to_string(),
+            src_dir: tmp.join("src"),
+            build_dir: tmp.join("build"),
+            install_dir: tmp.join("install"),
+            log_dir: tmp.join("log"),
+            env: HashMap::new(),
+            options: BuildOptionsRef {
+                parallel_workers: 4,
+                cmake_args: vec![],
+                make_args: vec![],
+                symlink_install: false,
+                test_mode: false,
+                dry_run: true,
+            },
+            interrupted: &DUMMY_INTERRUPTED,
+        }
+    }
+
+    #[test]
+    fn test_no_build_entry_fails() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let mut ctx = make_ctx(tmp.path());
+        ctx.options.dry_run = false; // Need to actually check for files
+        fs::create_dir_all(&ctx.src_dir).unwrap();
+
+        let result = build_ament_python(&ctx);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("no setup.py"));
+    }
+
+    #[test]
+    fn test_dry_run_with_setup_py() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let ctx = make_ctx(tmp.path());
+        fs::create_dir_all(&ctx.src_dir).unwrap();
+        fs::write(ctx.src_dir.join("setup.py"), "# stub").unwrap();
+
+        let result = build_ament_python(&ctx);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_copy_package_xml() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let ctx = make_ctx(tmp.path());
+        fs::create_dir_all(&ctx.src_dir).unwrap();
+        fs::create_dir_all(&ctx.install_dir).unwrap();
+        fs::write(
+            ctx.src_dir.join("package.xml"),
+            "<package><name>test_py_pkg</name></package>",
+        )
+        .unwrap();
+
+        copy_package_xml(&ctx).unwrap();
+
+        let dest = ctx
+            .install_dir
+            .join("share")
+            .join("test_py_pkg")
+            .join("package.xml");
+        assert!(dest.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_symlink_package_xml() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let mut ctx = make_ctx(tmp.path());
+        ctx.options.symlink_install = true;
+        fs::create_dir_all(&ctx.src_dir).unwrap();
+        fs::create_dir_all(&ctx.install_dir).unwrap();
+        fs::write(
+            ctx.src_dir.join("package.xml"),
+            "<package><name>test_py_pkg</name></package>",
+        )
+        .unwrap();
+
+        copy_package_xml(&ctx).unwrap();
+
+        let dest = ctx
+            .install_dir
+            .join("share")
+            .join("test_py_pkg")
+            .join("package.xml");
+        assert!(dest.is_symlink());
+    }
+}

--- a/crates/launch-plus-core/src/builder/ament_python.rs
+++ b/crates/launch-plus-core/src/builder/ament_python.rs
@@ -1,0 +1,1 @@
+//! ament_python build backend: setuptools/pip build for a single package.

--- a/crates/launch-plus-core/src/builder/colcon_local_setup_util_sh.py
+++ b/crates/launch-plus-core/src/builder/colcon_local_setup_util_sh.py
@@ -1,0 +1,407 @@
+# Copyright 2016-2019 Dirk Thomas
+# Licensed under the Apache License, Version 2.0
+
+import argparse
+from collections import OrderedDict
+import os
+from pathlib import Path
+import sys
+
+
+FORMAT_STR_COMMENT_LINE = '# {comment}'
+FORMAT_STR_SET_ENV_VAR = 'export {name}="{value}"'
+FORMAT_STR_USE_ENV_VAR = '${name}'
+FORMAT_STR_INVOKE_SCRIPT = 'COLCON_CURRENT_PREFIX="{prefix}" _colcon_prefix_sh_source_script "{script_path}"'  # noqa: E501
+FORMAT_STR_REMOVE_LEADING_SEPARATOR = 'if [ "$(echo -n ${name} | head -c 1)" = ":" ]; then export {name}=${{{name}#?}} ; fi'  # noqa: E501
+FORMAT_STR_REMOVE_TRAILING_SEPARATOR = 'if [ "$(echo -n ${name} | tail -c 1)" = ":" ]; then export {name}=${{{name}%?}} ; fi'  # noqa: E501
+
+DSV_TYPE_APPEND_NON_DUPLICATE = 'append-non-duplicate'
+DSV_TYPE_PREPEND_NON_DUPLICATE = 'prepend-non-duplicate'
+DSV_TYPE_PREPEND_NON_DUPLICATE_IF_EXISTS = 'prepend-non-duplicate-if-exists'
+DSV_TYPE_SET = 'set'
+DSV_TYPE_SET_IF_UNSET = 'set-if-unset'
+DSV_TYPE_SOURCE = 'source'
+
+
+def main(argv=sys.argv[1:]):  # noqa: D103
+    parser = argparse.ArgumentParser(
+        description='Output shell commands for the packages in topological '
+                    'order')
+    parser.add_argument(
+        'primary_extension',
+        help='The file extension of the primary shell')
+    parser.add_argument(
+        'additional_extension', nargs='?',
+        help='The additional file extension to be considered')
+    parser.add_argument(
+        '--merged-install', action='store_true',
+        help='All install prefixes are merged into a single location')
+    args = parser.parse_args(argv)
+
+    packages = get_packages(Path(__file__).parent, args.merged_install)
+
+    ordered_packages = order_packages(packages)
+    for pkg_name in ordered_packages:
+        if _include_comments():
+            print(
+                FORMAT_STR_COMMENT_LINE.format_map(
+                    {'comment': 'Package: ' + pkg_name}))
+        prefix = os.path.abspath(os.path.dirname(__file__))
+        if not args.merged_install:
+            prefix = os.path.join(prefix, pkg_name)
+        for line in get_commands(
+            pkg_name, prefix, args.primary_extension,
+            args.additional_extension
+        ):
+            print(line)
+
+    for line in _remove_ending_separators():
+        print(line)
+
+
+def get_packages(prefix_path, merged_install):
+    """
+    Find packages based on colcon-specific files created during installation.
+
+    :param Path prefix_path: The install prefix path of all packages
+    :param bool merged_install: The flag if the packages are all installed
+      directly in the prefix or if each package is installed in a subdirectory
+      named after the package
+    :returns: A mapping from the package name to the set of runtime
+      dependencies
+    :rtype: dict
+    """
+    packages = {}
+    # since importing colcon_core isn't feasible here the following constant
+    # must match colcon_core.location.get_relative_package_index_path()
+    subdirectory = 'share/colcon-core/packages'
+    if merged_install:
+        # return if workspace is empty
+        if not (prefix_path / subdirectory).is_dir():
+            return packages
+        # find all files in the subdirectory
+        for p in (prefix_path / subdirectory).iterdir():
+            if not p.is_file():
+                continue
+            if p.name.startswith('.'):
+                continue
+            add_package_runtime_dependencies(p, packages)
+    else:
+        # for each subdirectory look for the package specific file
+        for p in prefix_path.iterdir():
+            if not p.is_dir():
+                continue
+            if p.name.startswith('.'):
+                continue
+            p = p / subdirectory / p.name
+            if p.is_file():
+                add_package_runtime_dependencies(p, packages)
+
+    # remove unknown dependencies
+    pkg_names = set(packages.keys())
+    for k in packages.keys():
+        packages[k] = {d for d in packages[k] if d in pkg_names}
+
+    return packages
+
+
+def add_package_runtime_dependencies(path, packages):
+    """
+    Check the path and if it exists extract the packages runtime dependencies.
+
+    :param Path path: The resource file containing the runtime dependencies
+    :param dict packages: A mapping from package names to the sets of runtime
+      dependencies to add to
+    """
+    content = path.read_text()
+    dependencies = set(content.split(os.pathsep) if content else [])
+    packages[path.name] = dependencies
+
+
+def order_packages(packages):
+    """
+    Order packages topologically.
+
+    :param dict packages: A mapping from package name to the set of runtime
+      dependencies
+    :returns: The package names
+    :rtype: list
+    """
+    # select packages with no dependencies in alphabetical order
+    to_be_ordered = list(packages.keys())
+    ordered = []
+    while to_be_ordered:
+        pkg_names_without_deps = [
+            name for name in to_be_ordered if not packages[name]]
+        if not pkg_names_without_deps:
+            reduce_cycle_set(packages)
+            raise RuntimeError(
+                'Circular dependency between: ' + ', '.join(sorted(packages)))
+        pkg_names_without_deps.sort()
+        pkg_name = pkg_names_without_deps[0]
+        to_be_ordered.remove(pkg_name)
+        ordered.append(pkg_name)
+        # remove item from dependency lists
+        for k in list(packages.keys()):
+            if pkg_name in packages[k]:
+                packages[k].remove(pkg_name)
+    return ordered
+
+
+def reduce_cycle_set(packages):
+    """
+    Reduce the set of packages to the ones part of the circular dependency.
+
+    :param dict packages: A mapping from package name to the set of runtime
+      dependencies which is modified in place
+    """
+    last_depended = None
+    while len(packages) > 0:
+        # get all remaining dependencies
+        depended = set()
+        for pkg_name, dependencies in packages.items():
+            depended = depended.union(dependencies)
+        # remove all packages which are not dependent on
+        for name in list(packages.keys()):
+            if name not in depended:
+                del packages[name]
+        if last_depended:
+            # if remaining packages haven't changed return them
+            if last_depended == depended:
+                return packages.keys()
+        # otherwise reduce again
+        last_depended = depended
+
+
+def _include_comments():
+    # skipping comment lines when COLCON_TRACE is not set speeds up the
+    # processing especially on Windows
+    return bool(os.environ.get('COLCON_TRACE'))
+
+
+def get_commands(pkg_name, prefix, primary_extension, additional_extension):
+    commands = []
+    package_dsv_path = os.path.join(prefix, 'share', pkg_name, 'package.dsv')
+    if os.path.exists(package_dsv_path):
+        commands += process_dsv_file(
+            package_dsv_path, prefix, primary_extension, additional_extension)
+    return commands
+
+
+def process_dsv_file(
+    dsv_path, prefix, primary_extension=None, additional_extension=None
+):
+    commands = []
+    if _include_comments():
+        commands.append(FORMAT_STR_COMMENT_LINE.format_map({'comment': dsv_path}))
+    with open(dsv_path, 'r') as h:
+        content = h.read()
+    lines = content.splitlines()
+
+    basenames = OrderedDict()
+    for i, line in enumerate(lines):
+        # skip over empty or whitespace-only lines
+        if not line.strip():
+            continue
+        # skip over comments
+        if line.startswith('#'):
+            continue
+        try:
+            type_, remainder = line.split(';', 1)
+        except ValueError:
+            raise RuntimeError(
+                "Line %d in '%s' doesn't contain a semicolon separating the "
+                'type from the arguments' % (i + 1, dsv_path))
+        if type_ != DSV_TYPE_SOURCE:
+            # handle non-source lines
+            try:
+                commands += handle_dsv_types_except_source(
+                    type_, remainder, prefix)
+            except RuntimeError as e:
+                raise RuntimeError(
+                    "Line %d in '%s' %s" % (i + 1, dsv_path, e)) from e
+        else:
+            # group remaining source lines by basename
+            path_without_ext, ext = os.path.splitext(remainder)
+            if path_without_ext not in basenames:
+                basenames[path_without_ext] = set()
+            assert ext.startswith('.')
+            ext = ext[1:]
+            if ext in (primary_extension, additional_extension):
+                basenames[path_without_ext].add(ext)
+
+    # add the dsv extension to each basename if the file exists
+    for basename, extensions in basenames.items():
+        if not os.path.isabs(basename):
+            basename = os.path.join(prefix, basename)
+        if os.path.exists(basename + '.dsv'):
+            extensions.add('dsv')
+
+    for basename, extensions in basenames.items():
+        if not os.path.isabs(basename):
+            basename = os.path.join(prefix, basename)
+        if 'dsv' in extensions:
+            # process dsv files recursively
+            commands += process_dsv_file(
+                basename + '.dsv', prefix, primary_extension=primary_extension,
+                additional_extension=additional_extension)
+        elif primary_extension in extensions and len(extensions) == 1:
+            # source primary-only files
+            commands += [
+                FORMAT_STR_INVOKE_SCRIPT.format_map({
+                    'prefix': prefix,
+                    'script_path': basename + '.' + primary_extension})]
+        elif additional_extension in extensions:
+            # source non-primary files
+            commands += [
+                FORMAT_STR_INVOKE_SCRIPT.format_map({
+                    'prefix': prefix,
+                    'script_path': basename + '.' + additional_extension})]
+
+    return commands
+
+
+def handle_dsv_types_except_source(type_, remainder, prefix):
+    commands = []
+    if type_ in (DSV_TYPE_SET, DSV_TYPE_SET_IF_UNSET):
+        try:
+            env_name, value = remainder.split(';', 1)
+        except ValueError:
+            raise RuntimeError(
+                "doesn't contain a semicolon separating the environment name "
+                'from the value')
+        try_prefixed_value = os.path.join(prefix, value) if value else prefix
+        if os.path.exists(try_prefixed_value):
+            value = try_prefixed_value
+        if type_ == DSV_TYPE_SET:
+            commands += _set(env_name, value)
+        elif type_ == DSV_TYPE_SET_IF_UNSET:
+            commands += _set_if_unset(env_name, value)
+        else:
+            assert False
+    elif type_ in (
+        DSV_TYPE_APPEND_NON_DUPLICATE,
+        DSV_TYPE_PREPEND_NON_DUPLICATE,
+        DSV_TYPE_PREPEND_NON_DUPLICATE_IF_EXISTS
+    ):
+        try:
+            env_name_and_values = remainder.split(';')
+        except ValueError:
+            raise RuntimeError(
+                "doesn't contain a semicolon separating the environment name "
+                'from the values')
+        env_name = env_name_and_values[0]
+        values = env_name_and_values[1:]
+        for value in values:
+            if not value:
+                value = prefix
+            elif not os.path.isabs(value):
+                value = os.path.join(prefix, value)
+            if (
+                type_ == DSV_TYPE_PREPEND_NON_DUPLICATE_IF_EXISTS and
+                not os.path.exists(value)
+            ):
+                comment = f'skip extending {env_name} with not existing ' \
+                    f'path: {value}'
+                if _include_comments():
+                    commands.append(
+                        FORMAT_STR_COMMENT_LINE.format_map({'comment': comment}))
+            elif type_ == DSV_TYPE_APPEND_NON_DUPLICATE:
+                commands += _append_unique_value(env_name, value)
+            else:
+                commands += _prepend_unique_value(env_name, value)
+    else:
+        raise RuntimeError(
+            'contains an unknown environment hook type: ' + type_)
+    return commands
+
+
+env_state = {}
+
+
+def _append_unique_value(name, value):
+    global env_state
+    if name not in env_state:
+        if os.environ.get(name):
+            env_state[name] = set(os.environ[name].split(os.pathsep))
+        else:
+            env_state[name] = set()
+    # append even if the variable has not been set yet, in case a shell script sets the
+    # same variable without the knowledge of this Python script.
+    # later _remove_ending_separators() will cleanup any unintentional leading separator
+    extend = FORMAT_STR_USE_ENV_VAR.format_map({'name': name}) + os.pathsep
+    line = FORMAT_STR_SET_ENV_VAR.format_map(
+        {'name': name, 'value': extend + value})
+    if value not in env_state[name]:
+        env_state[name].add(value)
+    else:
+        if not _include_comments():
+            return []
+        line = FORMAT_STR_COMMENT_LINE.format_map({'comment': line})
+    return [line]
+
+
+def _prepend_unique_value(name, value):
+    global env_state
+    if name not in env_state:
+        if os.environ.get(name):
+            env_state[name] = set(os.environ[name].split(os.pathsep))
+        else:
+            env_state[name] = set()
+    # prepend even if the variable has not been set yet, in case a shell script sets the
+    # same variable without the knowledge of this Python script.
+    # later _remove_ending_separators() will cleanup any unintentional trailing separator
+    extend = os.pathsep + FORMAT_STR_USE_ENV_VAR.format_map({'name': name})
+    line = FORMAT_STR_SET_ENV_VAR.format_map(
+        {'name': name, 'value': value + extend})
+    if value not in env_state[name]:
+        env_state[name].add(value)
+    else:
+        if not _include_comments():
+            return []
+        line = FORMAT_STR_COMMENT_LINE.format_map({'comment': line})
+    return [line]
+
+
+# generate commands for removing prepended underscores
+def _remove_ending_separators():
+    # do nothing if the shell extension does not implement the logic
+    if FORMAT_STR_REMOVE_TRAILING_SEPARATOR is None:
+        return []
+
+    global env_state
+    commands = []
+    for name in env_state:
+        # skip variables that already had values before this script started prepending
+        if name in os.environ:
+            continue
+        commands += [
+            FORMAT_STR_REMOVE_LEADING_SEPARATOR.format_map({'name': name}),
+            FORMAT_STR_REMOVE_TRAILING_SEPARATOR.format_map({'name': name})]
+    return commands
+
+
+def _set(name, value):
+    global env_state
+    env_state[name] = value
+    line = FORMAT_STR_SET_ENV_VAR.format_map(
+        {'name': name, 'value': value})
+    return [line]
+
+
+def _set_if_unset(name, value):
+    global env_state
+    line = FORMAT_STR_SET_ENV_VAR.format_map(
+        {'name': name, 'value': value})
+    if env_state.get(name, os.environ.get(name)):
+        line = FORMAT_STR_COMMENT_LINE.format_map({'comment': line})
+    return [line]
+
+
+if __name__ == '__main__':  # pragma: no cover
+    try:
+        rc = main()
+    except RuntimeError as e:
+        print(str(e), file=sys.stderr)
+        rc = 1
+    sys.exit(rc)

--- a/crates/launch-plus-core/src/builder/environment.rs
+++ b/crates/launch-plus-core/src/builder/environment.rs
@@ -1,0 +1,203 @@
+//! Build environment computation: CMAKE_PREFIX_PATH, AMENT_PREFIX_PATH, etc.
+//!
+//! Computes the environment variables needed to build each package given
+//! its already-built dependencies.  The scheduler calls [`build_env_for_package`]
+//! before launching each package build.
+
+use std::collections::HashMap;
+use std::path::Path;
+
+/// Compute the environment variables needed to build a package.
+///
+/// The returned map contains variables that should be **set** (not appended to)
+/// in the child process environment.  The caller should merge these with the
+/// inherited process environment, with these values taking precedence.
+///
+/// # Arguments
+/// * `install_base` - The install root (e.g. `install/`)
+/// * `built_deps` - Names of packages already built and installed under
+///   `install_base/<dep>/`.  Must include only in-set dependencies that have
+///   been successfully built, in dependency order.
+pub fn build_env_for_package(
+    install_base: &Path,
+    built_deps: &[String],
+) -> HashMap<String, String> {
+    let mut env = HashMap::new();
+
+    if built_deps.is_empty() {
+        return env;
+    }
+
+    // Build the prefix paths from built dependencies.
+    // Most-recently-built (deepest dep) goes first so cmake finds the
+    // closest override, matching colcon behavior.
+    let prefixes: Vec<String> = built_deps
+        .iter()
+        .rev()
+        .map(|dep| install_base.join(dep).to_string_lossy().into_owned())
+        .collect();
+
+    // CMAKE_PREFIX_PATH: semicolons on Windows, colons on Unix.
+    // Append existing system CMAKE_PREFIX_PATH.
+    let cmake_prefix = build_path_var(&prefixes, "CMAKE_PREFIX_PATH");
+    env.insert("CMAKE_PREFIX_PATH".to_string(), cmake_prefix);
+
+    // AMENT_PREFIX_PATH
+    let ament_prefix = build_path_var(&prefixes, "AMENT_PREFIX_PATH");
+    env.insert("AMENT_PREFIX_PATH".to_string(), ament_prefix);
+
+    // LD_LIBRARY_PATH: <prefix>/lib for each dep
+    let lib_paths: Vec<String> = built_deps
+        .iter()
+        .rev()
+        .map(|dep| {
+            install_base
+                .join(dep)
+                .join("lib")
+                .to_string_lossy()
+                .into_owned()
+        })
+        .collect();
+    let ld_path = build_path_var(&lib_paths, "LD_LIBRARY_PATH");
+    env.insert("LD_LIBRARY_PATH".to_string(), ld_path);
+
+    // PATH: <prefix>/bin for each dep
+    let bin_paths: Vec<String> = built_deps
+        .iter()
+        .rev()
+        .map(|dep| {
+            install_base
+                .join(dep)
+                .join("bin")
+                .to_string_lossy()
+                .into_owned()
+        })
+        .collect();
+    let path = build_path_var(&bin_paths, "PATH");
+    env.insert("PATH".to_string(), path);
+
+    // PYTHONPATH: <prefix>/lib/python3.*/site-packages for each dep.
+    // We detect the python version from the system.
+    let python_subdir = detect_python_site_packages_subdir();
+    let python_paths: Vec<String> = built_deps
+        .iter()
+        .rev()
+        .map(|dep| {
+            install_base
+                .join(dep)
+                .join(&python_subdir)
+                .to_string_lossy()
+                .into_owned()
+        })
+        .collect();
+    let pythonpath = build_path_var(&python_paths, "PYTHONPATH");
+    env.insert("PYTHONPATH".to_string(), pythonpath);
+
+    env
+}
+
+/// Build a colon-separated path variable by prepending `new_paths` to the
+/// current value of `var_name` from the process environment.
+fn build_path_var(new_paths: &[String], var_name: &str) -> String {
+    let parts: Vec<&str> = new_paths.iter().map(|s| s.as_str()).collect();
+
+    // Append existing value from the process environment.
+    if let Ok(existing) = std::env::var(var_name) {
+        if !existing.is_empty() {
+            // We need to own the string to extend lifetime.
+            // Use a slightly different approach: build the full string.
+            let joined = parts.join(":");
+            return format!("{joined}:{existing}");
+        }
+    }
+
+    parts.join(":")
+}
+
+/// Detect the Python site-packages subdirectory (e.g. `lib/python3.10/site-packages`).
+///
+/// Falls back to `lib/python3/dist-packages` if detection fails.
+fn detect_python_site_packages_subdir() -> String {
+    // Try to detect from the running system.
+    if let Ok(output) = std::process::Command::new("python3")
+        .args(["-c", "import sys; print(f'lib/python{sys.version_info.major}.{sys.version_info.minor}/site-packages')"])
+        .output()
+    {
+        if output.status.success() {
+            let s = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            if !s.is_empty() {
+                return s;
+            }
+        }
+    }
+    // Fallback
+    "lib/python3/dist-packages".to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_build_env_empty_deps() {
+        let tmp = TempDir::new().unwrap();
+        let env = build_env_for_package(tmp.path(), &[]);
+        assert!(env.is_empty());
+    }
+
+    #[test]
+    fn test_build_env_single_dep() {
+        let tmp = TempDir::new().unwrap();
+        let install = tmp.path().join("install");
+        std::fs::create_dir_all(&install).unwrap();
+
+        let deps = vec!["rclcpp".to_string()];
+        let env = build_env_for_package(&install, &deps);
+
+        let cmake = env.get("CMAKE_PREFIX_PATH").unwrap();
+        assert!(cmake.contains("rclcpp"));
+
+        let ament = env.get("AMENT_PREFIX_PATH").unwrap();
+        assert!(ament.contains("rclcpp"));
+
+        let ld = env.get("LD_LIBRARY_PATH").unwrap();
+        assert!(ld.contains("rclcpp/lib"));
+
+        let path = env.get("PATH").unwrap();
+        assert!(path.contains("rclcpp/bin"));
+
+        let pypath = env.get("PYTHONPATH").unwrap();
+        assert!(pypath.contains("rclcpp"));
+    }
+
+    #[test]
+    fn test_build_env_multiple_deps_order() {
+        let tmp = TempDir::new().unwrap();
+        let install = tmp.path().join("install");
+        std::fs::create_dir_all(&install).unwrap();
+
+        // deps are in topo order (dep first, then dependent)
+        let deps = vec!["base".to_string(), "mid".to_string(), "top".to_string()];
+        let env = build_env_for_package(&install, &deps);
+
+        let cmake = env.get("CMAKE_PREFIX_PATH").unwrap();
+        // Most recent (deepest/last in list) should come first in the path
+        let top_pos = cmake.find("top").unwrap();
+        let base_pos = cmake.find("base").unwrap();
+        assert!(
+            top_pos < base_pos,
+            "top should appear before base in CMAKE_PREFIX_PATH"
+        );
+    }
+
+    #[test]
+    fn test_detect_python_site_packages() {
+        let subdir = detect_python_site_packages_subdir();
+        // Should match lib/python3.X/site-packages or fallback
+        assert!(
+            subdir.starts_with("lib/python3"),
+            "unexpected python subdir: {subdir}"
+        );
+    }
+}

--- a/crates/launch-plus-core/src/builder/install.rs
+++ b/crates/launch-plus-core/src/builder/install.rs
@@ -1,0 +1,886 @@
+//! Install layout generation: DSV files, setup scripts, ament_index markers.
+//!
+//! Generates a colcon-compatible isolated install layout under `install/`.
+//! The layout matches what `colcon build --install-base <dir>` produces so that
+//! `source install/setup.bash` works identically.
+
+use std::fs;
+use std::path::Path;
+
+/// Embedded copy of colcon's `_local_setup_util_sh.py`.
+///
+/// This script is written to the install root and invoked by `local_setup.bash`
+/// (and `.sh`, `.zsh`) to topologically sort packages and generate the shell
+/// commands that set up the environment.
+const LOCAL_SETUP_UTIL_SH_PY: &str = include_str!("colcon_local_setup_util_sh.py");
+
+// ---------------------------------------------------------------------------
+// Root-level layout
+// ---------------------------------------------------------------------------
+
+/// Create the root-level install layout files.
+///
+/// These files live directly under `install_base/` and are responsible for
+/// chaining to the parent prefix (e.g. `/opt/ros/humble`) and then sourcing
+/// all per-package environment hooks in topological order.
+///
+/// # Arguments
+/// * `install_base` - The install directory (e.g. `install/`)
+/// * `parent_prefix` - The parent ROS prefix to chain to (e.g. `/opt/ros/humble`).
+///   If `None`, no parent prefix is chained.
+pub fn create_root_layout(install_base: &Path, parent_prefix: Option<&str>) -> crate::Result<()> {
+    fs::create_dir_all(install_base)?;
+
+    // .colcon_install_layout
+    fs::write(install_base.join(".colcon_install_layout"), "isolated\n")?;
+
+    // COLCON_IGNORE (empty marker)
+    fs::write(install_base.join("COLCON_IGNORE"), "")?;
+
+    // _local_setup_util_sh.py
+    fs::write(
+        install_base.join("_local_setup_util_sh.py"),
+        LOCAL_SETUP_UTIL_SH_PY,
+    )?;
+
+    let parent = parent_prefix.unwrap_or("/opt/ros/humble");
+
+    // setup.bash
+    fs::write(install_base.join("setup.bash"), generate_setup_bash(parent))?;
+
+    // setup.sh
+    fs::write(
+        install_base.join("setup.sh"),
+        generate_setup_sh(parent, install_base),
+    )?;
+
+    // setup.zsh
+    fs::write(install_base.join("setup.zsh"), generate_setup_zsh(parent))?;
+
+    // local_setup.bash
+    fs::write(
+        install_base.join("local_setup.bash"),
+        TEMPLATE_LOCAL_SETUP_BASH,
+    )?;
+
+    // local_setup.sh
+    fs::write(
+        install_base.join("local_setup.sh"),
+        generate_local_setup_sh(install_base),
+    )?;
+
+    // local_setup.zsh
+    fs::write(
+        install_base.join("local_setup.zsh"),
+        TEMPLATE_LOCAL_SETUP_ZSH,
+    )?;
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Per-package layout
+// ---------------------------------------------------------------------------
+
+/// Create the install layout metadata for a single package.
+///
+/// This writes the DSV manifest, hook scripts, environment scripts,
+/// ament_index markers, and colcon-core package metadata needed for
+/// `setup.bash` to correctly set up the environment for this package.
+///
+/// # Arguments
+/// * `install_base` - The install root (e.g. `install/`)
+/// * `pkg_name` - The package name
+/// * `runtime_deps` - Runtime dependencies (exec_depend) of this package
+///   that are also in the install set.  Used for the colcon-core metadata
+///   that drives topological ordering in `_local_setup_util_sh.py`.
+/// * `has_library` - Whether the package installs shared libraries into `lib/`.
+///   If true, an `ld_library_path_lib` hook is generated.
+pub fn create_package_install_metadata(
+    install_base: &Path,
+    pkg_name: &str,
+    runtime_deps: &[String],
+    has_library: bool,
+) -> crate::Result<()> {
+    let pkg_dir = install_base.join(pkg_name);
+
+    // share/colcon-core/packages/<pkg>
+    let colcon_core_dir = pkg_dir.join("share/colcon-core/packages");
+    fs::create_dir_all(&colcon_core_dir)?;
+    let deps_str = runtime_deps.join(":");
+    fs::write(colcon_core_dir.join(pkg_name), &deps_str)?;
+
+    // share/ament_index/resource_index/packages/<pkg>
+    let ament_idx_dir = pkg_dir.join("share/ament_index/resource_index/packages");
+    fs::create_dir_all(&ament_idx_dir)?;
+    fs::write(ament_idx_dir.join(pkg_name), "")?;
+
+    // share/<pkg>/hook/
+    let hook_dir = pkg_dir.join("share").join(pkg_name).join("hook");
+    fs::create_dir_all(&hook_dir)?;
+
+    // cmake_prefix_path hook (always present)
+    fs::write(
+        hook_dir.join("cmake_prefix_path.dsv"),
+        "prepend-non-duplicate;CMAKE_PREFIX_PATH;\n",
+    )?;
+    fs::write(
+        hook_dir.join("cmake_prefix_path.sh"),
+        "# generated from launch-plus builder\n\n\
+         _colcon_prepend_unique_value CMAKE_PREFIX_PATH \"$COLCON_CURRENT_PREFIX\"\n",
+    )?;
+
+    // ld_library_path_lib hook (only if the package has libraries)
+    if has_library {
+        fs::write(
+            hook_dir.join("ld_library_path_lib.dsv"),
+            "prepend-non-duplicate;LD_LIBRARY_PATH;lib\n",
+        )?;
+        fs::write(
+            hook_dir.join("ld_library_path_lib.sh"),
+            "# generated from launch-plus builder\n\n\
+             _colcon_prepend_unique_value LD_LIBRARY_PATH \"$COLCON_CURRENT_PREFIX/lib\"\n",
+        )?;
+    }
+
+    // share/<pkg>/environment/
+    let env_dir = pkg_dir.join("share").join(pkg_name).join("environment");
+    fs::create_dir_all(&env_dir)?;
+
+    // ament_prefix_path
+    fs::write(
+        env_dir.join("ament_prefix_path.dsv"),
+        "prepend-non-duplicate;AMENT_PREFIX_PATH;\n",
+    )?;
+    fs::write(
+        env_dir.join("ament_prefix_path.sh"),
+        "# generated from launch-plus builder\n\n\
+         ament_prepend_unique_value AMENT_PREFIX_PATH \"$AMENT_CURRENT_PREFIX\"\n",
+    )?;
+
+    // path
+    fs::write(
+        env_dir.join("path.dsv"),
+        "prepend-non-duplicate-if-exists;PATH;bin\n",
+    )?;
+    fs::write(
+        env_dir.join("path.sh"),
+        "# generated from launch-plus builder\n\n\
+         if [ -d \"$AMENT_CURRENT_PREFIX/bin\" ]; then\n  \
+         ament_prepend_unique_value PATH \"$AMENT_CURRENT_PREFIX/bin\"\nfi\n",
+    )?;
+
+    // share/<pkg>/package.dsv
+    let share_pkg_dir = pkg_dir.join("share").join(pkg_name);
+    let mut dsv_lines = Vec::new();
+    dsv_lines.push(format!(
+        "source;share/{pkg_name}/hook/cmake_prefix_path.dsv"
+    ));
+    dsv_lines.push(format!("source;share/{pkg_name}/hook/cmake_prefix_path.sh"));
+    if has_library {
+        dsv_lines.push(format!(
+            "source;share/{pkg_name}/hook/ld_library_path_lib.dsv"
+        ));
+        dsv_lines.push(format!(
+            "source;share/{pkg_name}/hook/ld_library_path_lib.sh"
+        ));
+    }
+    dsv_lines.push(format!("source;share/{pkg_name}/local_setup.bash"));
+    dsv_lines.push(format!("source;share/{pkg_name}/local_setup.dsv"));
+    dsv_lines.push(format!("source;share/{pkg_name}/local_setup.sh"));
+    dsv_lines.push(format!("source;share/{pkg_name}/local_setup.zsh"));
+    let dsv_content = dsv_lines.join("\n") + "\n";
+    fs::write(share_pkg_dir.join("package.dsv"), &dsv_content)?;
+
+    // share/<pkg>/local_setup.dsv
+    let mut local_dsv = String::new();
+    local_dsv.push_str("source;share/");
+    local_dsv.push_str(pkg_name);
+    local_dsv.push_str("/environment/ament_prefix_path.dsv\n");
+    local_dsv.push_str("source;share/");
+    local_dsv.push_str(pkg_name);
+    local_dsv.push_str("/environment/ament_prefix_path.sh\n");
+    local_dsv.push_str("source;share/");
+    local_dsv.push_str(pkg_name);
+    local_dsv.push_str("/environment/path.dsv\n");
+    local_dsv.push_str("source;share/");
+    local_dsv.push_str(pkg_name);
+    local_dsv.push_str("/environment/path.sh\n");
+    fs::write(share_pkg_dir.join("local_setup.dsv"), &local_dsv)?;
+
+    // share/<pkg>/local_setup.bash
+    fs::write(
+        share_pkg_dir.join("local_setup.bash"),
+        generate_pkg_local_setup_bash(pkg_name),
+    )?;
+
+    // share/<pkg>/local_setup.sh
+    fs::write(
+        share_pkg_dir.join("local_setup.sh"),
+        generate_pkg_local_setup_sh(pkg_name),
+    )?;
+
+    // share/<pkg>/local_setup.zsh
+    fs::write(
+        share_pkg_dir.join("local_setup.zsh"),
+        generate_pkg_local_setup_zsh(pkg_name),
+    )?;
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Template generators — root level
+// ---------------------------------------------------------------------------
+
+fn generate_setup_bash(parent_prefix: &str) -> String {
+    format!(
+        r##"# generated from launch-plus builder
+
+# function to source another script with conditional trace output
+_colcon_prefix_chain_bash_source_script() {{
+  if [ -f "$1" ]; then
+    if [ -n "$COLCON_TRACE" ]; then
+      echo "# . \"$1\""
+    fi
+    . "$1"
+  else
+    echo "not found: \"$1\"" 1>&2
+  fi
+}}
+
+# source chained prefixes
+COLCON_CURRENT_PREFIX="{parent_prefix}"
+_colcon_prefix_chain_bash_source_script "$COLCON_CURRENT_PREFIX/local_setup.bash"
+
+# source this prefix
+COLCON_CURRENT_PREFIX="$(builtin cd "`dirname "${{BASH_SOURCE[0]}}"`" > /dev/null && pwd)"
+_colcon_prefix_chain_bash_source_script "$COLCON_CURRENT_PREFIX/local_setup.bash"
+
+unset COLCON_CURRENT_PREFIX
+unset _colcon_prefix_chain_bash_source_script
+"##
+    )
+}
+
+fn generate_setup_sh(parent_prefix: &str, install_base: &Path) -> String {
+    let install_abs = install_base
+        .canonicalize()
+        .unwrap_or_else(|_| install_base.to_path_buf());
+    format!(
+        r##"# generated from launch-plus builder
+
+_colcon_prefix_chain_sh_COLCON_CURRENT_PREFIX={install_abs}
+if [ ! -z "$COLCON_CURRENT_PREFIX" ]; then
+  _colcon_prefix_chain_sh_COLCON_CURRENT_PREFIX="$COLCON_CURRENT_PREFIX"
+elif [ ! -d "$_colcon_prefix_chain_sh_COLCON_CURRENT_PREFIX" ]; then
+  echo "The build time path \"$_colcon_prefix_chain_sh_COLCON_CURRENT_PREFIX\" doesn't exist. Either source a script for a different shell or set the environment variable \"COLCON_CURRENT_PREFIX\" explicitly." 1>&2
+  unset _colcon_prefix_chain_sh_COLCON_CURRENT_PREFIX
+  return 1
+fi
+
+_colcon_prefix_chain_sh_source_script() {{
+  if [ -f "$1" ]; then
+    if [ -n "$COLCON_TRACE" ]; then
+      echo "# . \"$1\""
+    fi
+    . "$1"
+  else
+    echo "not found: \"$1\"" 1>&2
+  fi
+}}
+
+# source chained prefixes
+COLCON_CURRENT_PREFIX="{parent_prefix}"
+_colcon_prefix_chain_sh_source_script "$COLCON_CURRENT_PREFIX/local_setup.sh"
+
+# source this prefix
+COLCON_CURRENT_PREFIX="$_colcon_prefix_chain_sh_COLCON_CURRENT_PREFIX"
+_colcon_prefix_chain_sh_source_script "$COLCON_CURRENT_PREFIX/local_setup.sh"
+
+unset _colcon_prefix_chain_sh_COLCON_CURRENT_PREFIX
+unset _colcon_prefix_chain_sh_source_script
+unset COLCON_CURRENT_PREFIX
+"##,
+        install_abs = install_abs.display(),
+        parent_prefix = parent_prefix,
+    )
+}
+
+fn generate_setup_zsh(parent_prefix: &str) -> String {
+    format!(
+        r##"# generated from launch-plus builder
+
+_colcon_prefix_chain_zsh_source_script() {{
+  if [ -f "$1" ]; then
+    if [ -n "$COLCON_TRACE" ]; then
+      echo "# . \"$1\""
+    fi
+    . "$1"
+  else
+    echo "not found: \"$1\"" 1>&2
+  fi
+}}
+
+# source chained prefixes
+COLCON_CURRENT_PREFIX="{parent_prefix}"
+_colcon_prefix_chain_zsh_source_script "$COLCON_CURRENT_PREFIX/local_setup.zsh"
+
+# source this prefix
+COLCON_CURRENT_PREFIX="$(builtin cd -q "`dirname "${{(%):-%N}}"`" > /dev/null && pwd)"
+_colcon_prefix_chain_zsh_source_script "$COLCON_CURRENT_PREFIX/local_setup.zsh"
+
+unset COLCON_CURRENT_PREFIX
+unset _colcon_prefix_chain_zsh_source_script
+"##
+    )
+}
+
+fn generate_local_setup_sh(install_base: &Path) -> String {
+    let install_abs = install_base
+        .canonicalize()
+        .unwrap_or_else(|_| install_base.to_path_buf());
+    format!(
+        r##"# generated from launch-plus builder
+
+_colcon_prefix_sh_COLCON_CURRENT_PREFIX="{install_abs}"
+if [ -z "$COLCON_CURRENT_PREFIX" ]; then
+  if [ ! -d "$_colcon_prefix_sh_COLCON_CURRENT_PREFIX" ]; then
+    echo "The build time path \"$_colcon_prefix_sh_COLCON_CURRENT_PREFIX\" doesn't exist. Either source a script for a different shell or set the environment variable \"COLCON_CURRENT_PREFIX\" explicitly." 1>&2
+    unset _colcon_prefix_sh_COLCON_CURRENT_PREFIX
+    return 1
+  fi
+else
+  _colcon_prefix_sh_COLCON_CURRENT_PREFIX="$COLCON_CURRENT_PREFIX"
+fi
+
+_colcon_prefix_sh_prepend_unique_value() {{
+  _listname="$1"
+  _value="$2"
+  eval _values=\"\$$_listname\"
+  _colcon_prefix_sh_prepend_unique_value_IFS="$IFS"
+  IFS=":"
+  _all_values="$_value"
+  _contained_value=""
+  for _item in $_values; do
+    if [ -z "$_item" ]; then continue; fi
+    if [ "$_item" = "$_value" ]; then _contained_value=1; continue; fi
+    _all_values="$_all_values:$_item"
+  done
+  unset _item
+  unset _contained_value
+  IFS="$_colcon_prefix_sh_prepend_unique_value_IFS"
+  unset _colcon_prefix_sh_prepend_unique_value_IFS
+  eval export $_listname=\"$_all_values\"
+  unset _all_values _values _value _listname
+}}
+
+_colcon_prefix_sh_prepend_unique_value COLCON_PREFIX_PATH "$_colcon_prefix_sh_COLCON_CURRENT_PREFIX"
+unset _colcon_prefix_sh_prepend_unique_value
+
+if [ -n "$COLCON_PYTHON_EXECUTABLE" ]; then
+  if [ ! -f "$COLCON_PYTHON_EXECUTABLE" ]; then
+    echo "error: COLCON_PYTHON_EXECUTABLE '$COLCON_PYTHON_EXECUTABLE' doesn't exist"
+    return 1
+  fi
+  _colcon_python_executable="$COLCON_PYTHON_EXECUTABLE"
+else
+  _colcon_python_executable="/usr/bin/python3"
+  if [ ! -f "$_colcon_python_executable" ]; then
+    if ! /usr/bin/env python3 --version > /dev/null 2> /dev/null; then
+      echo "error: unable to find python3 executable"
+      return 1
+    fi
+    _colcon_python_executable=`/usr/bin/env python3 -c "import sys; print(sys.executable)"`
+  fi
+fi
+
+_colcon_prefix_sh_source_script() {{
+  if [ -f "$1" ]; then
+    if [ -n "$COLCON_TRACE" ]; then echo "# . \"$1\""; fi
+    . "$1"
+  else
+    echo "not found: \"$1\"" 1>&2
+  fi
+}}
+
+_colcon_ordered_commands="$($_colcon_python_executable "$_colcon_prefix_sh_COLCON_CURRENT_PREFIX/_local_setup_util_sh.py" sh)"
+unset _colcon_python_executable
+eval "${{_colcon_ordered_commands}}"
+unset _colcon_ordered_commands
+unset _colcon_prefix_sh_source_script
+unset _colcon_prefix_sh_COLCON_CURRENT_PREFIX
+"##,
+        install_abs = install_abs.display()
+    )
+}
+
+/// `local_setup.bash` — can determine its own path, so no hardcoded fallback needed.
+const TEMPLATE_LOCAL_SETUP_BASH: &str = r##"# generated from launch-plus builder
+
+if [ -z "$COLCON_CURRENT_PREFIX" ]; then
+  _colcon_prefix_bash_COLCON_CURRENT_PREFIX="$(builtin cd "`dirname "${BASH_SOURCE[0]}"`" > /dev/null && pwd)"
+else
+  _colcon_prefix_bash_COLCON_CURRENT_PREFIX="$COLCON_CURRENT_PREFIX"
+fi
+
+_colcon_prefix_bash_prepend_unique_value() {
+  _listname="$1"
+  _value="$2"
+  eval _values=\"\$$_listname\"
+  _colcon_prefix_bash_prepend_unique_value_IFS="$IFS"
+  IFS=":"
+  _all_values="$_value"
+  _contained_value=""
+  for _item in $_values; do
+    if [ -z "$_item" ]; then continue; fi
+    if [ "$_item" = "$_value" ]; then _contained_value=1; continue; fi
+    _all_values="$_all_values:$_item"
+  done
+  unset _item _contained_value
+  IFS="$_colcon_prefix_bash_prepend_unique_value_IFS"
+  unset _colcon_prefix_bash_prepend_unique_value_IFS
+  eval export $_listname=\"$_all_values\"
+  unset _all_values _values _value _listname
+}
+
+_colcon_prefix_bash_prepend_unique_value COLCON_PREFIX_PATH "$_colcon_prefix_bash_COLCON_CURRENT_PREFIX"
+unset _colcon_prefix_bash_prepend_unique_value
+
+if [ -n "$COLCON_PYTHON_EXECUTABLE" ]; then
+  if [ ! -f "$COLCON_PYTHON_EXECUTABLE" ]; then
+    echo "error: COLCON_PYTHON_EXECUTABLE '$COLCON_PYTHON_EXECUTABLE' doesn't exist"
+    return 1
+  fi
+  _colcon_python_executable="$COLCON_PYTHON_EXECUTABLE"
+else
+  _colcon_python_executable="/usr/bin/python3"
+  if [ ! -f "$_colcon_python_executable" ]; then
+    if ! /usr/bin/env python3 --version > /dev/null 2> /dev/null; then
+      echo "error: unable to find python3 executable"
+      return 1
+    fi
+    _colcon_python_executable=`/usr/bin/env python3 -c "import sys; print(sys.executable)"`
+  fi
+fi
+
+_colcon_prefix_sh_source_script() {
+  if [ -f "$1" ]; then
+    if [ -n "$COLCON_TRACE" ]; then echo "# . \"$1\""; fi
+    . "$1"
+  else
+    echo "not found: \"$1\"" 1>&2
+  fi
+}
+
+_colcon_ordered_commands="$($_colcon_python_executable "$_colcon_prefix_bash_COLCON_CURRENT_PREFIX/_local_setup_util_sh.py" sh bash)"
+unset _colcon_python_executable
+eval "${_colcon_ordered_commands}"
+unset _colcon_ordered_commands
+unset _colcon_prefix_sh_source_script
+unset _colcon_prefix_bash_COLCON_CURRENT_PREFIX
+"##;
+
+/// `local_setup.zsh` — can determine its own path via zsh-specific syntax.
+const TEMPLATE_LOCAL_SETUP_ZSH: &str = r##"# generated from launch-plus builder
+
+if [ -z "$COLCON_CURRENT_PREFIX" ]; then
+  _colcon_prefix_zsh_COLCON_CURRENT_PREFIX="$(builtin cd -q "`dirname "${(%):-%N}"`" > /dev/null && pwd)"
+else
+  _colcon_prefix_zsh_COLCON_CURRENT_PREFIX="$COLCON_CURRENT_PREFIX"
+fi
+
+_colcon_prefix_zsh_convert_to_array() {
+  local _listname=$1
+  local _dollar="$"
+  local _split="{="
+  local _to_array="(\"$_dollar$_split$_listname}\")"
+  eval $_listname=$_to_array
+}
+
+_colcon_prefix_zsh_prepend_unique_value() {
+  _listname="$1"
+  _value="$2"
+  eval _values=\"\$$_listname\"
+  _colcon_prefix_zsh_prepend_unique_value_IFS="$IFS"
+  IFS=":"
+  _all_values="$_value"
+  _contained_value=""
+  _colcon_prefix_zsh_convert_to_array _values
+  for _item in $_values; do
+    if [ -z "$_item" ]; then continue; fi
+    if [ "$_item" = "$_value" ]; then _contained_value=1; continue; fi
+    _all_values="$_all_values:$_item"
+  done
+  unset _item _contained_value
+  IFS="$_colcon_prefix_zsh_prepend_unique_value_IFS"
+  unset _colcon_prefix_zsh_prepend_unique_value_IFS
+  eval export $_listname=\"$_all_values\"
+  unset _all_values _values _value _listname
+}
+
+_colcon_prefix_zsh_prepend_unique_value COLCON_PREFIX_PATH "$_colcon_prefix_zsh_COLCON_CURRENT_PREFIX"
+unset _colcon_prefix_zsh_prepend_unique_value
+unset _colcon_prefix_zsh_convert_to_array
+
+if [ -n "$COLCON_PYTHON_EXECUTABLE" ]; then
+  if [ ! -f "$COLCON_PYTHON_EXECUTABLE" ]; then
+    echo "error: COLCON_PYTHON_EXECUTABLE '$COLCON_PYTHON_EXECUTABLE' doesn't exist"
+    return 1
+  fi
+  _colcon_python_executable="$COLCON_PYTHON_EXECUTABLE"
+else
+  _colcon_python_executable="/usr/bin/python3"
+  if [ ! -f "$_colcon_python_executable" ]; then
+    if ! /usr/bin/env python3 --version > /dev/null 2> /dev/null; then
+      echo "error: unable to find python3 executable"
+      return 1
+    fi
+    _colcon_python_executable=`/usr/bin/env python3 -c "import sys; print(sys.executable)"`
+  fi
+fi
+
+_colcon_prefix_sh_source_script() {
+  if [ -f "$1" ]; then
+    if [ -n "$COLCON_TRACE" ]; then echo "# . \"$1\""; fi
+    . "$1"
+  else
+    echo "not found: \"$1\"" 1>&2
+  fi
+}
+
+_colcon_ordered_commands="$($_colcon_python_executable "$_colcon_prefix_zsh_COLCON_CURRENT_PREFIX/_local_setup_util_sh.py" sh zsh)"
+unset _colcon_python_executable
+eval "${_colcon_ordered_commands}"
+unset _colcon_ordered_commands
+unset _colcon_prefix_sh_source_script
+unset _colcon_prefix_zsh_COLCON_CURRENT_PREFIX
+"##;
+
+// ---------------------------------------------------------------------------
+// Template generators — per-package level
+// ---------------------------------------------------------------------------
+
+fn generate_pkg_local_setup_bash(_pkg_name: &str) -> String {
+    r##"# generated from launch-plus builder
+
+_this_path=$(builtin cd "`dirname "${BASH_SOURCE[0]}"`" && pwd)
+AMENT_CURRENT_PREFIX=$(builtin cd "`dirname "${{BASH_SOURCE[0]}}"`/../.." && pwd)
+_package_local_setup_AMENT_CURRENT_PREFIX=$AMENT_CURRENT_PREFIX
+
+if [ -n "$AMENT_TRACE_SETUP_FILES" ]; then
+  echo "# . \"$_this_path/local_setup.sh\""
+fi
+. "$_this_path/local_setup.sh"
+unset _this_path
+
+if [ -z "$AMENT_RETURN_ENVIRONMENT_HOOKS" ]; then
+  unset AMENT_ENVIRONMENT_HOOKS
+fi
+
+AMENT_CURRENT_PREFIX=$_package_local_setup_AMENT_CURRENT_PREFIX
+
+if [ -z "$AMENT_RETURN_ENVIRONMENT_HOOKS" ]; then
+  _package_local_setup_IFS=$IFS
+  IFS=":"
+  for _hook in $AMENT_ENVIRONMENT_HOOKS; do
+    AMENT_CURRENT_PREFIX=$_package_local_setup_AMENT_CURRENT_PREFIX
+    IFS=$_package_local_setup_IFS
+    . "$_hook"
+  done
+  unset _hook
+  IFS=$_package_local_setup_IFS
+  unset _package_local_setup_IFS
+  unset AMENT_ENVIRONMENT_HOOKS
+fi
+
+unset _package_local_setup_AMENT_CURRENT_PREFIX
+unset AMENT_CURRENT_PREFIX
+"##
+    .to_string()
+}
+
+fn generate_pkg_local_setup_sh(pkg_name: &str) -> String {
+    format!(
+        r##"# generated from launch-plus builder
+
+: ${{AMENT_CURRENT_PREFIX:="$COLCON_CURRENT_PREFIX/{pkg_name}"}}
+if [ ! -d "$AMENT_CURRENT_PREFIX" ]; then
+  if [ -z "$COLCON_CURRENT_PREFIX" ]; then
+    echo "The compile time prefix path '$AMENT_CURRENT_PREFIX' doesn't " \
+      "exist. Consider sourcing a different extension than '.sh'." 1>&2
+  else
+    AMENT_CURRENT_PREFIX="$COLCON_CURRENT_PREFIX"
+  fi
+fi
+
+ament_append_value() {{
+  _listname="$1"
+  _value="$2"
+  eval _values=\"\$$_listname\"
+  if [ -z "$_values" ]; then
+    eval export $_listname=\"$_value\"
+  else
+    _ament_append_value_IFS=$IFS
+    unset IFS
+    eval export $_listname=\"\$$_listname:$_value\"
+    IFS=$_ament_append_value_IFS
+    unset _ament_append_value_IFS
+  fi
+  unset _values _value _listname
+}}
+
+ament_append_unique_value() {{
+  _listname=$1
+  _value=$2
+  eval _values=\$$_listname
+  _duplicate=
+  _ament_append_unique_value_IFS=$IFS
+  IFS=":"
+  if [ "$AMENT_SHELL" = "zsh" ]; then
+    ament_zsh_to_array _values
+  fi
+  for _item in $_values; do
+    if [ -z "$_item" ]; then continue; fi
+    if [ $_item = $_value ]; then _duplicate=1; fi
+  done
+  unset _item
+  if [ -z "$_duplicate" ]; then
+    if [ -z "$_values" ]; then
+      eval $_listname=\"$_value\"
+    else
+      unset IFS
+      eval $_listname=\"\$$_listname:$_value\"
+    fi
+  fi
+  IFS=$_ament_append_unique_value_IFS
+  unset _ament_append_unique_value_IFS _duplicate _values _value _listname
+}}
+
+ament_prepend_unique_value() {{
+  _listname="$1"
+  _value="$2"
+  eval _values=\"\$$_listname\"
+  _duplicate=
+  _ament_prepend_unique_value_IFS=$IFS
+  IFS=":"
+  if [ "$AMENT_SHELL" = "zsh" ]; then
+    ament_zsh_to_array _values
+  fi
+  for _item in $_values; do
+    if [ -z "$_item" ]; then continue; fi
+    if [ "$_item" = "$_value" ]; then _duplicate=1; fi
+  done
+  unset _item
+  if [ -z "$_duplicate" ]; then
+    if [ -z "$_values" ]; then
+      eval export $_listname=\"$_value\"
+    else
+      unset IFS
+      eval export $_listname=\"$_value:\$$_listname\"
+    fi
+  fi
+  IFS=$_ament_prepend_unique_value_IFS
+  unset _ament_prepend_unique_value_IFS _duplicate _values _value _listname
+}}
+
+if [ -z "$AMENT_RETURN_ENVIRONMENT_HOOKS" ]; then
+  unset AMENT_ENVIRONMENT_HOOKS
+fi
+
+ament_append_value AMENT_ENVIRONMENT_HOOKS "$AMENT_CURRENT_PREFIX/share/{pkg_name}/environment/ament_prefix_path.sh"
+ament_append_value AMENT_ENVIRONMENT_HOOKS "$AMENT_CURRENT_PREFIX/share/{pkg_name}/environment/path.sh"
+
+if [ -z "$AMENT_RETURN_ENVIRONMENT_HOOKS" ]; then
+  _package_local_setup_IFS=$IFS
+  IFS=":"
+  if [ "$AMENT_SHELL" = "zsh" ]; then
+    ament_zsh_to_array AMENT_ENVIRONMENT_HOOKS
+  fi
+  for _hook in $AMENT_ENVIRONMENT_HOOKS; do
+    if [ -f "$_hook" ]; then
+      IFS=$_package_local_setup_IFS
+      if [ -n "$AMENT_TRACE_SETUP_FILES" ]; then
+        echo "# . \"$_hook\""
+      fi
+      . "$_hook"
+    fi
+  done
+  unset _hook
+  IFS=$_package_local_setup_IFS
+  unset _package_local_setup_IFS
+  unset AMENT_ENVIRONMENT_HOOKS
+fi
+
+unset AMENT_CURRENT_PREFIX
+"##
+    )
+}
+
+fn generate_pkg_local_setup_zsh(_pkg_name: &str) -> String {
+    r##"# generated from launch-plus builder
+
+AMENT_SHELL=zsh
+
+_this_path=$(builtin cd -q "`dirname "${(%):-%N}"`" > /dev/null && pwd)
+AMENT_CURRENT_PREFIX=$(builtin cd -q "`dirname "${(%):-%N}"`/../.." > /dev/null && pwd)
+_package_local_setup_AMENT_CURRENT_PREFIX=$AMENT_CURRENT_PREFIX
+
+ament_zsh_to_array() {
+  local _listname=$1
+  local _dollar="$"
+  local _split="{="
+  local _to_array="(\"$_dollar$_split$_listname}\")"
+  eval $_listname=$_to_array
+}
+
+if [ -n "$AMENT_TRACE_SETUP_FILES" ]; then
+  echo "# . \"$_this_path/local_setup.sh\""
+fi
+. "$_this_path/local_setup.sh"
+unset _this_path
+
+if [ -z "$AMENT_RETURN_ENVIRONMENT_HOOKS" ]; then
+  unset AMENT_ENVIRONMENT_HOOKS
+fi
+
+AMENT_CURRENT_PREFIX=$_package_local_setup_AMENT_CURRENT_PREFIX
+
+if [ -z "$AMENT_RETURN_ENVIRONMENT_HOOKS" ]; then
+  _package_local_setup_IFS=$IFS
+  IFS=":"
+  for _hook in $AMENT_ENVIRONMENT_HOOKS; do
+    AMENT_CURRENT_PREFIX=$_package_local_setup_AMENT_CURRENT_PREFIX
+    IFS=$_package_local_setup_IFS
+    . "$_hook"
+  done
+  unset _hook
+  IFS=$_package_local_setup_IFS
+  unset _package_local_setup_IFS
+  unset AMENT_ENVIRONMENT_HOOKS
+fi
+
+unset _package_local_setup_AMENT_CURRENT_PREFIX
+unset AMENT_CURRENT_PREFIX
+"##
+    .to_string()
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_create_root_layout() {
+        let tmp = TempDir::new().unwrap();
+        let install = tmp.path().join("install");
+        create_root_layout(&install, Some("/opt/ros/humble")).unwrap();
+
+        // Check layout marker
+        let layout = fs::read_to_string(install.join(".colcon_install_layout")).unwrap();
+        assert_eq!(layout.trim(), "isolated");
+
+        // Check COLCON_IGNORE exists
+        assert!(install.join("COLCON_IGNORE").exists());
+
+        // Check all setup scripts exist
+        assert!(install.join("setup.bash").exists());
+        assert!(install.join("setup.sh").exists());
+        assert!(install.join("setup.zsh").exists());
+        assert!(install.join("local_setup.bash").exists());
+        assert!(install.join("local_setup.sh").exists());
+        assert!(install.join("local_setup.zsh").exists());
+        assert!(install.join("_local_setup_util_sh.py").exists());
+
+        // Check parent prefix is referenced in setup.bash
+        let setup_bash = fs::read_to_string(install.join("setup.bash")).unwrap();
+        assert!(setup_bash.contains("/opt/ros/humble"));
+    }
+
+    #[test]
+    fn test_create_package_install_metadata() {
+        let tmp = TempDir::new().unwrap();
+        let install = tmp.path().join("install");
+        fs::create_dir_all(&install).unwrap();
+
+        let deps = vec!["rclcpp".to_string(), "std_msgs".to_string()];
+        create_package_install_metadata(&install, "my_pkg", &deps, true).unwrap();
+
+        let pkg_dir = install.join("my_pkg");
+
+        // colcon-core deps
+        let deps_file =
+            fs::read_to_string(pkg_dir.join("share/colcon-core/packages/my_pkg")).unwrap();
+        assert_eq!(deps_file, "rclcpp:std_msgs");
+
+        // ament_index marker
+        assert!(
+            pkg_dir
+                .join("share/ament_index/resource_index/packages/my_pkg")
+                .exists()
+        );
+
+        // cmake_prefix_path hook
+        let cmake_dsv =
+            fs::read_to_string(pkg_dir.join("share/my_pkg/hook/cmake_prefix_path.dsv")).unwrap();
+        assert!(cmake_dsv.contains("prepend-non-duplicate;CMAKE_PREFIX_PATH;"));
+
+        // ld_library_path hook (has_library=true)
+        assert!(
+            pkg_dir
+                .join("share/my_pkg/hook/ld_library_path_lib.dsv")
+                .exists()
+        );
+
+        // environment hooks
+        assert!(
+            pkg_dir
+                .join("share/my_pkg/environment/ament_prefix_path.dsv")
+                .exists()
+        );
+        assert!(pkg_dir.join("share/my_pkg/environment/path.dsv").exists());
+
+        // package.dsv
+        let pkg_dsv = fs::read_to_string(pkg_dir.join("share/my_pkg/package.dsv")).unwrap();
+        assert!(pkg_dsv.contains("source;share/my_pkg/hook/cmake_prefix_path.dsv"));
+        assert!(pkg_dsv.contains("source;share/my_pkg/hook/ld_library_path_lib.dsv"));
+        assert!(pkg_dsv.contains("source;share/my_pkg/local_setup.bash"));
+
+        // local_setup scripts
+        assert!(pkg_dir.join("share/my_pkg/local_setup.bash").exists());
+        assert!(pkg_dir.join("share/my_pkg/local_setup.sh").exists());
+        assert!(pkg_dir.join("share/my_pkg/local_setup.zsh").exists());
+        assert!(pkg_dir.join("share/my_pkg/local_setup.dsv").exists());
+
+        // local_setup.sh references this package
+        let local_sh = fs::read_to_string(pkg_dir.join("share/my_pkg/local_setup.sh")).unwrap();
+        assert!(local_sh.contains("my_pkg/environment/ament_prefix_path.sh"));
+    }
+
+    #[test]
+    fn test_no_ld_library_path_when_no_library() {
+        let tmp = TempDir::new().unwrap();
+        let install = tmp.path().join("install");
+        fs::create_dir_all(&install).unwrap();
+
+        create_package_install_metadata(&install, "pure_py_pkg", &[], false).unwrap();
+
+        let pkg_dir = install.join("pure_py_pkg");
+
+        // ld_library_path hook should NOT exist
+        assert!(
+            !pkg_dir
+                .join("share/pure_py_pkg/hook/ld_library_path_lib.dsv")
+                .exists()
+        );
+
+        // package.dsv should not reference it
+        let pkg_dsv = fs::read_to_string(pkg_dir.join("share/pure_py_pkg/package.dsv")).unwrap();
+        assert!(!pkg_dsv.contains("ld_library_path"));
+    }
+}

--- a/crates/launch-plus-core/src/builder/mod.rs
+++ b/crates/launch-plus-core/src/builder/mod.rs
@@ -1,4 +1,4 @@
-//! Builder: compute a selective colcon build plan from a resolved launch target.
+//! Builder: compute a selective build plan and execute it for a resolved launch target.
 //!
 //! # Model
 //!
@@ -12,14 +12,21 @@
 //!    `exec_depend` is intentionally excluded: launch-plus tracks runtime deps through the
 //!    launch graph itself, making `exec_depend` redundant for this workflow.
 //! 3. [`compute_build_order`] — Kahn's topological sort so dependencies are built first.
-//! 4. `colcon build --packages-select <ordered list>` — exact list, not `--packages-up-to`,
-//!    so colcon's native dep resolver is bypassed entirely.
+//! 4. Direct `cmake`/`make` (ament_cmake) or `setuptools` (ament_python) invocations per
+//!    package, scheduled in parallel via a greedy worker pool.
 //!
 //! Transitive build dependencies that are not yet on disk are fetched iteratively:
 //! each round expands the dep graph, fetches missing packages, and repeats until
 //! no new packages appear.
 //!
-//! For `test` mode, [`DependencyMode::All`] adds `test_depend` packages to the build set.
+//! For `test` mode, [`DependencyMode::BuildAndTest`] adds `test_depend` packages
+//! to the build set.
+
+pub mod ament_cmake;
+pub mod ament_python;
+pub mod environment;
+pub mod install;
+pub mod scheduler;
 
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
@@ -32,7 +39,7 @@ static INTERRUPTED: AtomicBool = AtomicBool::new(false);
 use crate::fetcher::{FetchOptions, fetch_packages};
 use crate::indexer::{DependencyMode, Lockfile, compute_build_order, resolve_dependencies};
 
-/// Everything colcon needs to build the launch target.
+/// Everything needed to build the launch target.
 #[derive(Debug, Clone)]
 pub struct BuildPlan {
     /// Lockfile packages to build, in topological order (dependencies first).
@@ -43,27 +50,49 @@ pub struct BuildPlan {
     /// but are not part of the lockfile.  They must be installed via `rosdep` or
     /// `apt` before building.
     pub external_deps: HashSet<String>,
-    /// Source directory passed to `colcon build --base-paths`.
+    /// Source directory containing fetched repositories.
     pub src_dir: PathBuf,
-    /// Colcon build output directory (`--build-base`).
+    /// Build output directory (per-package build artifacts).
     pub build_base: PathBuf,
-    /// Colcon install prefix (`--install-base`).
+    /// Install prefix (per-package install trees).
     pub install_base: PathBuf,
-    /// Colcon log directory (`--log-base`).
+    /// Log directory.
     pub log_base: PathBuf,
 }
 
 /// Options controlling how the build is executed.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct BuildOptions {
-    /// Print the colcon command without running it.
+    /// Print the build commands without running them.
     pub dry_run: bool,
-    /// Extra arguments inserted into `colcon build` before `--packages-select`.
-    ///
-    /// Typically loaded from a flagfile (one token per line).  Any colcon flag is
-    /// accepted: `--symlink-install`, `--parallel-workers 8`, `--cmake-args
-    /// -DCMAKE_BUILD_TYPE=Release`, `--allow-overriding pkg`, etc.
-    pub extra_colcon_args: Vec<String>,
+    /// Maximum number of parallel build workers.
+    pub parallel_workers: usize,
+    /// Extra arguments passed to cmake (e.g. `-DCMAKE_BUILD_TYPE=Release`).
+    pub cmake_args: Vec<String>,
+    /// Extra arguments passed to make.
+    pub make_args: Vec<String>,
+    /// Use symlink install instead of copying files.
+    pub symlink_install: bool,
+    /// Continue building independent packages after a failure.
+    pub continue_on_error: bool,
+    /// Test mode: sets `BUILD_TESTING=ON` and uses `BuildAndTest` dep mode.
+    pub test_mode: bool,
+}
+
+impl Default for BuildOptions {
+    fn default() -> Self {
+        Self {
+            dry_run: false,
+            parallel_workers: std::thread::available_parallelism()
+                .map(|n| n.get())
+                .unwrap_or(4),
+            cmake_args: Vec::new(),
+            make_args: Vec::new(),
+            symlink_install: false,
+            continue_on_error: false,
+            test_mode: false,
+        }
+    }
 }
 
 /// Compute a build plan from explicit seed packages, fetching transitive deps as needed.
@@ -71,16 +100,6 @@ pub struct BuildOptions {
 /// Expands transitively by reading on-disk `package.xml`.  Packages whose
 /// `package.xml` is not yet on disk are fetched, and the expansion is retried
 /// until the graph stabilises (up to 10 rounds).
-///
-/// # Why `BuildAndExec` instead of `Build`
-///
-/// Ideally only `Build` deps would be needed here, since `exec_depend` packages
-/// are not required for compilation.  However, colcon's ament_cmake task validates
-/// that **all** `package.xml` dependencies (including `exec_depend`) have install
-/// artifacts before running cmake.  There is no flag to disable this check.
-///
-/// TODO(milestone): replace colcon with direct cmake invocations so that only
-/// true build dependencies need to be compiled.
 pub fn plan_build_from_packages(
     seed_packages: &std::collections::HashSet<String>,
     lockfile: &Lockfile,
@@ -91,12 +110,10 @@ pub fn plan_build_from_packages(
     fetch_options: &FetchOptions,
     test_mode: bool,
 ) -> crate::Result<BuildPlan> {
-    // TODO: switch to DependencyMode::Build once we replace colcon with direct
-    // cmake invocations (colcon forces exec_depend validation at install time).
     let mode = if test_mode {
-        DependencyMode::All
+        DependencyMode::BuildAndTest
     } else {
-        DependencyMode::BuildAndExec
+        DependencyMode::Build
     };
 
     // Iterative expand+fetch: each round may discover new packages whose
@@ -134,7 +151,12 @@ pub fn plan_build_from_packages(
     })
 }
 
-/// Execute `colcon build --packages-select <packages>`.
+/// Execute the build plan using colcon as a subprocess.
+///
+/// This is the legacy colcon-based executor, retained as a fallback during
+/// the transition to the native builder backend. Once the native backend
+/// (ament_cmake, ament_python, scheduler) is complete, this function will
+/// be replaced.
 ///
 /// When `options.dry_run` is true, prints the command to stdout without running it.
 #[allow(unsafe_code)]
@@ -160,7 +182,17 @@ pub fn execute_build(plan: &BuildPlan, options: &BuildOptions) -> crate::Result<
     args.push("--install-base".to_string());
     args.push(plan.install_base.to_string_lossy().into_owned());
 
-    args.extend(options.extra_colcon_args.iter().cloned());
+    // Map new BuildOptions fields to colcon args for the legacy path.
+    if options.symlink_install {
+        args.push("--symlink-install".to_string());
+    }
+    if options.continue_on_error {
+        args.push("--continue-on-error".to_string());
+    }
+    if !options.cmake_args.is_empty() {
+        args.push("--cmake-args".to_string());
+        args.extend(options.cmake_args.iter().cloned());
+    }
 
     args.push("--packages-select".to_string());
     args.extend(plan.packages.iter().cloned());
@@ -205,9 +237,7 @@ pub fn execute_build(plan: &BuildPlan, options: &BuildOptions) -> crate::Result<
 
     if INTERRUPTED.load(Ordering::SeqCst) {
         // Child was killed by our forwarded signal; propagate as an error.
-        return Err(crate::Error::ProcessExecution(
-            "build interrupted by Ctrl+C".to_string(),
-        ));
+        return Err(crate::Error::BuildInterrupted);
     }
 
     if !status.success() {

--- a/crates/launch-plus-core/src/builder/mod.rs
+++ b/crates/launch-plus-core/src/builder/mod.rs
@@ -213,7 +213,16 @@ pub fn execute_build(
         pkg_deps.insert(pkg.clone(), deps);
     }
 
-    // 3. Create timestamped log directory with `latest` symlink.
+    // 3. Resolve per-package source directories from lockfile.
+    let mut pkg_src_dirs: HashMap<String, PathBuf> = HashMap::new();
+    for pkg in &plan.packages {
+        if let Some(pkg_lock) = lockfile.packages.get(pkg) {
+            let src = plan.src_dir.join(&pkg_lock.repo).join(&pkg_lock.path);
+            pkg_src_dirs.insert(pkg.clone(), src);
+        }
+    }
+
+    // 4. Create timestamped log directory with `latest` symlink.
     let timestamp = chrono_timestamp();
     let log_dir = plan.log_base.join(&timestamp);
     std::fs::create_dir_all(&log_dir)?;
@@ -246,8 +255,14 @@ pub fn execute_build(
         )
     };
 
-    let result =
-        scheduler::run_parallel_build(&plan, options, &build_types, &pkg_deps, &INTERRUPTED)?;
+    let result = scheduler::run_parallel_build(
+        &plan,
+        options,
+        &build_types,
+        &pkg_deps,
+        &pkg_src_dirs,
+        &INTERRUPTED,
+    )?;
 
     #[cfg(unix)]
     unsafe {

--- a/crates/launch-plus-core/src/builder/mod.rs
+++ b/crates/launch-plus-core/src/builder/mod.rs
@@ -28,16 +28,18 @@ pub mod environment;
 pub mod install;
 pub mod scheduler;
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
-use std::process::Command;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 /// Flag set by the SIGINT handler so the builder knows the child was interrupted.
 static INTERRUPTED: AtomicBool = AtomicBool::new(false);
 
 use crate::fetcher::{FetchOptions, fetch_packages};
-use crate::indexer::{DependencyMode, Lockfile, compute_build_order, resolve_dependencies};
+use crate::indexer::{
+    DependencyMode, Lockfile, compute_build_order, read_package_build_type, read_package_deps,
+    resolve_dependencies,
+};
 
 /// Everything needed to build the launch target.
 #[derive(Debug, Clone)]
@@ -151,72 +153,91 @@ pub fn plan_build_from_packages(
     })
 }
 
-/// Execute the build plan using colcon as a subprocess.
+/// Execute the build plan using the native builder backend.
 ///
-/// This is the legacy colcon-based executor, retained as a fallback during
-/// the transition to the native builder backend. Once the native backend
-/// (ament_cmake, ament_python, scheduler) is complete, this function will
-/// be replaced.
+/// Steps:
+/// 1. Determine build type for each package (ament_cmake or ament_python)
+/// 2. Validate: reject unsupported build types
+/// 3. Create timestamped log directory with `latest` symlink
+/// 4. Create root install layout (setup.bash, setup.sh, setup.zsh, etc.)
+/// 5. Run the parallel scheduler
+/// 6. Create per-package install metadata for successfully built packages
 ///
-/// When `options.dry_run` is true, prints the command to stdout without running it.
+/// When `options.dry_run` is true, prints the build commands without executing.
 #[allow(unsafe_code)]
-pub fn execute_build(plan: &BuildPlan, options: &BuildOptions) -> crate::Result<()> {
+pub fn execute_build(
+    plan: &BuildPlan,
+    options: &BuildOptions,
+    lockfile: &Lockfile,
+) -> crate::Result<()> {
     if plan.packages.is_empty() {
         tracing::info!("No packages to build.");
         return Ok(());
     }
 
-    // --log-base is a colcon global argument (before the verb).
-    let mut args: Vec<String> = vec![
-        "--log-base".to_string(),
-        plan.log_base.to_string_lossy().into_owned(),
-        "build".to_string(),
-    ];
-
-    args.push("--base-paths".to_string());
-    args.push(plan.src_dir.to_string_lossy().into_owned());
-
-    args.push("--build-base".to_string());
-    args.push(plan.build_base.to_string_lossy().into_owned());
-
-    args.push("--install-base".to_string());
-    args.push(plan.install_base.to_string_lossy().into_owned());
-
-    // Map new BuildOptions fields to colcon args for the legacy path.
-    if options.symlink_install {
-        args.push("--symlink-install".to_string());
-    }
-    if options.continue_on_error {
-        args.push("--continue-on-error".to_string());
-    }
-    if !options.cmake_args.is_empty() {
-        args.push("--cmake-args".to_string());
-        args.extend(options.cmake_args.iter().cloned());
+    // 1. Determine build type for each package.
+    let mut build_types: HashMap<String, scheduler::BuildType> = HashMap::new();
+    for pkg in &plan.packages {
+        let bt = match read_package_build_type(lockfile, &plan.src_dir, pkg) {
+            Some(ref s) if s == "ament_python" => scheduler::BuildType::AmentPython,
+            Some(ref s) if s == "ament_cmake" => scheduler::BuildType::AmentCmake,
+            None => scheduler::BuildType::AmentCmake, // default
+            Some(other) => {
+                return Err(crate::Error::UnsupportedBuildType {
+                    package: pkg.clone(),
+                    build_type: other,
+                });
+            }
+        };
+        build_types.insert(pkg.clone(), bt);
     }
 
-    args.push("--packages-select".to_string());
-    args.extend(plan.packages.iter().cloned());
-
-    let cmd_str = format!("colcon {}", args.join(" "));
-
-    if options.dry_run {
-        println!("{cmd_str}");
-        return Ok(());
+    // 2. Build per-package dependency sets (in-set build deps only).
+    let mut pkg_deps: HashMap<String, HashSet<String>> = HashMap::new();
+    let pkg_set: HashSet<&String> = plan.packages.iter().collect();
+    for pkg in &plan.packages {
+        let mut deps = HashSet::new();
+        if let Some(d) = read_package_deps(lockfile, &plan.src_dir, pkg) {
+            for dep_name in d
+                .build
+                .iter()
+                .chain(d.build_export.iter())
+                .chain(d.buildtool.iter())
+                .chain(d.buildtool_export.iter())
+            {
+                if pkg_set.contains(dep_name) {
+                    deps.insert(dep_name.clone());
+                }
+            }
+        }
+        pkg_deps.insert(pkg.clone(), deps);
     }
 
-    tracing::info!("{cmd_str}");
+    // 3. Create timestamped log directory with `latest` symlink.
+    let timestamp = chrono_timestamp();
+    let log_dir = plan.log_base.join(&timestamp);
+    std::fs::create_dir_all(&log_dir)?;
+    let latest_link = plan.log_base.join("latest");
+    // Remove existing symlink and create new one.
+    #[cfg(unix)]
+    {
+        let _ = std::fs::remove_file(&latest_link);
+        let _ = std::os::unix::fs::symlink(&timestamp, &latest_link);
+    }
 
-    // Spawn colcon as a child process and forward SIGINT so a single Ctrl+C
-    // terminates both colcon and the builder.
-    let mut child = Command::new("colcon")
-        .args(&args)
-        .spawn()
-        .map_err(|e| crate::Error::ProcessExecution(format!("failed to run colcon: {e}")))?;
+    // Use the timestamped log dir for this build.
+    let mut plan = plan.clone();
+    plan.log_base = log_dir;
 
+    // 4. Create root install layout.
+    let parent_prefix = std::env::var("COLCON_PREFIX_PATH")
+        .or_else(|_| std::env::var("AMENT_PREFIX_PATH"))
+        .ok();
+    install::create_root_layout(&plan.install_base, parent_prefix.as_deref())?;
+
+    // 5. Install SIGINT handler and run scheduler.
     INTERRUPTED.store(false, Ordering::SeqCst);
 
-    // Install a SIGINT handler that sets the flag instead of killing our process.
-    // The default SIGINT behaviour is restored after the child exits.
     #[cfg(unix)]
     let prev_handler = unsafe {
         libc::signal(
@@ -225,37 +246,109 @@ pub fn execute_build(plan: &BuildPlan, options: &BuildOptions) -> crate::Result<
         )
     };
 
-    let status = child
-        .wait()
-        .map_err(|e| crate::Error::ProcessExecution(format!("failed to wait for colcon: {e}")))?;
+    let result =
+        scheduler::run_parallel_build(&plan, options, &build_types, &pkg_deps, &INTERRUPTED)?;
 
-    // Restore previous signal handler.
     #[cfg(unix)]
     unsafe {
         libc::signal(libc::SIGINT, prev_handler);
     }
 
-    if INTERRUPTED.load(Ordering::SeqCst) {
-        // Child was killed by our forwarded signal; propagate as an error.
-        return Err(crate::Error::BuildInterrupted);
+    // 6. Create per-package install metadata for successfully built packages.
+    for pkg in &result.completed {
+        // Read runtime deps (exec_depend) for the colcon metadata files.
+        let runtime_deps: Vec<String> =
+            if let Some(d) = read_package_deps(lockfile, &plan.src_dir, pkg) {
+                d.exec
+            } else {
+                vec![]
+            };
+        let has_library = plan.install_base.join(pkg).join("lib").join(pkg).exists()
+            || plan.install_base.join(pkg).join("lib").is_dir();
+        install::create_package_install_metadata(
+            &plan.install_base.join(pkg),
+            pkg,
+            &runtime_deps,
+            has_library,
+        )?;
     }
 
-    if !status.success() {
-        return Err(crate::Error::ProcessExecution(format!(
-            "colcon build failed with status: {status}"
-        )));
+    // 7. Report results.
+    if result.is_success() {
+        eprintln!(
+            "\nBuild complete: {} packages built successfully.",
+            result.completed.len()
+        );
+        Ok(())
+    } else {
+        let failed_names: Vec<&str> = result.failed.iter().map(|(n, _)| n.as_str()).collect();
+        Err(crate::Error::BuildFailed {
+            package: failed_names.join(", "),
+            detail: format!(
+                "{} succeeded, {} failed",
+                result.completed.len(),
+                result.failed.len()
+            ),
+        })
     }
-    Ok(())
+}
+
+/// Generate an ISO-8601 timestamp string for log directory naming.
+fn chrono_timestamp() -> String {
+    use std::time::SystemTime;
+    let now = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap_or_default();
+    let secs = now.as_secs();
+    // Simple formatting without chrono dependency.
+    // Format: YYYY-MM-DD_HH-MM-SS
+    let days = secs / 86400;
+    let time_of_day = secs % 86400;
+    let hours = time_of_day / 3600;
+    let minutes = (time_of_day % 3600) / 60;
+    let seconds = time_of_day % 60;
+
+    // Approximate date calculation (good enough for log dirs).
+    let mut year = 1970i64;
+    #[allow(clippy::cast_possible_wrap)]
+    let mut remaining_days = days as i64;
+    loop {
+        let days_in_year = if is_leap_year(year) { 366 } else { 365 };
+        if remaining_days < days_in_year {
+            break;
+        }
+        remaining_days -= days_in_year;
+        year += 1;
+    }
+    let month_days = if is_leap_year(year) {
+        [31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+    } else {
+        [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+    };
+    let mut month = 1;
+    for &md in &month_days {
+        if remaining_days < md {
+            break;
+        }
+        remaining_days -= md;
+        month += 1;
+    }
+    let day = remaining_days + 1;
+
+    format!("{year:04}-{month:02}-{day:02}_{hours:02}-{minutes:02}-{seconds:02}")
+}
+
+fn is_leap_year(year: i64) -> bool {
+    (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
 }
 
 /// Signal-safe SIGINT handler: sets the INTERRUPTED flag.
 ///
-/// The child process (colcon) is in the same process group and receives SIGINT
-/// directly from the terminal.  This handler prevents our process from being
-/// killed before we can clean up.
+/// Child processes in the same process group receive SIGINT directly from
+/// the terminal.  This handler prevents our process from being killed
+/// before we can clean up.
 #[cfg(unix)]
+#[allow(unsafe_code)]
 extern "C" fn sigint_handler(_sig: libc::c_int) {
-    use std::sync::atomic::Ordering;
-    // AtomicBool::store is signal-safe.
     INTERRUPTED.store(true, Ordering::SeqCst);
 }

--- a/crates/launch-plus-core/src/builder/mod.rs
+++ b/crates/launch-plus-core/src/builder/mod.rs
@@ -175,6 +175,25 @@ pub fn execute_build(
         return Ok(());
     }
 
+    // 0. Absolutize all plan paths — build tools run in per-package build dirs,
+    //    so relative paths would resolve incorrectly.
+    let cwd = std::env::current_dir().unwrap_or_default();
+    let abs = |p: &Path| -> PathBuf {
+        if p.is_absolute() {
+            p.to_path_buf()
+        } else {
+            cwd.join(p)
+        }
+    };
+    let plan = &BuildPlan {
+        packages: plan.packages.clone(),
+        external_deps: plan.external_deps.clone(),
+        src_dir: abs(&plan.src_dir),
+        build_base: abs(&plan.build_base),
+        install_base: abs(&plan.install_base),
+        log_base: abs(&plan.log_base),
+    };
+
     // 1. Determine build type for each package.
     let mut build_types: HashMap<String, scheduler::BuildType> = HashMap::new();
     for pkg in &plan.packages {

--- a/crates/launch-plus-core/src/builder/mod.rs
+++ b/crates/launch-plus-core/src/builder/mod.rs
@@ -290,10 +290,17 @@ pub fn execute_build(
 
     // 7. Report results.
     if result.is_success() {
-        eprintln!(
-            "\nBuild complete: {} packages built successfully.",
-            result.completed.len()
-        );
+        if options.dry_run {
+            eprintln!(
+                "\nDry run complete: {} packages would be built.",
+                result.completed.len()
+            );
+        } else {
+            eprintln!(
+                "\nBuild complete: {} packages built successfully.",
+                result.completed.len()
+            );
+        }
         Ok(())
     } else {
         let failed_names: Vec<&str> = result.failed.iter().map(|(n, _)| n.as_str()).collect();

--- a/crates/launch-plus-core/src/builder/scheduler.rs
+++ b/crates/launch-plus-core/src/builder/scheduler.rs
@@ -77,12 +77,14 @@ impl BuildResult {
 /// * `options` - Build options
 /// * `build_types` - Map of package name → build type
 /// * `pkg_deps` - Map of package name → set of in-set build dependencies
+/// * `pkg_src_dirs` - Map of package name → source directory path
 /// * `interrupted` - Global SIGINT flag
 pub fn run_parallel_build(
     plan: &BuildPlan,
     options: &BuildOptions,
     build_types: &HashMap<String, BuildType>,
     pkg_deps: &HashMap<String, HashSet<String>>,
+    pkg_src_dirs: &HashMap<String, std::path::PathBuf>,
     interrupted: &'static AtomicBool,
 ) -> crate::Result<BuildResult> {
     if plan.packages.is_empty() {
@@ -163,6 +165,7 @@ pub fn run_parallel_build(
                     cvar,
                     opts_ref,
                     plan,
+                    pkg_src_dirs,
                     interrupted,
                     options.continue_on_error,
                 );
@@ -183,6 +186,7 @@ fn worker_loop(
     cvar: &Condvar,
     opts_ref: &BuildOptionsRef,
     plan: &BuildPlan,
+    pkg_src_dirs: &HashMap<String, std::path::PathBuf>,
     interrupted: &'static AtomicBool,
     continue_on_error: bool,
 ) {
@@ -217,7 +221,10 @@ fn worker_loop(
 
         let ctx = PackageBuildContext {
             pkg_name: pkg_name.clone(),
-            src_dir: find_package_dir(&plan.src_dir, &pkg_name),
+            src_dir: pkg_src_dirs
+                .get(&pkg_name)
+                .cloned()
+                .unwrap_or_else(|| find_package_dir(&plan.src_dir, &pkg_name)),
             build_dir: plan.build_base.join(&pkg_name),
             install_dir: plan.install_base.join(&pkg_name),
             log_dir: plan.log_base.join(&pkg_name),
@@ -376,6 +383,7 @@ mod tests {
         let result = run_parallel_build(
             &plan,
             &options,
+            &HashMap::new(),
             &HashMap::new(),
             &HashMap::new(),
             &INTERRUPTED,

--- a/crates/launch-plus-core/src/builder/scheduler.rs
+++ b/crates/launch-plus-core/src/builder/scheduler.rs
@@ -51,7 +51,9 @@ struct SchedulerState {
     nodes: HashMap<String, PackageNode>,
     /// Total package count (for progress display).
     total: usize,
-    /// Counter for progress display.
+    /// Counter for "started" progress display.
+    started_count: usize,
+    /// Counter for "finished" progress display.
     finished_count: usize,
 }
 
@@ -145,6 +147,7 @@ pub fn run_parallel_build(
         poisoned: false,
         nodes,
         total,
+        started_count: 0,
         finished_count: 0,
     });
     let cvar = Condvar::new();
@@ -194,7 +197,7 @@ fn worker_loop(
 ) {
     loop {
         // === Pick next package ===
-        let (pkg_name, build_type, built_deps) = {
+        let (pkg_name, build_type, built_deps, seq) = {
             let mut guard = state.lock().unwrap();
 
             // Wait until there's work or we should exit.
@@ -206,7 +209,9 @@ fn worker_loop(
                     let bt = guard.nodes[&pkg].build_type;
                     let deps = guard.completed.clone();
                     guard.in_progress.insert(pkg.clone());
-                    break (pkg, bt, deps);
+                    guard.started_count += 1;
+                    let seq = guard.started_count;
+                    break (pkg, bt, deps, seq);
                 }
                 // No work available — check if we're done.
                 if guard.in_progress.is_empty() {
@@ -237,11 +242,10 @@ fn worker_loop(
 
         // Progress: starting.
         if !dry_run {
-            let guard = state.lock().unwrap();
             eprintln!(
                 "[{}/{}] Building {} ({})",
-                guard.finished_count + guard.in_progress.len(),
-                guard.total,
+                seq,
+                plan.packages.len(),
                 pkg_name,
                 match build_type {
                     BuildType::AmentCmake => "ament_cmake",
@@ -267,8 +271,7 @@ fn worker_loop(
                 Ok(()) => {
                     if !dry_run {
                         eprintln!(
-                            "[{}/{}] \u{2713} {} ({:.1}s)",
-                            guard.finished_count,
+                            "[{seq}/{}] \u{2713} {} ({:.1}s)",
                             guard.total,
                             pkg_name,
                             elapsed.as_secs_f64()
@@ -290,8 +293,7 @@ fn worker_loop(
                 }
                 Err(e) => {
                     eprintln!(
-                        "[{}/{}] \u{2717} {} ({:.1}s): {}",
-                        guard.finished_count,
+                        "[{seq}/{}] \u{2717} {} ({:.1}s): {}",
                         guard.total,
                         pkg_name,
                         elapsed.as_secs_f64(),

--- a/crates/launch-plus-core/src/builder/scheduler.rs
+++ b/crates/launch-plus-core/src/builder/scheduler.rs
@@ -1,4 +1,417 @@
-//! Greedy parallel build scheduler with configurable worker pool.
+//! Greedy parallel build scheduler.
 //!
-//! Dispatches package builds as soon as all dependencies are satisfied,
-//! using `std::thread::scope` with N worker threads.
+//! Maintains a dependency graph and dispatches ready packages to a worker
+//! pool of N threads.  Each worker picks the next ready package, builds it
+//! via the appropriate backend (ament_cmake or ament_python), and marks it
+//! done — which may unlock further packages.
+//!
+//! Supports `--continue-on-error` (keep building independent packages after
+//! a failure) and SIGINT (stop accepting new work, wait for in-flight builds).
+
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::path::Path;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Condvar, Mutex};
+use std::time::Instant;
+
+use super::ament_cmake::{BuildOptionsRef, PackageBuildContext};
+use super::environment::build_env_for_package;
+use super::{BuildOptions, BuildPlan};
+
+/// Build type for a package, determined from `<export><build_type>` in package.xml.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BuildType {
+    AmentCmake,
+    AmentPython,
+}
+
+/// Per-package node in the scheduler's dependency graph.
+#[derive(Debug)]
+struct PackageNode {
+    build_type: BuildType,
+    /// Number of in-set dependencies that haven't finished yet.
+    remaining_deps: usize,
+    /// Packages that depend on this one (will have their remaining_deps decremented).
+    dependents: Vec<String>,
+}
+
+/// Mutable scheduler state protected by a mutex.
+struct SchedulerState {
+    /// Packages ready to build (all deps satisfied).
+    ready: VecDeque<String>,
+    /// Packages currently being built.
+    in_progress: HashSet<String>,
+    /// Successfully completed packages, in completion order.
+    completed: Vec<String>,
+    /// Failed packages: (name, error message).
+    failed: Vec<(String, String)>,
+    /// Set on first failure when `!continue_on_error` — workers stop picking up new work.
+    poisoned: bool,
+    /// Per-package nodes.
+    nodes: HashMap<String, PackageNode>,
+    /// Total package count (for progress display).
+    total: usize,
+    /// Counter for progress display.
+    finished_count: usize,
+}
+
+/// Result of a parallel build run.
+#[derive(Debug)]
+pub struct BuildResult {
+    /// Successfully built packages, in completion order.
+    pub completed: Vec<String>,
+    /// Failed packages: (name, error message).
+    pub failed: Vec<(String, String)>,
+}
+
+impl BuildResult {
+    pub fn is_success(&self) -> bool {
+        self.failed.is_empty()
+    }
+}
+
+/// Run a parallel build of all packages in the plan.
+///
+/// # Arguments
+/// * `plan` - Build plan with packages in topological order
+/// * `options` - Build options
+/// * `build_types` - Map of package name → build type
+/// * `pkg_deps` - Map of package name → set of in-set build dependencies
+/// * `interrupted` - Global SIGINT flag
+pub fn run_parallel_build(
+    plan: &BuildPlan,
+    options: &BuildOptions,
+    build_types: &HashMap<String, BuildType>,
+    pkg_deps: &HashMap<String, HashSet<String>>,
+    interrupted: &'static AtomicBool,
+) -> crate::Result<BuildResult> {
+    if plan.packages.is_empty() {
+        return Ok(BuildResult {
+            completed: vec![],
+            failed: vec![],
+        });
+    }
+
+    let pkg_set: HashSet<&String> = plan.packages.iter().collect();
+
+    // Build the dependency graph for the scheduler.
+    let mut nodes: HashMap<String, PackageNode> = HashMap::new();
+
+    for pkg in &plan.packages {
+        let build_type = build_types
+            .get(pkg)
+            .copied()
+            .unwrap_or(BuildType::AmentCmake);
+        let deps = pkg_deps.get(pkg).cloned().unwrap_or_default();
+        // Only count in-set deps.
+        let in_set_deps: HashSet<String> =
+            deps.into_iter().filter(|d| pkg_set.contains(d)).collect();
+        nodes.insert(
+            pkg.clone(),
+            PackageNode {
+                build_type,
+                remaining_deps: in_set_deps.len(),
+                dependents: Vec::new(),
+            },
+        );
+    }
+
+    // Fill in dependents (reverse edges).
+    for pkg in &plan.packages {
+        let deps = pkg_deps.get(pkg).cloned().unwrap_or_default();
+        for dep in deps {
+            if let Some(node) = nodes.get_mut(&dep) {
+                node.dependents.push(pkg.clone());
+            }
+        }
+    }
+
+    // Find initially ready packages (no in-set deps).
+    let mut ready: VecDeque<String> = VecDeque::new();
+    for pkg in &plan.packages {
+        if nodes[pkg].remaining_deps == 0 {
+            ready.push_back(pkg.clone());
+        }
+    }
+
+    let total = plan.packages.len();
+    let state = Mutex::new(SchedulerState {
+        ready,
+        in_progress: HashSet::new(),
+        completed: Vec::new(),
+        failed: Vec::new(),
+        poisoned: false,
+        nodes,
+        total,
+        finished_count: 0,
+    });
+    let cvar = Condvar::new();
+    let opts_ref = BuildOptionsRef::from(options);
+
+    let worker_count = options.parallel_workers.min(total);
+
+    std::thread::scope(|s| {
+        for _worker_id in 0..worker_count {
+            let state = &state;
+            let cvar = &cvar;
+            let opts_ref = &opts_ref;
+            let plan = &plan;
+
+            s.spawn(move || {
+                worker_loop(
+                    state,
+                    cvar,
+                    opts_ref,
+                    plan,
+                    interrupted,
+                    options.continue_on_error,
+                );
+            });
+        }
+    });
+
+    let guard = state.lock().unwrap();
+    Ok(BuildResult {
+        completed: guard.completed.clone(),
+        failed: guard.failed.clone(),
+    })
+}
+
+/// Main worker loop: pick ready → build → report → repeat.
+fn worker_loop(
+    state: &Mutex<SchedulerState>,
+    cvar: &Condvar,
+    opts_ref: &BuildOptionsRef,
+    plan: &BuildPlan,
+    interrupted: &'static AtomicBool,
+    continue_on_error: bool,
+) {
+    loop {
+        // === Pick next package ===
+        let (pkg_name, build_type, built_deps) = {
+            let mut guard = state.lock().unwrap();
+
+            // Wait until there's work or we should exit.
+            loop {
+                if interrupted.load(Ordering::SeqCst) || guard.poisoned {
+                    return;
+                }
+                if let Some(pkg) = guard.ready.pop_front() {
+                    let bt = guard.nodes[&pkg].build_type;
+                    let deps = guard.completed.clone();
+                    guard.in_progress.insert(pkg.clone());
+                    break (pkg, bt, deps);
+                }
+                // No work available — check if we're done.
+                if guard.in_progress.is_empty() {
+                    // Nothing in progress, nothing ready → all done or blocked.
+                    return;
+                }
+                guard = cvar.wait(guard).unwrap();
+            }
+        };
+
+        // === Build the package ===
+        let start = Instant::now();
+        let build_env = build_env_for_package(&plan.install_base, &built_deps);
+
+        let ctx = PackageBuildContext {
+            pkg_name: pkg_name.clone(),
+            src_dir: find_package_dir(&plan.src_dir, &pkg_name),
+            build_dir: plan.build_base.join(&pkg_name),
+            install_dir: plan.install_base.join(&pkg_name),
+            log_dir: plan.log_base.join(&pkg_name),
+            env: build_env,
+            options: opts_ref.clone(),
+            interrupted,
+        };
+
+        // Progress: starting.
+        {
+            let guard = state.lock().unwrap();
+            eprintln!(
+                "[{}/{}] Building {} ({})",
+                guard.finished_count + guard.in_progress.len(),
+                guard.total,
+                pkg_name,
+                match build_type {
+                    BuildType::AmentCmake => "ament_cmake",
+                    BuildType::AmentPython => "ament_python",
+                }
+            );
+        }
+
+        let result = match build_type {
+            BuildType::AmentCmake => super::ament_cmake::build_ament_cmake(&ctx),
+            BuildType::AmentPython => super::ament_python::build_ament_python(&ctx),
+        };
+
+        let elapsed = start.elapsed();
+
+        // === Report result ===
+        {
+            let mut guard = state.lock().unwrap();
+            guard.in_progress.remove(&pkg_name);
+            guard.finished_count += 1;
+
+            match result {
+                Ok(()) => {
+                    eprintln!(
+                        "[{}/{}] \u{2713} {} ({:.1}s)",
+                        guard.finished_count,
+                        guard.total,
+                        pkg_name,
+                        elapsed.as_secs_f64()
+                    );
+
+                    guard.completed.push(pkg_name.clone());
+
+                    // Unlock dependents.
+                    let dependents = guard.nodes[&pkg_name].dependents.clone();
+                    for dep_pkg in dependents {
+                        if let Some(node) = guard.nodes.get_mut(&dep_pkg) {
+                            node.remaining_deps -= 1;
+                            if node.remaining_deps == 0 && !guard.poisoned {
+                                guard.ready.push_back(dep_pkg);
+                            }
+                        }
+                    }
+                }
+                Err(e) => {
+                    eprintln!(
+                        "[{}/{}] \u{2717} {} ({:.1}s): {}",
+                        guard.finished_count,
+                        guard.total,
+                        pkg_name,
+                        elapsed.as_secs_f64(),
+                        e
+                    );
+
+                    guard.failed.push((pkg_name.clone(), e.to_string()));
+
+                    if !continue_on_error {
+                        guard.poisoned = true;
+                    }
+                }
+            }
+        }
+
+        cvar.notify_all();
+    }
+}
+
+/// Search for a package's source directory by looking for package.xml files.
+///
+/// Checks direct subdirectory first, then walks up to 3 levels deep.
+/// Falls back to `src_dir/<pkg_name>` if not found.
+fn find_package_dir(src_dir: &Path, pkg_name: &str) -> std::path::PathBuf {
+    // Fast path: direct subdirectory.
+    let direct = src_dir.join(pkg_name);
+    if direct.join("package.xml").exists() {
+        return direct;
+    }
+
+    // Walk up to 4 levels deep looking for the package.
+    for entry in walkdir_limited(src_dir, 4) {
+        if entry.file_name() == Some(std::ffi::OsStr::new("package.xml")) {
+            if let Some(parent) = entry.parent() {
+                if parent.file_name().map(|n| n.to_string_lossy()) == Some(pkg_name.into()) {
+                    return parent.to_path_buf();
+                }
+            }
+        }
+    }
+
+    // Fallback.
+    direct
+}
+
+/// Simple directory walker limited to `max_depth` levels.
+fn walkdir_limited(root: &Path, max_depth: usize) -> Vec<std::path::PathBuf> {
+    let mut result = Vec::new();
+    let mut stack: Vec<(std::path::PathBuf, usize)> = vec![(root.to_path_buf(), 0)];
+
+    while let Some((dir, depth)) = stack.pop() {
+        if depth >= max_depth {
+            continue;
+        }
+        let entries = match std::fs::read_dir(&dir) {
+            Ok(e) => e,
+            Err(_) => continue,
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                stack.push((path, depth + 1));
+            } else {
+                result.push(path);
+            }
+        }
+    }
+
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_empty_build() {
+        static INTERRUPTED: AtomicBool = AtomicBool::new(false);
+
+        let tmp = TempDir::new().unwrap();
+        let plan = BuildPlan {
+            packages: vec![],
+            external_deps: HashSet::new(),
+            src_dir: tmp.path().join("src"),
+            build_base: tmp.path().join("build"),
+            install_base: tmp.path().join("install"),
+            log_base: tmp.path().join("log"),
+        };
+        let options = BuildOptions::default();
+
+        let result = run_parallel_build(
+            &plan,
+            &options,
+            &HashMap::new(),
+            &HashMap::new(),
+            &INTERRUPTED,
+        )
+        .unwrap();
+
+        assert!(result.is_success());
+        assert!(result.completed.is_empty());
+    }
+
+    #[test]
+    fn test_find_package_dir_direct() {
+        let tmp = TempDir::new().unwrap();
+        let pkg_dir = tmp.path().join("my_pkg");
+        fs::create_dir_all(&pkg_dir).unwrap();
+        fs::write(pkg_dir.join("package.xml"), "<package/>").unwrap();
+
+        let found = find_package_dir(tmp.path(), "my_pkg");
+        assert_eq!(found, pkg_dir);
+    }
+
+    #[test]
+    fn test_find_package_dir_nested() {
+        let tmp = TempDir::new().unwrap();
+        let pkg_dir = tmp.path().join("some_repo").join("my_pkg");
+        fs::create_dir_all(&pkg_dir).unwrap();
+        fs::write(pkg_dir.join("package.xml"), "<package/>").unwrap();
+
+        let found = find_package_dir(tmp.path(), "my_pkg");
+        assert_eq!(found, pkg_dir);
+    }
+
+    #[test]
+    fn test_find_package_dir_fallback() {
+        let tmp = TempDir::new().unwrap();
+        let found = find_package_dir(tmp.path(), "nonexistent");
+        assert_eq!(found, tmp.path().join("nonexistent"));
+    }
+}

--- a/crates/launch-plus-core/src/builder/scheduler.rs
+++ b/crates/launch-plus-core/src/builder/scheduler.rs
@@ -1,0 +1,4 @@
+//! Greedy parallel build scheduler with configurable worker pool.
+//!
+//! Dispatches package builds as soon as all dependencies are satisfied,
+//! using `std::thread::scope` with N worker threads.

--- a/crates/launch-plus-core/src/builder/scheduler.rs
+++ b/crates/launch-plus-core/src/builder/scheduler.rs
@@ -168,6 +168,7 @@ pub fn run_parallel_build(
                     pkg_src_dirs,
                     interrupted,
                     options.continue_on_error,
+                    options.dry_run,
                 );
             });
         }
@@ -189,6 +190,7 @@ fn worker_loop(
     pkg_src_dirs: &HashMap<String, std::path::PathBuf>,
     interrupted: &'static AtomicBool,
     continue_on_error: bool,
+    dry_run: bool,
 ) {
     loop {
         // === Pick next package ===
@@ -234,7 +236,7 @@ fn worker_loop(
         };
 
         // Progress: starting.
-        {
+        if !dry_run {
             let guard = state.lock().unwrap();
             eprintln!(
                 "[{}/{}] Building {} ({})",
@@ -263,13 +265,15 @@ fn worker_loop(
 
             match result {
                 Ok(()) => {
-                    eprintln!(
-                        "[{}/{}] \u{2713} {} ({:.1}s)",
-                        guard.finished_count,
-                        guard.total,
-                        pkg_name,
-                        elapsed.as_secs_f64()
-                    );
+                    if !dry_run {
+                        eprintln!(
+                            "[{}/{}] \u{2713} {} ({:.1}s)",
+                            guard.finished_count,
+                            guard.total,
+                            pkg_name,
+                            elapsed.as_secs_f64()
+                        );
+                    }
 
                     guard.completed.push(pkg_name.clone());
 

--- a/crates/launch-plus-core/src/error.rs
+++ b/crates/launch-plus-core/src/error.rs
@@ -55,4 +55,20 @@ pub enum Error {
     /// Process execution failed
     #[error("process execution failed: {0}")]
     ProcessExecution(String),
+
+    /// Build failed for a specific package
+    #[error("build failed for package '{package}': {detail}")]
+    BuildFailed { package: String, detail: String },
+
+    /// Unsupported build type in package.xml
+    #[error("unsupported build type '{build_type}' for package '{package}'")]
+    UnsupportedBuildType { package: String, build_type: String },
+
+    /// Build interrupted by signal (e.g. Ctrl+C)
+    #[error("build interrupted by Ctrl+C")]
+    BuildInterrupted,
+
+    /// Invalid build flag (e.g. user manually specifying BUILD_TESTING)
+    #[error("invalid build flag: {detail}")]
+    InvalidBuildFlag { detail: String },
 }

--- a/crates/launch-plus-core/src/indexer.rs
+++ b/crates/launch-plus-core/src/indexer.rs
@@ -254,6 +254,9 @@ pub struct PackageInfo {
     pub path: String,
     /// Dependencies extracted from package.xml
     pub dependencies: Dependencies,
+    /// Build type from `<export><build_type>` (e.g. "ament_cmake", "ament_python").
+    /// `None` if not specified (defaults to ament_cmake by convention).
+    pub build_type: Option<String>,
 }
 
 /// Evaluate a REP-149 `condition` attribute on a dependency element.
@@ -697,14 +700,19 @@ pub fn parse_package_xml(content: &str, path: &str) -> crate::Result<PackageInfo
 
     let mut name = String::new();
     let mut dependencies = Dependencies::default();
+    let mut build_type: Option<String> = None;
     let mut current_tag = String::new();
     let mut skip_current = false;
+    let mut inside_export = false;
     let mut buf = Vec::new();
 
     loop {
         match reader.read_event_into(&mut buf) {
             Ok(Event::Start(e)) => {
                 current_tag = String::from_utf8_lossy(e.name().as_ref()).to_string();
+                if current_tag == "export" {
+                    inside_export = true;
+                }
                 // REP-149 §3: evaluate condition="$VAR == value" attributes.
                 // Dependencies whose condition evaluates to false are skipped.
                 skip_current = !evaluate_condition(&e);
@@ -717,61 +725,68 @@ pub fn parse_package_xml(content: &str, path: &str) -> crate::Result<PackageInfo
                     crate::Error::XmlParse(format!("failed to unescape text: {err}"))
                 })?;
 
-                let dep = text.trim().to_string();
-                if dep.is_empty() {
+                let val = text.trim().to_string();
+                if val.is_empty() {
                     // skip empty text nodes
+                } else if inside_export && current_tag == "build_type" {
+                    build_type = Some(val);
                 } else {
                     match current_tag.as_str() {
                         "name" if name.is_empty() => {
-                            name = dep;
+                            name = val;
                         }
                         "build_depend" => {
-                            if !dependencies.build.contains(&dep) {
-                                dependencies.build.push(dep);
+                            if !dependencies.build.contains(&val) {
+                                dependencies.build.push(val);
                             }
                         }
                         "build_export_depend" => {
-                            if !dependencies.build_export.contains(&dep) {
-                                dependencies.build_export.push(dep);
+                            if !dependencies.build_export.contains(&val) {
+                                dependencies.build_export.push(val);
                             }
                         }
                         "buildtool_depend" => {
-                            if !dependencies.buildtool.contains(&dep) {
-                                dependencies.buildtool.push(dep);
+                            if !dependencies.buildtool.contains(&val) {
+                                dependencies.buildtool.push(val);
                             }
                         }
                         "buildtool_export_depend" => {
-                            if !dependencies.buildtool_export.contains(&dep) {
-                                dependencies.buildtool_export.push(dep);
+                            if !dependencies.buildtool_export.contains(&val) {
+                                dependencies.buildtool_export.push(val);
                             }
                         }
                         "exec_depend" => {
-                            if !dependencies.exec.contains(&dep) {
-                                dependencies.exec.push(dep);
+                            if !dependencies.exec.contains(&val) {
+                                dependencies.exec.push(val);
                             }
                         }
                         "test_depend" => {
-                            if !dependencies.test.contains(&dep) {
-                                dependencies.test.push(dep);
+                            if !dependencies.test.contains(&val) {
+                                dependencies.test.push(val);
                             }
                         }
                         // REP-149: <depend> = build_depend + build_export_depend + exec_depend
                         "depend" => {
-                            if !dependencies.build.contains(&dep) {
-                                dependencies.build.push(dep.clone());
+                            if !dependencies.build.contains(&val) {
+                                dependencies.build.push(val.clone());
                             }
-                            if !dependencies.build_export.contains(&dep) {
-                                dependencies.build_export.push(dep.clone());
+                            if !dependencies.build_export.contains(&val) {
+                                dependencies.build_export.push(val.clone());
                             }
-                            if !dependencies.exec.contains(&dep) {
-                                dependencies.exec.push(dep);
+                            if !dependencies.exec.contains(&val) {
+                                dependencies.exec.push(val);
                             }
                         }
                         _ => {}
                     }
                 }
             }
-            Ok(Event::End(_)) => {
+            Ok(Event::End(e)) => {
+                let name = e.name();
+                let tag = String::from_utf8_lossy(name.as_ref());
+                if tag == "export" {
+                    inside_export = false;
+                }
                 current_tag.clear();
             }
             Ok(Event::Eof) => break,
@@ -803,6 +818,7 @@ pub fn parse_package_xml(content: &str, path: &str) -> crate::Result<PackageInfo
         name,
         path: path.to_string(),
         dependencies,
+        build_type,
     })
 }
 
@@ -1283,14 +1299,15 @@ pub fn generate_lockfile(
 /// Dependency resolution mode
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DependencyMode {
-    /// Build dependencies only (for colcon build)
+    /// Build dependencies only: `build_depend`, `build_export_depend`,
+    /// `buildtool_depend`, `buildtool_export_depend`.
     Build,
-    /// Execution dependencies only (for runtime)
+    /// Execution dependencies only (for runtime).
     Exec,
-    /// Both build and exec dependencies
+    /// Both build and exec dependencies (legacy: needed when colcon was the backend).
     BuildAndExec,
-    /// All dependencies including test
-    All,
+    /// Build + test dependencies: same as `Build` plus `test_depend`.
+    BuildAndTest,
 }
 
 /// Result of transitive dependency resolution
@@ -1328,6 +1345,25 @@ fn read_package_deps(
     let content = std::fs::read_to_string(&xml_path).ok()?;
     let parsed = parse_package_xml(&content, &xml_path.to_string_lossy()).ok()?;
     Some(parsed.dependencies)
+}
+
+/// Read on-disk `package.xml` build type for a package.
+///
+/// Returns `None` if the package is not in the lockfile, its `package.xml` is
+/// not on disk, or no `<export><build_type>` is specified.
+pub fn read_package_build_type(
+    lockfile: &Lockfile,
+    src_dir: &std::path::Path,
+    pkg_name: &str,
+) -> Option<String> {
+    let pkg_lock = lockfile.packages.get(pkg_name)?;
+    let xml_path = src_dir
+        .join(&pkg_lock.repo)
+        .join(&pkg_lock.path)
+        .join("package.xml");
+    let content = std::fs::read_to_string(&xml_path).ok()?;
+    let parsed = parse_package_xml(&content, &xml_path.to_string_lossy()).ok()?;
+    parsed.build_type
 }
 
 /// Compute transitive dependencies for a set of root packages.
@@ -1389,12 +1425,11 @@ pub fn resolve_dependencies(
                 queue.extend(deps.buildtool_export.iter().cloned());
                 queue.extend(deps.exec.iter().cloned());
             }
-            DependencyMode::All => {
+            DependencyMode::BuildAndTest => {
                 queue.extend(deps.build.iter().cloned());
                 queue.extend(deps.build_export.iter().cloned());
                 queue.extend(deps.buildtool.iter().cloned());
                 queue.extend(deps.buildtool_export.iter().cloned());
-                queue.extend(deps.exec.iter().cloned());
                 queue.extend(deps.test.iter().cloned());
             }
         }

--- a/crates/launch-plus-core/src/indexer.rs
+++ b/crates/launch-plus-core/src/indexer.rs
@@ -1332,7 +1332,7 @@ impl DependencyGraph {
 /// Read on-disk `package.xml` dependencies for a package.
 ///
 /// Returns `None` if the package is not in the lockfile or its `package.xml` is not on disk.
-fn read_package_deps(
+pub fn read_package_deps(
     lockfile: &Lockfile,
     src_dir: &std::path::Path,
     pkg_name: &str,

--- a/crates/launch-plus-core/src/lib.rs
+++ b/crates/launch-plus-core/src/lib.rs
@@ -9,7 +9,7 @@
 //! - `indexer`: Parse .repos files and generate lockfiles
 //! - `resolver`: Parse launch files and resolve dependencies
 //! - `fetcher`: Partial git clone via sparse-checkout
-//! - `builder`: Selective colcon build orchestration
+//! - `builder`: Selective build orchestration (native cmake/setuptools backend)
 //! - `executor`: Process spawning and lifecycle management
 
 pub mod builder;
@@ -40,7 +40,7 @@ pub use locator::{PackageLocator, locator_from_lockfile, locator_from_workspace}
 // Re-export indexer types for lockfile access
 pub use indexer::{
     Dependencies, DependencyGraph, DependencyMode, Lockfile, PackageLock, RepoLock,
-    compute_build_order, resolve_dependencies,
+    compute_build_order, read_package_build_type, resolve_dependencies,
 };
 
 // Re-export fetcher types

--- a/crates/launch-plus-core/src/lib.rs
+++ b/crates/launch-plus-core/src/lib.rs
@@ -40,7 +40,7 @@ pub use locator::{PackageLocator, locator_from_lockfile, locator_from_workspace}
 // Re-export indexer types for lockfile access
 pub use indexer::{
     Dependencies, DependencyGraph, DependencyMode, Lockfile, PackageLock, RepoLock,
-    compute_build_order, read_package_build_type, resolve_dependencies,
+    compute_build_order, read_package_build_type, read_package_deps, resolve_dependencies,
 };
 
 // Re-export fetcher types

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -22,7 +22,7 @@ a thin `clap`-based wrapper.
 │  │   ├── substitution engine ($(var), $(eval), etc.)  │
 │  │   └── Python resolver (embedded py_resolver.py)    │
 │  ├── orchestrator — coordinates resolve + fetch loop  │
-│  ├── builder    — colcon build orchestration          │
+│  ├── builder    — native cmake/setuptools build        │
 │  └── rosdep     — system dependency resolution        │
 └───────────────────────────────────────────────────────┘
 ```
@@ -109,8 +109,11 @@ launch-plus build <pkg> <launcher>
     └── pip install
     │
     ▼
-[builder]
-    └── colcon build --packages-select <minimal set>
+[builder] — native build backend
+    ├── topological sort (Kahn's algorithm)
+    ├── greedy parallel scheduler (N worker threads)
+    ├── ament_cmake: cmake configure → make → make install
+    └── ament_python: setup.py install / pip3 install
 ```
 
 ## Key components
@@ -167,11 +170,25 @@ package that hasn't been fetched yet, it signals via `_PackageNotFetchedError`.
 The orchestrator catches this, fetches the missing package, and retries (up to
 3 times).
 
-### Builder (`builder.rs`)
+### Builder (`builder/`)
 
-Computes the transitive build-dependency closure and invokes `colcon build`.
-Reads extra arguments from a flagfile.  Validates that flagfile tokens don't
-conflict with launch-plus-managed arguments.
+Computes the transitive build-dependency closure and builds packages using a
+native backend — direct `cmake`/`make` invocations for `ament_cmake` packages
+and `setup.py`/`pip3` for `ament_python` packages.  No external build tool
+(e.g. colcon) is required.
+
+The builder automatically configures `BUILD_TESTING`:
+- **OFF** by default (normal `build` command)
+- **ON** when the `test` command is used
+- Manually passing `-DBUILD_TESTING=...` via `--cmake-args` is rejected with
+  an error to prevent conflicts with the automatic configuration.
+
+Key submodules:
+- `scheduler.rs` — greedy parallel scheduler with `std::thread::scope` + `Mutex`/`Condvar`
+- `ament_cmake.rs` — cmake configure → make → make install for one package
+- `ament_python.rs` — setuptools/pip build for one package
+- `environment.rs` — computes `CMAKE_PREFIX_PATH`, `AMENT_PREFIX_PATH`, `LD_LIBRARY_PATH`, etc.
+- `install.rs` — generates colcon-compatible install layout (DSV files, setup scripts, ament_index markers)
 
 ### Rosdep (`rosdep.rs`)
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -111,7 +111,7 @@ the source directory and the install directory**.  Concretely:
 src/my_pkg/launch/bringup.launch.xml
 src/my_pkg/config/params.yaml
 
-# Install path (after colcon build --symlink-install)
+# Install path (after build --symlink-install)
 install/my_pkg/share/my_pkg/launch/bringup.launch.xml
 install/my_pkg/share/my_pkg/config/params.yaml
 ```
@@ -204,7 +204,7 @@ build-dependency closure** from the resolved launch graph:
 3. **System deps** — packages not in the lockfile are resolved via `rosdep`
    (with `--rosdep`)
 
-Only the resulting minimal set is passed to `colcon build --packages-select`.
+Only the resulting minimal set is built by the native backend.
 
 ### The `exec_depend` problem
 
@@ -230,13 +230,14 @@ launch-plus's goal is to avoid this entirely: because the resolver already knows
 which packages are actually needed (it read the launch file), it *should* compute
 the build closure using only `build_depend` and `buildtool_depend`.
 
-**Current status:** today, launch-plus still includes `exec_depend` in the build
-set because it delegates to `colcon build`, which validates that all
-`package.xml` dependencies — including `exec_depend` — have install artifacts
-before running cmake.  There is no colcon flag to disable this check.  Replacing
-colcon with direct ament invocations (see [#18](https://github.com/paulsohn/launch-plus/issues/18))
-will remove this constraint, allowing the build closure to use only true
-build-time dependencies.
+**Status:** launch-plus uses a native build backend (direct cmake/setuptools
+invocations) that does **not** validate `exec_depend` at build time.  The build
+closure uses only true build-time dependencies (`build_depend`,
+`buildtool_depend`, `build_export_depend`, `buildtool_export_depend`, and
+`<depend>`).  Runtime dependencies are tracked through the launch graph itself.
+
+This eliminates the need for workarounds like Autoware's `remove-exec-depend`
+CI action — `exec_depend` packages are simply not included in the build set.
 
 ## Static analysis: what the resolver can verify
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -23,7 +23,7 @@ sandbox and content-addressable cache, launch-plus through its SHA-pinned lockfi
 
 But launch-plus is **not** a general-purpose build system.  It is a
 ROS 2-specific tool that understands launch files, `package.xml`, and the
-`colcon`/`ament` ecosystem natively.
+`ament` ecosystem natively.
 
 Bazel rules for ROS 2 do exist (e.g. the ones provided by Apex.AI), and they
 work well for teams that can commit to a full Bazel migration.  However, adopting
@@ -31,15 +31,15 @@ Bazel in an existing ROS 2 project is a significant undertaking:
 
 - Every package needs a `BUILD` file — `package.xml` and `CMakeLists.txt` are not
   enough
-- The entire build toolchain changes: `colcon`, `ament_cmake`, and `rosdep` are
-  replaced by Bazel equivalents
+- The entire build toolchain changes: `ament_cmake`, `rosdep`, and the standard
+  build tools are replaced by Bazel equivalents
 - Third-party ROS packages (from the buildfarm or other `.repos` sources) must be
   wrapped with Bazel build rules
 - Teams must learn and maintain a parallel build system
 
 launch-plus takes the opposite approach: **zero migration**.  It works with the
 ROS 2 conventions your project already uses — `.repos` manifests, `package.xml`,
-`colcon build`, `rosdep` — and layers the dependency-tracing and sparse-checkout
+`ament_cmake`, `rosdep` — and layers the dependency-tracing and sparse-checkout
 capabilities on top.  You can adopt it incrementally without changing any existing
 build files.
 
@@ -50,7 +50,7 @@ ROS 2-specific concerns that a general-purpose build system has no reason to
 address.
 
 In short: if your team has already invested in Bazel for ROS 2, you may not need
-launch-plus for the build subset.  But if you use the standard `colcon`/`ament`
+launch-plus for the build subset.  But if you use the standard `ament`
 toolchain — as most ROS 2 projects do — launch-plus gives you Bazel-like
 targeted builds and reproducibility without requiring a build system migration.
 
@@ -128,42 +128,31 @@ executing your launch file, so `print()` still works — it just goes to stderr.
 
 ## Building
 
-### Why does launch-plus still build `exec_depend` packages?
+### Does launch-plus build `exec_depend` packages?
 
-It shouldn't have to — `exec_depend` declares packages needed at *runtime*, not
-at build time.  However, launch-plus currently delegates to `colcon build`, which
-validates that **all** `package.xml` dependencies (including `exec_depend`) have
-install artifacts before running cmake.  There is no colcon flag to disable this
-check, so launch-plus must include `exec_depend` in the build set today.
+No.  launch-plus uses a native build backend (direct cmake/setuptools
+invocations) that does **not** validate `exec_depend` at build time.  The build
+closure uses only true build-time dependencies: `build_depend`,
+`buildtool_depend`, `build_export_depend`, `buildtool_export_depend`, and
+`<depend>`.  Runtime dependencies are tracked through the launch graph itself.
 
-This is a well-known pain point.  The Autoware project maintains
-[`remove-exec-depend`](https://github.com/autowarefoundation/autoware-github-actions/tree/main/remove-exec-depend),
-a CI action that strips `<exec_depend>` from every `package.xml` before
-building, just to work around colcon's behavior.
+This eliminates the need for workarounds like Autoware's `remove-exec-depend`
+CI action.  See [Dependency closure](concepts.md#dependency-closure) for details.
 
-Once colcon is replaced with direct ament invocations
-([#18](https://github.com/paulsohn/launch-plus/issues/18)), the build closure
-will use only `build_depend`, `buildtool_depend`, `build_export_depend`, and
-`buildtool_export_depend`.  Runtime dependencies will
-be expected to be satisfied by installed system packages — exactly the role
-`exec_depend` was designed to express.  See
-[Dependency closure](concepts.md#dependency-closure) for details.
+### How do I pass extra cmake arguments?
 
-### How does `--colcon-flagfile` work?
+Use `--cmake-args` on the command line:
 
-The flagfile contains extra arguments for `colcon build`, one shell token per
-line.  Comments (`#`) are supported:
-
-```txt
---symlink-install
---cmake-args
--DCMAKE_BUILD_TYPE=Release
---parallel-workers
-4
+```bash
+launch-plus build my_pkg my_launch.xml --cmake-args -DCMAKE_BUILD_TYPE=Release
 ```
 
-Flags that conflict with launch-plus-managed arguments (`--packages-select`,
-`--base-paths`, `--build-base`, `--install-base`) are rejected.
+Other build options: `--make-args`, `--symlink-install`, `--parallel-workers N`,
+`--continue-on-error`, `--dry-run`.
+
+**Note:** `BUILD_TESTING` is managed automatically — `OFF` for `build`, `ON` for
+`test`.  Manually passing `-DBUILD_TESTING=...` via `--cmake-args` is rejected
+with an error to prevent conflicts.
 
 ### Can I build for a different ROS distro?
 
@@ -174,8 +163,8 @@ setup file before running launch-plus.
 ### What about cross-compilation?
 
 launch-plus itself is a native tool.  Cross-compilation of ROS 2 packages
-depends on your colcon/CMake cross-compilation setup.  You can pass
-cross-compilation flags via the colcon flagfile.
+depends on your CMake cross-compilation setup.  You can pass
+cross-compilation flags via `--cmake-args`.
 
 ## Lockfile
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -127,25 +127,26 @@ source /opt/ros/humble/setup.bash
 launch-plus build -c my_bringup robot.launch.xml \
   robot_name:=my_robot \
   --rosdep \
-  --colcon-flagfile colcon-flags.txt
+  --symlink-install
 ```
 
 This resolves the launch file, computes the transitive build-dependency closure,
-fetches any missing packages, installs system dependencies via rosdep, and runs
-`colcon build` with only the needed packages.
+fetches any missing packages, installs system dependencies via rosdep, and builds
+using the native cmake/setuptools backend.
 
-### Colcon flagfile
+### Build options
 
-Extra colcon arguments are passed via a **flagfile** — one shell token per line:
+| Flag | Description |
+|------|-------------|
+| `--symlink-install` | Use symlinks instead of copying files to install tree |
+| `--parallel-workers N` | Max parallel build jobs (default: CPU count) |
+| `--cmake-args ARGS...` | Extra cmake arguments (e.g. `-DCMAKE_BUILD_TYPE=Release`) |
+| `--make-args ARGS...` | Extra make arguments |
+| `--continue-on-error` | Keep building independent packages after a failure |
+| `--dry-run` | Print build commands without executing them |
 
-```txt
-# colcon-flags.txt
---symlink-install
---cmake-args
--DCMAKE_BUILD_TYPE=Release
---parallel-workers
-4
-```
+**`BUILD_TESTING` is managed automatically**: `OFF` for `build`, `ON` for `test`.
+Passing `-DBUILD_TESTING=...` via `--cmake-args` is an error.
 
 ## Step 5: Verify (optional)
 
@@ -179,14 +180,13 @@ After running launch-plus, your workspace will look like:
 my_workspace/
 ├── my_project.repos          # your manifest
 ├── manifest.lock.repos       # generated lockfile (commit this)
-├── colcon-flags.txt          # colcon arguments
 ├── src/                      # sparse-checked out packages
 │   ├── core/my_msgs/
 │   ├── drivers/my_driver/
 │   └── launch/my_bringup/
-├── build/                    # colcon build output
-├── install/                  # colcon install output
-└── log/                      # colcon log output
+├── build/                    # per-package build artifacts
+├── install/                  # isolated install tree (colcon-compatible)
+└── log/                      # per-package build logs
 ```
 
 ## Next steps

--- a/docs/motivation.md
+++ b/docs/motivation.md
@@ -159,7 +159,7 @@ standard ROS 2 conventions:
 - `.repos` files (vcstool format)
 - `package.xml` (REP-149 / REP-127)
 - XML and Python launch files (ROS 2 launch API)
-- `colcon` for building
+- `ament_cmake` / `ament_python` build types
 - `rosdep` for system dependency resolution
 
 If your project follows these conventions, launch-plus can help.

--- a/docs/supported-environments.md
+++ b/docs/supported-environments.md
@@ -8,7 +8,7 @@
 | Ubuntu 24.04 (x86_64) | Supported | |
 | Ubuntu 22.04 (aarch64) | Planned | Cross-compilation via `cross` |
 | Ubuntu 24.04 (aarch64) | Planned | Cross-compilation via `cross` |
-| macOS | Not supported | No `apt-get`; rosdep/colcon untested |
+| macOS | Not supported | No `apt-get`; rosdep untested |
 | Windows | Not supported | Git sparse-checkout paths untested |
 
 ## ROS 2 distributions
@@ -49,14 +49,15 @@ command — the table below shows which tools are needed and when.
 |---|---|---|
 | `git` | All commands | Sparse-checkout, ls-remote, archive |
 | `python3` | `resolve`, `build`, `check`, `test` | Evaluating Python launch files and `$(eval ...)` |
-| `colcon` | `build`, `test` | Build orchestration; **planned to be replaceable** |
-| `rosdep` | `--rosdep` flag only | System dependency resolution; **planned to be replaceable** |
+| `cmake` | `build`, `test` | Building ament_cmake packages |
+| `make` | `build`, `test` | Building ament_cmake packages |
+| `rosdep` | `--rosdep` flag only | System dependency resolution |
 | `apt-get` | `--rosdep` with `#apt` deps | Called via `sudo` |
 | `pip` | `--rosdep` with `#pip` deps | Called with `--break-system-packages` |
 
-**Planned changes:** `colcon` and `rosdep` are currently invoked as subprocesses,
-but we plan to support alternative build backends and dependency resolvers in
-the future, reducing the number of external dependencies.
+**Note:** `rosdep` is invoked as a subprocess.  The build backend uses direct
+`cmake`/`make` invocations — no external build orchestrator (e.g. colcon) is
+required.
 
 ## Launch file support
 
@@ -157,7 +158,7 @@ resolving a Humble launch file on a Jazzy host) is not supported.
 - **Standard package layout** — packages must have a `package.xml` at their root.
   Non-standard layouts (e.g. nested packages without a top-level `package.xml`)
   may not be detected during indexing.
-- **colcon as build tool** — the `build` command invokes `colcon build`.  Other
-  build tools (catkin_make, catkin_tools) are not supported.
+- **ament build types** — only `ament_cmake` and `ament_python` packages are
+  supported.  Other build types (catkin, cmake, plain) are not handled.
 - **Git repositories** — only git repos are supported in `.repos` files.
   Subversion, Mercurial, etc. are not handled.

--- a/example/autoware/colcon-flags.txt
+++ b/example/autoware/colcon-flags.txt
@@ -1,7 +1,0 @@
-# Colcon flagfile for the Autoware example build.
-# See example/colcon-flags.example.txt for all available options.
-
---symlink-install
---cmake-args
--DBUILD_TESTING=OFF
---catkin-skip-building-tests

--- a/example/autoware/test-autoware.sh
+++ b/example/autoware/test-autoware.sh
@@ -12,7 +12,7 @@
 # Requires:
 #   - launch-plus binary on PATH (or built at ../../target/release/launch-plus)
 #   - ROS 2 sourced (for rosdep + ament)
-#   - colcon installed (for the build step)
+#   - cmake and make (for building ament_cmake packages)
 
 set -euo pipefail
 
@@ -111,7 +111,7 @@ echo
 # ── Step 2: Build ────────────────────────────────────────────────────────────
 
 echo "==> Step 2: Build"
-$LP build ${MODE_ARGS[@]+"${MODE_ARGS[@]}"} "${LAUNCH_ARGS[@]}" "${COMMON_FLAGS[@]}" --colcon-flagfile colcon-flags.txt
+$LP build ${MODE_ARGS[@]+"${MODE_ARGS[@]}"} "${LAUNCH_ARGS[@]}" "${COMMON_FLAGS[@]}" --symlink-install
 echo "    OK"
 echo
 


### PR DESCRIPTION
## Summary

Replaces the colcon subprocess with a built-in build backend that invokes cmake/make (ament_cmake) and setup.py/pip (ament_python) directly. Closes #18.

- **Native build backend** — no colcon dependency; direct cmake configure → make → make install for ament_cmake, setup.py/pip for ament_python
- **Greedy parallel scheduler** — `std::thread::scope` + `Mutex`/`Condvar` worker pool with SIGINT handling and `--continue-on-error` support
- **Colcon-compatible install layout** — DSV files, setup.bash/sh/zsh, ament_index markers; `source install/setup.bash` works identically
- **`BUILD_TESTING` auto-configuration** — `OFF` by default, `ON` with `--test-mode`; manual `-DBUILD_TESTING=...` via `--cmake-args` is rejected with a clear error
- **`exec_depend` excluded from build closure** — only true build-time deps are compiled, eliminating the need for workarounds like Autoware's `remove-exec-depend`
- **New CLI flags** — `--cmake-args`, `--make-args`, `--symlink-install`, `--parallel-workers`, `--continue-on-error`, `--dry-run` (replaces `--colcon-flagfile`)
- **Comprehensive docs update** — all references to colcon replaced across README, architecture, getting-started, concepts, FAQ, supported-environments, contributing, agent context, and milestones

### Module structure

```
builder/
  mod.rs            — BuildPlan, BuildOptions, plan_build_from_packages(), execute_build()
  scheduler.rs      — Greedy parallel scheduler with worker pool + SIGINT
  ament_cmake.rs    — cmake configure / make / make install for one package
  ament_python.rs   — setuptools/pip build for one package
  environment.rs    — Env var computation (CMAKE_PREFIX_PATH etc.)
  install.rs        — Install layout generation (DSV files, setup scripts, ament_index markers)
```

### What's NOT included (deferred)

- `ctest`/`pytest` execution (test command builds with `BUILD_TESTING=ON` but doesn't run tests yet)
- Ninja generator support (uses make)
- ccache integration
- Build caching / incremental rebuild optimization

## Test plan

- [x] 226 unit tests pass (15 new tests across scheduler, ament_cmake, ament_python, install, environment modules)
- [x] `cargo clippy` clean
- [x] Dry-run verified against Autoware example (42 packages in correct topological order)
- [x] `BUILD_TESTING` validation verified (manual `-DBUILD_TESTING=ON` produces clear error)
- [ ] Full Autoware integration test (`test-autoware.sh`) — requires ROS 2 environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)