### PR TITLE
fix(git): fetch from URL directly, fix no-checkout clone handling

### DIFF
--- a/crates/launch-plus-cli/src/main.rs
+++ b/crates/launch-plus-cli/src/main.rs
@@ -1287,9 +1287,9 @@ fn cmd_update(
                 workspace_path
             );
             blobless_clone(&repo.url, &repo_dir)
-                .and_then(|()| resolve_version_local(&repo_dir, version_ref))
+                .and_then(|()| resolve_version_local(&repo_dir, &repo.url, version_ref))
         } else {
-            resolve_version_local(&repo_dir, version_ref)
+            resolve_version_local(&repo_dir, &repo.url, version_ref)
         };
 
         match resolve_result {

--- a/crates/launch-plus-core/src/fetcher.rs
+++ b/crates/launch-plus-core/src/fetcher.rs
@@ -352,7 +352,7 @@ fn update_sparse_checkout(
         // artifact of sparse-checkout initialization is not real dirt.
         let bootstrap_options = FetchOptions {
             workspace_state: WorkspaceState::Default,
-            ..*options
+            ..options.clone()
         };
         checkout_sha(repo_dir, url, sha, &bootstrap_options)?;
         return Ok(());
@@ -780,10 +780,11 @@ fn checkout_sha(
     if have_locally {
         debug!("SHA {} already available locally, skipping fetch", sha);
     } else {
-        let mut fetch_args = vec!["fetch", url, sha];
+        let mut fetch_args = vec!["fetch"];
         if options.shallow {
-            fetch_args.insert(1, "--depth=1");
+            fetch_args.push("--depth=1");
         }
+        fetch_args.extend(["--", url, sha]);
 
         let output = Command::new("git")
             .current_dir(repo_dir)

--- a/crates/launch-plus-core/src/fetcher.rs
+++ b/crates/launch-plus-core/src/fetcher.rs
@@ -348,7 +348,13 @@ fn update_sparse_checkout(
         );
         init_sparse_checkout(repo_dir)?;
         set_sparse_checkout_paths(repo_dir, paths)?;
-        checkout_sha(repo_dir, url, sha, options)?;
+        // Use Default mode: there are no user changes to stash — the tree
+        // artifact of sparse-checkout initialization is not real dirt.
+        let bootstrap_options = FetchOptions {
+            workspace_state: WorkspaceState::Default,
+            ..*options
+        };
+        checkout_sha(repo_dir, url, sha, &bootstrap_options)?;
         return Ok(());
     }
 

--- a/crates/launch-plus-core/src/fetcher.rs
+++ b/crates/launch-plus-core/src/fetcher.rs
@@ -206,6 +206,11 @@ fn fetch_repo_sparse(
     options: &FetchOptions,
 ) -> crate::Result<()> {
     if repo_dir.exists() && repo_dir.join(".git").exists() {
+        // Blobless/partial clones use origin as the promisor remote for lazy
+        // blob fetches.  Ensure it points to the lockfile URL so that both
+        // explicit fetches and lazy object requests work after a URL change.
+        crate::indexer::ensure_remote_url(repo_dir, url)?;
+
         match options.workspace_state {
             WorkspaceState::Dirty => {
                 // Dirty mode: never touch existing repos — use whatever is on disk.
@@ -797,8 +802,9 @@ fn checkout_sha(
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
             return Err(crate::Error::Git(format!(
-                "git fetch of {} failed and commit is not available locally: {}",
+                "git fetch of {} from {} failed and commit is not available locally: {}",
                 sha,
+                url,
                 stderr.trim()
             )));
         }

--- a/crates/launch-plus-core/src/fetcher.rs
+++ b/crates/launch-plus-core/src/fetcher.rs
@@ -236,7 +236,7 @@ fn fetch_repo_sparse(
                     );
                     init_sparse_checkout(repo_dir)?;
                     set_sparse_checkout_paths(repo_dir, paths)?;
-                    checkout_sha(repo_dir, sha, options)?;
+                    checkout_sha(repo_dir, url, sha, options)?;
                 } else {
                     // Default mode: verify SHA + clean working tree, error if mismatch.
                     verify_repo_state(repo_dir, sha)?;
@@ -247,7 +247,7 @@ fn fetch_repo_sparse(
             }
             WorkspaceState::Clean => {
                 // Clean mode: reset to pinned SHA (with auto-stash).
-                update_sparse_checkout(repo_dir, sha, paths, options)?;
+                update_sparse_checkout(repo_dir, url, sha, paths, options)?;
             }
         }
     } else {
@@ -319,7 +319,7 @@ fn sparse_clone(
     set_sparse_checkout_paths(repo_dir, paths)?;
 
     // Fetch and checkout the specific SHA
-    checkout_sha(repo_dir, sha, options)?;
+    checkout_sha(repo_dir, url, sha, options)?;
 
     Ok(())
 }
@@ -327,6 +327,7 @@ fn sparse_clone(
 /// Update sparse-checkout for an existing repository
 fn update_sparse_checkout(
     repo_dir: &Path,
+    url: &str,
     sha: &str,
     paths: &[&str],
     options: &FetchOptions,
@@ -361,7 +362,7 @@ fn update_sparse_checkout(
                     &current_sha[..current_sha.len().min(8)],
                     &sha[..sha.len().min(8)],
                 );
-                checkout_sha(repo_dir, sha, options)?;
+                checkout_sha(repo_dir, url, sha, options)?;
             } else {
                 debug!(
                     "Already at SHA {} (non-sparse repo), skipping checkout",
@@ -374,7 +375,7 @@ fn update_sparse_checkout(
         info!("Initializing sparse-checkout with paths: {:?}", paths);
         init_sparse_checkout(repo_dir)?;
         set_sparse_checkout_paths(repo_dir, paths)?;
-        checkout_sha(repo_dir, sha, options)?;
+        checkout_sha(repo_dir, url, sha, options)?;
         return Ok(());
     }
 
@@ -403,7 +404,7 @@ fn update_sparse_checkout(
         || (options.workspace_state == WorkspaceState::Clean && is_working_tree_dirty(repo_dir)?);
 
     if need_checkout {
-        checkout_sha(repo_dir, sha, options)?;
+        checkout_sha(repo_dir, url, sha, options)?;
     } else {
         debug!(
             "Already at SHA {} with correct paths, skipping checkout",
@@ -731,7 +732,16 @@ fn stash_if_dirty(repo_dir: &Path, expected_sha: &str) -> crate::Result<bool> {
 }
 
 /// Checkout a specific SHA
-fn checkout_sha(repo_dir: &Path, sha: &str, options: &FetchOptions) -> crate::Result<()> {
+///
+/// Fetches directly from `url` instead of the named "origin" remote, so the
+/// fetch works even when the lockfile URL differs from what origin points to
+/// (e.g. after switching to a fork).
+fn checkout_sha(
+    repo_dir: &Path,
+    url: &str,
+    sha: &str,
+    options: &FetchOptions,
+) -> crate::Result<()> {
     // In clean mode, stash dirty changes first — before any other git operations.
     if options.workspace_state == WorkspaceState::Clean {
         stash_if_dirty(repo_dir, sha)?;
@@ -750,7 +760,7 @@ fn checkout_sha(repo_dir: &Path, sha: &str, options: &FetchOptions) -> crate::Re
     if have_locally {
         debug!("SHA {} already available locally, skipping fetch", sha);
     } else {
-        let mut fetch_args = vec!["fetch", "origin", sha];
+        let mut fetch_args = vec!["fetch", url, sha];
         if options.shallow {
             fetch_args.insert(1, "--depth=1");
         }
@@ -1025,7 +1035,8 @@ mod tests {
             workspace_state: WorkspaceState::Dirty,
             ..Default::default()
         };
-        checkout_sha(dir.path(), &sha1, &options).unwrap();
+        // URL is unused here because the SHA is available locally (no fetch needed).
+        checkout_sha(dir.path(), "unused://url", &sha1, &options).unwrap();
         assert_eq!(get_current_sha(dir.path()).unwrap(), sha1);
     }
 
@@ -1043,7 +1054,7 @@ mod tests {
             workspace_state: WorkspaceState::Clean,
             ..Default::default()
         };
-        checkout_sha(dir.path(), &sha1, &options).unwrap();
+        checkout_sha(dir.path(), "unused://url", &sha1, &options).unwrap();
         assert_eq!(get_current_sha(dir.path()).unwrap(), sha1);
         assert!(!is_working_tree_dirty(dir.path()).unwrap());
     }

--- a/crates/launch-plus-core/src/fetcher.rs
+++ b/crates/launch-plus-core/src/fetcher.rs
@@ -206,15 +206,9 @@ fn fetch_repo_sparse(
     options: &FetchOptions,
 ) -> crate::Result<()> {
     if repo_dir.exists() && repo_dir.join(".git").exists() {
-        // Blobless/partial clones use origin as the promisor remote for lazy
-        // blob fetches.  Ensure it points to the lockfile URL so that both
-        // explicit fetches and lazy object requests work after a URL change.
-        crate::indexer::ensure_remote_url(repo_dir, url)?;
-
         match options.workspace_state {
             WorkspaceState::Dirty => {
                 // Dirty mode: never touch existing repos — use whatever is on disk.
-                // Log the current state so the user knows what they're getting.
                 if let Ok(Some(description)) = describe_repo_state(repo_dir, sha) {
                     info!(
                         "Using as-is (--dirty) {} :\n  {}",
@@ -229,6 +223,9 @@ fn fetch_repo_sparse(
                 }
             }
             WorkspaceState::Default => {
+                // Sync origin for partial clones so lazy blob fetches work.
+                crate::indexer::ensure_remote_url(repo_dir, url)?;
+
                 if !repo_dir.join(".git").join("index").exists() {
                     // The indexer leaves a blobless --no-checkout clone: .git exists
                     // but no index file (nothing was ever checked out).  HEAD points
@@ -251,6 +248,8 @@ fn fetch_repo_sparse(
                 }
             }
             WorkspaceState::Clean => {
+                // Sync origin for partial clones so lazy blob fetches work.
+                crate::indexer::ensure_remote_url(repo_dir, url)?;
                 // Clean mode: reset to pinned SHA (with auto-stash).
                 update_sparse_checkout(repo_dir, url, sha, paths, options)?;
             }

--- a/crates/launch-plus-core/src/fetcher.rs
+++ b/crates/launch-plus-core/src/fetcher.rs
@@ -338,6 +338,20 @@ fn update_sparse_checkout(
         paths
     );
 
+    // The indexer leaves a blobless --no-checkout clone: .git exists but no
+    // index file.  Detect this and bootstrap sparse-checkout before anything
+    // else, regardless of workspace_state.
+    if !repo_dir.join(".git").join("index").exists() {
+        info!(
+            "Initializing sparse-checkout for no-checkout clone at {}",
+            repo_dir.display()
+        );
+        init_sparse_checkout(repo_dir)?;
+        set_sparse_checkout_paths(repo_dir, paths)?;
+        checkout_sha(repo_dir, url, sha, options)?;
+        return Ok(());
+    }
+
     let sparse_enabled = is_sparse_checkout_enabled(repo_dir);
 
     if !sparse_enabled {

--- a/crates/launch-plus-core/src/indexer.rs
+++ b/crates/launch-plus-core/src/indexer.rs
@@ -1169,15 +1169,33 @@ pub fn blobless_clone(url: &str, repo_dir: &Path) -> crate::Result<()> {
     Ok(())
 }
 
-/// Ensure the origin remote URL matches `expected_url`.
+/// Ensure the origin remote URL matches `expected_url` for partial clones.
 ///
-/// Blobless clones use origin as the promisor remote for lazy blob fetches
-/// (e.g. `git show`, `git checkout`).  If the manifest URL changed, origin
-/// must be updated so that both explicit fetches and lazy object requests
-/// go to the correct server.
+/// Blobless/partial clones use origin as the promisor remote for lazy blob
+/// fetches (e.g. `git show`, `git checkout`).  If the manifest URL changed,
+/// origin must be updated so that lazy object requests go to the correct
+/// server.
 ///
-/// This is a no-op when the URL already matches.
+/// This is a no-op when:
+/// - The URL already matches
+/// - The repo has no `origin` remote (e.g. a manually created repo)
+/// - The repo is not a partial clone (no promisor remote to fix)
 pub fn ensure_remote_url(repo_dir: &Path, expected_url: &str) -> crate::Result<()> {
+    // Only act on partial clones — full clones don't have a promisor remote,
+    // so rewriting origin would be a surprising side effect.
+    let is_partial = Command::new("git")
+        .current_dir(repo_dir)
+        .args(["config", "--get", "remote.origin.partialclonefilter"])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false);
+
+    if !is_partial {
+        return Ok(());
+    }
+
     let current_url = Command::new("git")
         .current_dir(repo_dir)
         .args(["remote", "get-url", "origin"])
@@ -1188,7 +1206,12 @@ pub fn ensure_remote_url(repo_dir: &Path, expected_url: &str) -> crate::Result<(
         .filter(|o| o.status.success())
         .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string());
 
-    if current_url.as_deref() == Some(expected_url) {
+    // No origin remote — unusual, but not our concern.
+    let Some(current_url) = current_url else {
+        return Ok(());
+    };
+
+    if current_url == expected_url {
         return Ok(());
     }
 

--- a/crates/launch-plus-core/src/indexer.rs
+++ b/crates/launch-plus-core/src/indexer.rs
@@ -218,7 +218,7 @@ pub fn resolve_version_local(
     // which may point to a different URL than the manifest specifies.
     let output = Command::new("git")
         .current_dir(repo_dir)
-        .args(["fetch", url, version_ref])
+        .args(["fetch", "--", url, version_ref])
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .output()
@@ -934,7 +934,7 @@ fn discover_packages_from_existing_repo(
     debug!("Fetching {} from {} in existing repo...", sha, url);
     let fetch_result = Command::new("git")
         .current_dir(repo_dir)
-        .args(["fetch", url, sha, "--depth=1"])
+        .args(["fetch", "--depth=1", "--", url, sha])
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .output();
@@ -945,7 +945,7 @@ fn discover_packages_from_existing_repo(
             debug!("Specific SHA fetch failed, trying general fetch...");
             let _ = Command::new("git")
                 .current_dir(repo_dir)
-                .args(["fetch", url, "--depth=1"])
+                .args(["fetch", "--depth=1", "--", url])
                 .stdout(Stdio::piped())
                 .stderr(Stdio::piped())
                 .output();
@@ -1124,7 +1124,7 @@ fn discover_packages_from_submodules(
                             let fetch_url = entry.url.as_deref().unwrap_or("origin");
                             let _ = Command::new("git")
                                 .current_dir(&submodule_dir)
-                                .args(["fetch", fetch_url, submodule_sha, "--depth=1"])
+                                .args(["fetch", "--depth=1", "--", fetch_url, submodule_sha])
                                 .stdout(Stdio::piped())
                                 .stderr(Stdio::piped())
                                 .output();

--- a/crates/launch-plus-core/src/indexer.rs
+++ b/crates/launch-plus-core/src/indexer.rs
@@ -1169,6 +1169,52 @@ pub fn blobless_clone(url: &str, repo_dir: &Path) -> crate::Result<()> {
     Ok(())
 }
 
+/// Ensure the origin remote URL matches `expected_url`.
+///
+/// Blobless clones use origin as the promisor remote for lazy blob fetches
+/// (e.g. `git show`, `git checkout`).  If the manifest URL changed, origin
+/// must be updated so that both explicit fetches and lazy object requests
+/// go to the correct server.
+///
+/// This is a no-op when the URL already matches.
+pub fn ensure_remote_url(repo_dir: &Path, expected_url: &str) -> crate::Result<()> {
+    let current_url = Command::new("git")
+        .current_dir(repo_dir)
+        .args(["remote", "get-url", "origin"])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string());
+
+    if current_url.as_deref() == Some(expected_url) {
+        return Ok(());
+    }
+
+    debug!(
+        "Updating origin URL for {} to {}",
+        repo_dir.display(),
+        expected_url
+    );
+    let output = Command::new("git")
+        .current_dir(repo_dir)
+        .args(["remote", "set-url", "origin", expected_url])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .map_err(|e| crate::Error::Git(format!("failed to run git remote set-url: {e}")))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(crate::Error::Git(format!(
+            "git remote set-url origin failed: {stderr}"
+        )));
+    }
+
+    Ok(())
+}
+
 /// Resolve a version (tag, branch, or SHA) to a concrete SHA.
 ///
 /// Resolution strategy:
@@ -1201,6 +1247,12 @@ fn resolve_version_from_repo(
     // Ensure a local clone exists to resolve from.
     if !dir.join(".git").exists() {
         blobless_clone(url, dir)?;
+    } else {
+        // Blobless clones use origin as the promisor remote for lazy blob
+        // fetches.  If the manifest URL changed (e.g. switched to a fork),
+        // update origin so that both explicit fetches and lazy blob requests
+        // go to the right place.
+        ensure_remote_url(dir, url)?;
     }
 
     resolve_version_local(dir, url, version)

--- a/crates/launch-plus-core/src/indexer.rs
+++ b/crates/launch-plus-core/src/indexer.rs
@@ -1823,4 +1823,113 @@ repositories:
         assert!(info.dependencies.build.contains(&"rclcpp".to_string()));
         assert!(info.dependencies.exec.contains(&"std_msgs".to_string()));
     }
+
+    // ── ensure_remote_url ───────────────────────────────────────────────
+
+    /// Helper: create a git repo and run commands in it.
+    fn git(dir: &std::path::Path, args: &[&str]) {
+        let output = Command::new("git")
+            .current_dir(dir)
+            .args(args)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "git {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    /// Helper: read origin URL from a repo.
+    fn get_origin_url(dir: &std::path::Path) -> Option<String> {
+        Command::new("git")
+            .current_dir(dir)
+            .args(["remote", "get-url", "origin"])
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output()
+            .ok()
+            .filter(|o| o.status.success())
+            .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+    }
+
+    #[test]
+    fn test_ensure_remote_url_noop_for_full_clone() {
+        let dir = tempfile::tempdir().unwrap();
+        git(dir.path(), &["init", "-b", "main"]);
+        git(
+            dir.path(),
+            &[
+                "remote",
+                "add",
+                "origin",
+                "https://old.example.com/repo.git",
+            ],
+        );
+
+        // Full clone (no partialclonefilter) — should not touch origin.
+        ensure_remote_url(dir.path(), "https://new.example.com/repo.git").unwrap();
+        assert_eq!(
+            get_origin_url(dir.path()).as_deref(),
+            Some("https://old.example.com/repo.git")
+        );
+    }
+
+    #[test]
+    fn test_ensure_remote_url_updates_partial_clone() {
+        let dir = tempfile::tempdir().unwrap();
+        git(dir.path(), &["init", "-b", "main"]);
+        git(
+            dir.path(),
+            &[
+                "remote",
+                "add",
+                "origin",
+                "https://old.example.com/repo.git",
+            ],
+        );
+        // Simulate partial clone config.
+        git(
+            dir.path(),
+            &["config", "remote.origin.partialclonefilter", "blob:none"],
+        );
+
+        ensure_remote_url(dir.path(), "https://new.example.com/repo.git").unwrap();
+        assert_eq!(
+            get_origin_url(dir.path()).as_deref(),
+            Some("https://new.example.com/repo.git")
+        );
+    }
+
+    #[test]
+    fn test_ensure_remote_url_noop_when_url_matches() {
+        let dir = tempfile::tempdir().unwrap();
+        git(dir.path(), &["init", "-b", "main"]);
+        git(
+            dir.path(),
+            &["remote", "add", "origin", "https://example.com/repo.git"],
+        );
+        git(
+            dir.path(),
+            &["config", "remote.origin.partialclonefilter", "blob:none"],
+        );
+
+        // URL already matches — no-op.
+        ensure_remote_url(dir.path(), "https://example.com/repo.git").unwrap();
+        assert_eq!(
+            get_origin_url(dir.path()).as_deref(),
+            Some("https://example.com/repo.git")
+        );
+    }
+
+    #[test]
+    fn test_ensure_remote_url_noop_without_origin() {
+        let dir = tempfile::tempdir().unwrap();
+        git(dir.path(), &["init", "-b", "main"]);
+        // No origin remote at all — should not error.
+        ensure_remote_url(dir.path(), "https://example.com/repo.git").unwrap();
+    }
 }

--- a/crates/launch-plus-core/src/indexer.rs
+++ b/crates/launch-plus-core/src/indexer.rs
@@ -1036,11 +1036,6 @@ fn discover_packages_from_submodules(
     repo_dir: &Path,
     sha: &str,
 ) -> crate::Result<Vec<PackageInfo>> {
-    struct SubmoduleEntry {
-        path: String,
-        url: Option<String>,
-    }
-
     // Parse .gitmodules to find submodule paths
     let gitmodules_ref = format!("{}:.gitmodules", sha);
     let output = Command::new("git")
@@ -1062,86 +1057,72 @@ fn discover_packages_from_submodules(
     let gitmodules = String::from_utf8_lossy(&output.stdout);
     let mut packages = Vec::new();
 
-    // Parse submodule entries from .gitmodules
+    // Parse submodule paths from .gitmodules
     // Format: [submodule "name"]\n\tpath = <path>\n\turl = <url>
-    let mut entries: Vec<SubmoduleEntry> = Vec::new();
     let mut current_path: Option<String> = None;
-    let mut current_url: Option<String> = None;
     for line in gitmodules.lines() {
         let trimmed = line.trim();
-        if trimmed.starts_with("[submodule") {
-            // Flush previous entry
-            if let Some(path) = current_path.take() {
-                entries.push(SubmoduleEntry {
-                    path,
-                    url: current_url.take(),
-                });
-            }
-            current_url = None;
-        } else if trimmed.starts_with("path = ") {
+        if trimmed.starts_with("path = ") {
             current_path = Some(trimmed.strip_prefix("path = ").unwrap().to_string());
-        } else if trimmed.starts_with("url = ") {
-            current_url = Some(trimmed.strip_prefix("url = ").unwrap().to_string());
+        } else if trimmed.starts_with("[submodule") {
+            current_path = None;
         }
-    }
-    // Flush last entry
-    if let Some(path) = current_path.take() {
-        entries.push(SubmoduleEntry {
-            path,
-            url: current_url.take(),
-        });
-    }
 
-    for entry in &entries {
-        // Get the submodule commit SHA from the tree
-        let output = Command::new("git")
-            .current_dir(repo_dir)
-            .args(["ls-tree", sha, &entry.path])
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .output();
+        if let Some(ref path) = current_path {
+            // Get the submodule commit SHA from the tree
+            let output = Command::new("git")
+                .current_dir(repo_dir)
+                .args(["ls-tree", sha, path])
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped())
+                .output();
 
-        if let Ok(output) = output {
-            if output.status.success() {
-                let stdout = String::from_utf8_lossy(&output.stdout);
-                // Format: "160000 commit <sha>\t<path>"
-                if let Some(line) = stdout.lines().next() {
-                    let parts: Vec<&str> = line.split_whitespace().collect();
-                    if parts.len() >= 3 && parts[1] == "commit" {
-                        let submodule_sha = parts[2];
-                        let submodule_dir = repo_dir.join(&entry.path);
+            if let Ok(output) = output {
+                if output.status.success() {
+                    let stdout = String::from_utf8_lossy(&output.stdout);
+                    // Format: "160000 commit <sha>\t<path>"
+                    if let Some(line) = stdout.lines().next() {
+                        let parts: Vec<&str> = line.split_whitespace().collect();
+                        if parts.len() >= 3 && parts[1] == "commit" {
+                            let submodule_sha = parts[2];
+                            let submodule_dir = repo_dir.join(path);
 
-                        // If submodule is initialized, inspect its objects
-                        if submodule_dir.join(".git").exists() {
-                            debug!(
-                                "Inspecting submodule at {} (SHA: {})",
-                                entry.path,
-                                &submodule_sha[..8.min(submodule_sha.len())]
-                            );
+                            // If submodule is initialized, inspect its objects
+                            if submodule_dir.join(".git").exists() {
+                                debug!(
+                                    "Inspecting submodule at {} (SHA: {})",
+                                    path,
+                                    &submodule_sha[..8.min(submodule_sha.len())]
+                                );
 
-                            // Fetch the submodule SHA directly from its URL
-                            // (not via "origin" which may point elsewhere).
-                            let fetch_url = entry.url.as_deref().unwrap_or("origin");
-                            let _ = Command::new("git")
-                                .current_dir(&submodule_dir)
-                                .args(["fetch", "--depth=1", "--", fetch_url, submodule_sha])
-                                .stdout(Stdio::piped())
-                                .stderr(Stdio::piped())
-                                .output();
+                                // Use "origin" here: submodules are initialized by
+                                // `git submodule init` which resolves .gitmodules URLs
+                                // (often relative) against the superproject remote and
+                                // sets origin accordingly.  Unlike the superproject,
+                                // submodule origin is managed by git, not the user.
+                                let _ = Command::new("git")
+                                    .current_dir(&submodule_dir)
+                                    .args(["fetch", "--depth=1", "origin", submodule_sha])
+                                    .stdout(Stdio::piped())
+                                    .stderr(Stdio::piped())
+                                    .output();
 
-                            if let Ok(mut sub_packages) =
-                                discover_packages_from_git_objects(&submodule_dir, submodule_sha)
-                            {
-                                // Prefix paths with submodule path
-                                for pkg in &mut sub_packages {
-                                    pkg.path = format!("{}/{}", entry.path, pkg.path);
+                                if let Ok(mut sub_packages) = discover_packages_from_git_objects(
+                                    &submodule_dir,
+                                    submodule_sha,
+                                ) {
+                                    // Prefix paths with submodule path
+                                    for pkg in &mut sub_packages {
+                                        pkg.path = format!("{}/{}", path, pkg.path);
+                                    }
+                                    packages.extend(sub_packages);
                                 }
-                                packages.extend(sub_packages);
                             }
                         }
                     }
                 }
             }
+            current_path = None;
         }
     }
 

--- a/crates/launch-plus-core/src/indexer.rs
+++ b/crates/launch-plus-core/src/indexer.rs
@@ -204,15 +204,21 @@ pub fn serialize_lockfile(lockfile: &Lockfile) -> crate::Result<String> {
 ///
 /// # Arguments
 /// * `repo_dir` - Path to local git clone
+/// * `url` - Git remote URL to fetch from (used directly, not via a named remote)
 /// * `version_ref` - Branch or tag name to resolve
 ///
 /// # Returns
 /// The full 40-character SHA of the fetched ref (via `FETCH_HEAD`)
-pub fn resolve_version_local(repo_dir: &Path, version_ref: &str) -> crate::Result<String> {
-    // Fetch the specific ref from origin
+pub fn resolve_version_local(
+    repo_dir: &Path,
+    url: &str,
+    version_ref: &str,
+) -> crate::Result<String> {
+    // Fetch directly from the URL so we never depend on the named "origin" remote,
+    // which may point to a different URL than the manifest specifies.
     let output = Command::new("git")
         .current_dir(repo_dir)
-        .args(["fetch", "origin", version_ref])
+        .args(["fetch", url, version_ref])
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .output()
@@ -221,7 +227,7 @@ pub fn resolve_version_local(repo_dir: &Path, version_ref: &str) -> crate::Resul
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
         return Err(crate::Error::Git(format!(
-            "git fetch origin {version_ref} failed: {stderr}"
+            "git fetch {url} {version_ref} failed: {stderr}"
         )));
     }
 
@@ -831,7 +837,7 @@ pub fn discover_packages(
     if let Some(dir) = repo_dir {
         if dir.exists() && dir.join(".git").exists() {
             debug!("Using existing repo at {}", dir.display());
-            return discover_packages_from_existing_repo(dir, sha, recurse_submodules);
+            return discover_packages_from_existing_repo(dir, url, sha, recurse_submodules);
         }
     }
 
@@ -862,7 +868,7 @@ pub fn discover_packages(
     })?;
 
     blobless_clone(url, dir)?;
-    discover_packages_from_existing_repo(dir, sha, recurse_submodules)
+    discover_packages_from_existing_repo(dir, url, sha, recurse_submodules)
 }
 
 /// Discover packages from a tar archive (git archive output)
@@ -919,14 +925,16 @@ fn discover_packages_from_tar(tar_data: &[u8]) -> crate::Result<Vec<PackageInfo>
 /// modifying the working directory. This is safe for sparse-checkout repos.
 fn discover_packages_from_existing_repo(
     repo_dir: &Path,
+    url: &str,
     sha: &str,
     recurse_submodules: bool,
 ) -> crate::Result<Vec<PackageInfo>> {
-    // Fetch the SHA (in case it's not available locally)
-    debug!("Fetching {} in existing repo...", sha);
+    // Fetch the SHA directly from the URL (not via named remote "origin",
+    // which may point elsewhere if the user changed it).
+    debug!("Fetching {} from {} in existing repo...", sha, url);
     let fetch_result = Command::new("git")
         .current_dir(repo_dir)
-        .args(["fetch", "origin", sha, "--depth=1"])
+        .args(["fetch", url, sha, "--depth=1"])
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .output();
@@ -937,7 +945,7 @@ fn discover_packages_from_existing_repo(
             debug!("Specific SHA fetch failed, trying general fetch...");
             let _ = Command::new("git")
                 .current_dir(repo_dir)
-                .args(["fetch", "origin", "--depth=1"])
+                .args(["fetch", url, "--depth=1"])
                 .stdout(Stdio::piped())
                 .stderr(Stdio::piped())
                 .output();
@@ -1028,6 +1036,11 @@ fn discover_packages_from_submodules(
     repo_dir: &Path,
     sha: &str,
 ) -> crate::Result<Vec<PackageInfo>> {
+    struct SubmoduleEntry {
+        path: String,
+        url: Option<String>,
+    }
+
     // Parse .gitmodules to find submodule paths
     let gitmodules_ref = format!("{}:.gitmodules", sha);
     let output = Command::new("git")
@@ -1049,68 +1062,86 @@ fn discover_packages_from_submodules(
     let gitmodules = String::from_utf8_lossy(&output.stdout);
     let mut packages = Vec::new();
 
-    // Parse submodule paths from .gitmodules
+    // Parse submodule entries from .gitmodules
     // Format: [submodule "name"]\n\tpath = <path>\n\turl = <url>
+    let mut entries: Vec<SubmoduleEntry> = Vec::new();
     let mut current_path: Option<String> = None;
+    let mut current_url: Option<String> = None;
     for line in gitmodules.lines() {
         let trimmed = line.trim();
-        if trimmed.starts_with("path = ") {
+        if trimmed.starts_with("[submodule") {
+            // Flush previous entry
+            if let Some(path) = current_path.take() {
+                entries.push(SubmoduleEntry {
+                    path,
+                    url: current_url.take(),
+                });
+            }
+            current_url = None;
+        } else if trimmed.starts_with("path = ") {
             current_path = Some(trimmed.strip_prefix("path = ").unwrap().to_string());
-        } else if trimmed.starts_with("[submodule") {
-            current_path = None;
+        } else if trimmed.starts_with("url = ") {
+            current_url = Some(trimmed.strip_prefix("url = ").unwrap().to_string());
         }
+    }
+    // Flush last entry
+    if let Some(path) = current_path.take() {
+        entries.push(SubmoduleEntry {
+            path,
+            url: current_url.take(),
+        });
+    }
 
-        if let Some(ref path) = current_path {
-            // Get the submodule commit SHA from the tree
-            let output = Command::new("git")
-                .current_dir(repo_dir)
-                .args(["ls-tree", sha, path])
-                .stdout(Stdio::piped())
-                .stderr(Stdio::piped())
-                .output();
+    for entry in &entries {
+        // Get the submodule commit SHA from the tree
+        let output = Command::new("git")
+            .current_dir(repo_dir)
+            .args(["ls-tree", sha, &entry.path])
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output();
 
-            if let Ok(output) = output {
-                if output.status.success() {
-                    let stdout = String::from_utf8_lossy(&output.stdout);
-                    // Format: "160000 commit <sha>\t<path>"
-                    if let Some(line) = stdout.lines().next() {
-                        let parts: Vec<&str> = line.split_whitespace().collect();
-                        if parts.len() >= 3 && parts[1] == "commit" {
-                            let submodule_sha = parts[2];
-                            let submodule_dir = repo_dir.join(path);
+        if let Ok(output) = output {
+            if output.status.success() {
+                let stdout = String::from_utf8_lossy(&output.stdout);
+                // Format: "160000 commit <sha>\t<path>"
+                if let Some(line) = stdout.lines().next() {
+                    let parts: Vec<&str> = line.split_whitespace().collect();
+                    if parts.len() >= 3 && parts[1] == "commit" {
+                        let submodule_sha = parts[2];
+                        let submodule_dir = repo_dir.join(&entry.path);
 
-                            // If submodule is initialized, inspect its objects
-                            if submodule_dir.join(".git").exists() {
-                                debug!(
-                                    "Inspecting submodule at {} (SHA: {})",
-                                    path,
-                                    &submodule_sha[..8.min(submodule_sha.len())]
-                                );
+                        // If submodule is initialized, inspect its objects
+                        if submodule_dir.join(".git").exists() {
+                            debug!(
+                                "Inspecting submodule at {} (SHA: {})",
+                                entry.path,
+                                &submodule_sha[..8.min(submodule_sha.len())]
+                            );
 
-                                // Fetch the submodule SHA
-                                let _ = Command::new("git")
-                                    .current_dir(&submodule_dir)
-                                    .args(["fetch", "origin", submodule_sha, "--depth=1"])
-                                    .stdout(Stdio::piped())
-                                    .stderr(Stdio::piped())
-                                    .output();
+                            // Fetch the submodule SHA directly from its URL
+                            // (not via "origin" which may point elsewhere).
+                            let fetch_url = entry.url.as_deref().unwrap_or("origin");
+                            let _ = Command::new("git")
+                                .current_dir(&submodule_dir)
+                                .args(["fetch", fetch_url, submodule_sha, "--depth=1"])
+                                .stdout(Stdio::piped())
+                                .stderr(Stdio::piped())
+                                .output();
 
-                                if let Ok(mut sub_packages) = discover_packages_from_git_objects(
-                                    &submodule_dir,
-                                    submodule_sha,
-                                ) {
-                                    // Prefix paths with submodule path
-                                    for pkg in &mut sub_packages {
-                                        pkg.path = format!("{}/{}", path, pkg.path);
-                                    }
-                                    packages.extend(sub_packages);
+                            if let Ok(mut sub_packages) =
+                                discover_packages_from_git_objects(&submodule_dir, submodule_sha)
+                            {
+                                // Prefix paths with submodule path
+                                for pkg in &mut sub_packages {
+                                    pkg.path = format!("{}/{}", entry.path, pkg.path);
                                 }
+                                packages.extend(sub_packages);
                             }
                         }
                     }
                 }
             }
-            current_path = None;
         }
     }
 
@@ -1191,7 +1222,7 @@ fn resolve_version_from_repo(
         blobless_clone(url, dir)?;
     }
 
-    resolve_version_local(dir, version)
+    resolve_version_local(dir, url, version)
 }
 
 /// Generate a lockfile from a .repos file


### PR DESCRIPTION
## Summary
- All `git fetch origin <ref>` calls in indexer and fetcher replaced with `git fetch -- <url> <ref>`, using the URL from the manifest/lockfile directly. Fixes reindex/fetch failure when a `.repos` entry changes URL (e.g. switching to a fork) while the blobless clone still exists on disk with `origin` pointing to the old URL.
- Blobless clones (`--filter=blob:none`) rely on the `origin` remote for implicit lazy blob fetches — when git encounters a missing blob during `git show` or `git checkout`, it silently fetches from `origin`. If `origin` still points to the old URL, these implicit fetches fail. `ensure_remote_url()` keeps `origin` in sync with the manifest URL for blobless clones only (full clones and `--dirty` mode are never touched).
- Submodule fetches intentionally kept using `origin` — `.gitmodules` URLs are often relative and `git submodule init` already resolves them into the submodule's `origin` remote.
- Fix `fetch` from blobless no-checkout clone state: `update_sparse_checkout` (Clean mode) didn't detect the no-index state, causing a full non-sparse checkout with misleading stash output instead of initializing sparse-checkout properly.
- Add `--` separator to all `git fetch` calls with user-provided URLs to prevent URLs starting with `-` from being parsed as git options.
- Include URL in fetcher's fetch-failure error message for easier debugging.

## Test plan
- [x] `cargo test` — all 208 tests pass (4 new for `ensure_remote_url`)
- [x] Manual: run `index` with original manifest, change a repo URL to a fork with a different branch, run `index` again — should succeed without deleting the existing clone
- [x] Manual: run `fetch` after re-indexing with the forked URL — should fetch the correct SHA from the new URL
- [x] Manual: run `fetch <pkg>` from a fresh blobless clone state — should initialize sparse-checkout and only check out the requested paths, not a full checkout with stash noise

🤖 Generated with [Claude Code](https://claude.com/claude-code)