### PR TITLE
fix(ci): pre-build frontend before dpkg-buildpackage

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,8 @@ jobs:
       - run: pnpm run build
         working-directory: roscope_viz
       - run: sudo apt-get update && sudo apt-get install -y python3-all debhelper dh-python pybuild-plugin-pyproject python3-hatchling
-      - run: dpkg-buildpackage -us -uc -b -d --output-directory .
+      - run: dpkg-buildpackage -us -uc -b -d
+      - run: mv ../*.deb .
       - uses: actions/upload-artifact@v7
         with:
           name: deb-${{ matrix.os }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,6 +62,10 @@ jobs:
         with:
           node-version: lts/*
       - run: npm install -g pnpm
+      - run: pnpm install --frozen-lockfile
+        working-directory: roscope_viz
+      - run: pnpm run build
+        working-directory: roscope_viz
       - run: sudo apt-get update && sudo apt-get install -y python3-all debhelper dh-python pybuild-plugin-pyproject python3-hatchling
       - run: dpkg-buildpackage -us -uc -b -d
       - uses: actions/upload-artifact@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,11 +67,11 @@ jobs:
       - run: pnpm run build
         working-directory: roscope_viz
       - run: sudo apt-get update && sudo apt-get install -y python3-all debhelper dh-python pybuild-plugin-pyproject python3-hatchling
-      - run: dpkg-buildpackage -us -uc -b -d
+      - run: dpkg-buildpackage -us -uc -b -d --output-directory .
       - uses: actions/upload-artifact@v7
         with:
           name: deb-${{ matrix.os }}
-          path: ../*.deb
+          path: "*.deb"
 
   release:
     name: Create Release


### PR DESCRIPTION
## Summary

`pnpm install` fails inside the `dpkg-buildpackage` subprocess environment (likely due to PATH or environment isolation). Pre-build the frontend in dedicated steps before `dpkg-buildpackage` runs; `hatch_build.py` already skips the build when `roscope/visualizer/static/index.html` is present.

## Test plan

- [x] Verify `build-deb` passes on ubuntu-22.04 and ubuntu-24.04

🤖 Generated with [Claude Code](https://claude.com/claude-code)