### PR TITLE
fix(deb): add pybuild-plugin-pyproject to Build-Depends

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
         with:
           node-version: lts/*
       - run: npm install -g pnpm
-      - run: sudo apt-get update && sudo apt-get install -y python3-all debhelper dh-python python3-hatchling
+      - run: sudo apt-get update && sudo apt-get install -y python3-all debhelper dh-python pybuild-plugin-pyproject python3-hatchling
       - run: dpkg-buildpackage -us -uc -b -d
       - uses: actions/upload-artifact@v7
         with:

--- a/debian/control
+++ b/debian/control
@@ -5,6 +5,7 @@ Maintainer: paulsohn <paulsohnjp@gmail.com>
 Build-Depends:
  debhelper-compat (= 13),
  dh-python,
+ pybuild-plugin-pyproject,
  python3-all,
  python3-hatchling
 Standards-Version: 4.6.2


### PR DESCRIPTION
## Summary

- `pybuild-plugin-pyproject` is a separate apt package not pulled in transitively by `dh-python`; without it pybuild fails at configure with _"PEP517 plugin dependencies are not available"_
- Add it to both `debian/control` Build-Depends and the workflow apt install step

## Test plan

- [ ] Verify `build-deb` passes on ubuntu-22.04 and ubuntu-24.04

🤖 Generated with [Claude Code](https://claude.com/claude-code)