### PR TITLE
feat: dirty mode scans src/ instead of requiring a lockfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,9 +197,14 @@ Commands that refer to source code support workspace state flags:
 
 | Flag | Short | When to use |
 |---|---|---|
-| `--clean` | `-c` | CI / reproducible runs — resets repos to lockfile SHAs |
-| `--dirty` | `-d` | Local iteration — uses whatever is on disk |
 | *(default)* | | Verifies HEAD matches lockfile SHA; errors on mismatch |
+| `--clean` | `-c` | CI / reproducible runs — resets repos to lockfile SHAs |
+| `--dirty` | `-d` | No lockfile required — scans `src/` for packages as-is |
+
+In dirty mode roscope does not read a lockfile.  Instead it walks the source
+directory (default: `src/`) looking for `package.xml` files.  This supports
+workflows where `src/` is populated by `vcs import` without generating a
+lockfile first.
 
 ## Documentation
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -128,17 +128,39 @@ reads files as they exist in the source directory.
 ## Workspace state: clean vs dirty
 
 Every command that refers to source code supports **workspace state flags** that
-control how roscope treats the on-disk state of fetched repositories:
+control how roscope locates and validates source packages.
 
-- **`--clean` (`-c`)** — Resets every fetched repository to the exact SHA
-  recorded in the lockfile.  Guarantees reproducible output.  Use in CI.
-- **`--dirty` (`-d`)** — Uses whatever is currently on disk.  Only fetches
-  repositories that are completely missing.  Use during local development to
-  preserve your edits.
-- **Default (no flag)** — Verifies that each repository's HEAD matches the
-  lockfile SHA and that the working tree is clean.  Errors if either check
-  fails.  This is the safest mode: it refuses to proceed on ambiguous state
-  without forcing any changes.
+- **Default (no flag)** — Requires a lockfile.  Verifies that each fetched
+  repository's HEAD matches the lockfile SHA and that the working tree is clean.
+  Errors if either check fails.  This is the safest mode: it refuses to proceed
+  on ambiguous state without forcing any changes.
+- **`--clean` (`-c`)** — Requires a lockfile.  Resets every fetched repository
+  to the exact SHA recorded in the lockfile.  Guarantees reproducible output.
+  Use in CI.
+- **`--dirty` (`-d`)** — **Does not require a lockfile.**  Instead, roscope
+  walks the `src/` directory (or the path given by `--src`) looking for
+  `package.xml` files.  Every directory containing a `package.xml` is treated
+  as a package at exactly the version on disk — no git operations are performed.
+  Packages not found in `src/` and not installable via rosdep are an error.
+  Use this mode when you have already populated `src/` with `vcs import` and
+  want to resolve without generating a lockfile first.
+
+### Dirty mode and the `vcs import` workflow
+
+Dirty mode is designed for teams that manage their source directory with
+`vcs import` but do not (yet) use a roscope lockfile:
+
+```bash
+vcs import src < my_project.repos   # populate src/ from your .repos file
+roscope resolve -d my_bringup robot.launch.xml
+```
+
+roscope scans `src/` exhaustively — recursing into subdirectories until it
+finds a `package.xml`, then treating that directory as a package root (without
+recursing further into it).  Only `.git/` directories are skipped.
+
+If `--lockfile` is also passed with `--dirty`, roscope emits a warning and
+ignores the lockfile entirely.
 
 ## Resolution modes
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -86,15 +86,16 @@ roscope resolve -d my_bringup robot.launch.xml \
 ```
 
 This will:
-1. Look up `my_bringup` in the lockfile
-2. Sparse-checkout just the `my_bringup` package
+1. Look up `my_bringup` in the lockfile (or scan `src/` in dirty mode)
+2. Sparse-checkout just the `my_bringup` package (lockfile modes only)
 3. Parse `robot.launch.xml`, following all `<include>` tags
 4. Fetch additional packages as they're discovered in the launch graph
 5. Output a single flattened XML with all includes inlined, variables
    substituted, and conditionals evaluated
 
-The `-d` (dirty) flag tells roscope to use whatever is on disk and only
-fetch what's missing.  Use `-c` (clean) for CI to ensure reproducibility.
+The `-d` (dirty) flag tells roscope to use `src/` as-is — no lockfile
+required, no git operations performed.  Use `-c` (clean) for CI to ensure
+reproducibility.
 
 ### Useful resolve flags
 
@@ -105,6 +106,36 @@ fetch what's missing.  Use `-c` (clean) for CI to ensure reproducibility.
 # Install system deps via rosdep (requires sourced ROS 2)
 --rosdep
 ```
+
+## Lockfile-free workflow (dirty mode)
+
+If you already manage your source directory with `vcs import` and do not want
+to generate a lockfile first, you can use dirty mode (`-d`) directly:
+
+```bash
+# Populate src/ from your .repos file
+vcs import src < my_project.repos
+
+# Resolve without a lockfile — roscope scans src/ for packages
+roscope resolve -d my_bringup robot.launch.xml \
+  robot_name:=my_robot \
+  --preview \
+  > resolved.launch.xml
+
+# Build likewise
+roscope build -d my_bringup robot.launch.xml \
+  robot_name:=my_robot \
+  --rosdep
+```
+
+In dirty mode roscope walks `src/` exhaustively to discover all packages.
+It does not perform any git operations; whatever is on disk is used as-is.
+Packages not found in `src/` must be available via rosdep (with `--rosdep`)
+or already installed in `AMENT_PREFIX_PATH`; otherwise resolution fails with
+an error.
+
+To switch to the full lockfile workflow later, run `roscope index` to generate
+a lockfile from your `.repos` manifest and commit it to your repository.
 
 ## Step 4: Build
 

--- a/roscope/cli.py
+++ b/roscope/cli.py
@@ -51,6 +51,8 @@ def _parse_workspace_state(clean: bool, dirty: bool) -> WorkspaceState:
     """Map --clean/--dirty flags to WorkspaceState."""
     from roscope.fetcher import WorkspaceState
 
+    if clean and dirty:
+        raise click.UsageError("--clean and --dirty are mutually exclusive")
     if clean:
         return WorkspaceState.CLEAN
     if dirty:
@@ -117,10 +119,9 @@ def _load_lockfile(
 
     if workspace_state == WorkspaceState.DIRTY:
         src_path = Path(src_dir)
-        if not src_path.exists():
+        if not src_path.is_dir():
             raise click.ClickException(
-                f"source directory '{src_dir}' does not exist; "
-                "cannot scan for packages in --dirty mode"
+                f"'{src_dir}' is not a directory; cannot scan for packages in --dirty mode"
             )
         return scan_source_dir(src_path)
 
@@ -452,12 +453,7 @@ def update(
 
 @main.command()
 @click.argument("packages", nargs=-1, required=True)
-@click.option(
-    "-l",
-    "--lockfile",
-    default="manifest.lock.repos",
-    help="Lockfile path (ignored in --dirty mode; src/ is scanned instead)",
-)
+@click.option("-l", "--lockfile", default="manifest.lock.repos", help="Lockfile path")
 @click.option("--src", default="src", help="Fetch directory")
 @click.option("--no-recurse-submodules", is_flag=True)
 @click.option("--shallow", is_flag=True, help="Use shallow clone (depth=1)")
@@ -541,12 +537,16 @@ def resolve(
     """Resolve launch file (no build)."""
     from click.core import ParameterSource  # type: ignore[attr-defined]
 
+    from roscope.fetcher import WorkspaceState
     from roscope.orchestrator import ResolveWorkflowOptions
 
     initial_args = _parse_launch_args(args)
     workspace_state = _parse_workspace_state(clean, dirty)
 
-    if dirty and ctx.get_parameter_source("lockfile") == ParameterSource.COMMANDLINE:  # type: ignore[attr-defined,union-attr]
+    lockfile_explicit = (
+        ctx.get_parameter_source("lockfile") == ParameterSource.COMMANDLINE  # type: ignore[attr-defined]
+    )
+    if workspace_state == WorkspaceState.DIRTY and lockfile_explicit:
         click.echo(
             f"warning: --lockfile is ignored in --dirty mode"
             f" ({src.rstrip('/')}/ is scanned instead)",
@@ -619,12 +619,16 @@ def check(
     """Validate launch file without running."""
     from click.core import ParameterSource  # type: ignore[attr-defined]
 
+    from roscope.fetcher import WorkspaceState
     from roscope.orchestrator import ResolveWorkflowOptions
 
     initial_args = _parse_launch_args(args)
     workspace_state = _parse_workspace_state(clean, dirty)
 
-    if dirty and ctx.get_parameter_source("lockfile") == ParameterSource.COMMANDLINE:  # type: ignore[attr-defined,union-attr]
+    lockfile_explicit = (
+        ctx.get_parameter_source("lockfile") == ParameterSource.COMMANDLINE  # type: ignore[attr-defined]
+    )
+    if workspace_state == WorkspaceState.DIRTY and lockfile_explicit:
         click.echo(
             f"warning: --lockfile is ignored in --dirty mode"
             f" ({src.rstrip('/')}/ is scanned instead)",
@@ -699,12 +703,16 @@ def build(
     """Fetch and build packages for a launcher."""
     from click.core import ParameterSource  # type: ignore[attr-defined]
 
+    from roscope.fetcher import WorkspaceState
     from roscope.orchestrator import ResolveWorkflowOptions
 
     initial_args = _parse_launch_args(args)
     workspace_state = _parse_workspace_state(clean, dirty)
 
-    if dirty and ctx.get_parameter_source("lockfile") == ParameterSource.COMMANDLINE:  # type: ignore[attr-defined,union-attr]
+    lockfile_explicit = (
+        ctx.get_parameter_source("lockfile") == ParameterSource.COMMANDLINE  # type: ignore[attr-defined]
+    )
+    if workspace_state == WorkspaceState.DIRTY and lockfile_explicit:
         click.echo(
             f"warning: --lockfile is ignored in --dirty mode"
             f" ({src.rstrip('/')}/ is scanned instead)",
@@ -777,13 +785,26 @@ def build_pkg(
     dry_run: bool,
 ) -> None:
     """Build package(s) by name with automatic transitive dependency fetching."""
+    from click.core import ParameterSource  # type: ignore[attr-defined]
+
     from roscope.builder import BuildOptions, execute_build, plan_build_from_packages
-    from roscope.fetcher import FetchOptions, fetch_packages
+    from roscope.fetcher import FetchOptions, WorkspaceState, fetch_packages
     from roscope.rosdep import rosdep_install
 
-    parsed_lockfile = _read_lockfile(lockfile)
     src_path = Path(src)
     workspace_state = _parse_workspace_state(clean, dirty)
+
+    lockfile_explicit = (
+        ctx.get_parameter_source("lockfile") == ParameterSource.COMMANDLINE  # type: ignore[attr-defined]
+    )
+    if workspace_state == WorkspaceState.DIRTY and lockfile_explicit:
+        click.echo(
+            f"warning: --lockfile is ignored in --dirty mode"
+            f" ({src.rstrip('/')}/ is scanned instead)",
+            err=True,
+        )
+
+    parsed_lockfile = _load_lockfile(lockfile, src, workspace_state)
 
     fetch_options = FetchOptions(
         recurse_submodules=True,

--- a/roscope/cli.py
+++ b/roscope/cli.py
@@ -857,7 +857,12 @@ def build_pkg(
 @click.argument("package")
 @click.argument("launcher")
 @click.argument("args", nargs=-1)
-@click.option("-l", "--lockfile", default="manifest.lock.repos")
+@click.option(
+    "-l",
+    "--lockfile",
+    default="manifest.lock.repos",
+    help="Lockfile path (ignored in --dirty mode; src/ is scanned instead)",
+)
 @click.option("--src", default="src")
 @click.option("-c", "--clean", is_flag=True)
 @click.option("-d", "--dirty", is_flag=True)
@@ -887,10 +892,23 @@ def test_cmd(
     dry_run: bool,
 ) -> None:
     """Fetch, build, and run tests (includes test_depend packages)."""
+    from click.core import ParameterSource  # type: ignore[attr-defined]
+
+    from roscope.fetcher import WorkspaceState
     from roscope.orchestrator import ResolveWorkflowOptions
 
     initial_args = _parse_launch_args(args)
     workspace_state = _parse_workspace_state(clean, dirty)
+
+    lockfile_explicit = (
+        ctx.get_parameter_source("lockfile") == ParameterSource.COMMANDLINE  # type: ignore[attr-defined]
+    )
+    if workspace_state == WorkspaceState.DIRTY and lockfile_explicit:
+        click.echo(
+            f"warning: --lockfile is ignored in --dirty mode"
+            f" ({src.rstrip('/')}/ is scanned instead)",
+            err=True,
+        )
 
     workflow_options = ResolveWorkflowOptions(
         preview=True,

--- a/roscope/cli.py
+++ b/roscope/cli.py
@@ -98,6 +98,35 @@ def _read_lockfile(lockfile_path: str) -> Lockfile:
     return parse_lockfile(content)
 
 
+def _load_lockfile(
+    lockfile_path: str,
+    src_dir: str,
+    workspace_state: WorkspaceState,
+) -> Lockfile:
+    """Load a lockfile appropriate for the current workspace state.
+
+    In dirty mode the lockfile is ignored entirely: the source directory is
+    scanned for ``package.xml`` files and a synthetic lockfile is built on the
+    fly.  This supports workflows where users populate ``src/`` via
+    ``vcs import`` without generating a lockfile first.
+
+    In default or clean mode the lockfile is required and loaded normally.
+    """
+    from roscope.fetcher import WorkspaceState
+    from roscope.indexer import scan_source_dir
+
+    if workspace_state == WorkspaceState.DIRTY:
+        src_path = Path(src_dir)
+        if not src_path.exists():
+            raise click.ClickException(
+                f"source directory '{src_dir}' does not exist; "
+                "cannot scan for packages in --dirty mode"
+            )
+        return scan_source_dir(src_path)
+
+    return _read_lockfile(lockfile_path)
+
+
 def _contains_git_dir(path: Path) -> bool:
     """Check if a directory contains a .git directory (recursively)."""
     if (path / ".git").exists():
@@ -423,7 +452,12 @@ def update(
 
 @main.command()
 @click.argument("packages", nargs=-1, required=True)
-@click.option("-l", "--lockfile", default="manifest.lock.repos", help="Lockfile path")
+@click.option(
+    "-l",
+    "--lockfile",
+    default="manifest.lock.repos",
+    help="Lockfile path (ignored in --dirty mode; src/ is scanned instead)",
+)
 @click.option("--src", default="src", help="Fetch directory")
 @click.option("--no-recurse-submodules", is_flag=True)
 @click.option("--shallow", is_flag=True, help="Use shallow clone (depth=1)")
@@ -464,7 +498,12 @@ def fetch(
 @click.argument("package")
 @click.argument("launcher")
 @click.argument("args", nargs=-1)
-@click.option("-l", "--lockfile", default="manifest.lock.repos", help="Lockfile path")
+@click.option(
+    "-l",
+    "--lockfile",
+    default="manifest.lock.repos",
+    help="Lockfile path (ignored in --dirty mode; src/ is scanned instead)",
+)
 @click.option("--src", default="src", help="Source directory")
 @click.option("--report", is_flag=True, help="Print dependency report to stderr")
 @click.option("--preview", is_flag=True, help="Resolve from source workspace")
@@ -540,7 +579,12 @@ def resolve(
 @click.argument("package")
 @click.argument("launcher")
 @click.argument("args", nargs=-1)
-@click.option("-l", "--lockfile", default="manifest.lock.repos", help="Lockfile path")
+@click.option(
+    "-l",
+    "--lockfile",
+    default="manifest.lock.repos",
+    help="Lockfile path (ignored in --dirty mode; src/ is scanned instead)",
+)
 @click.option("--src", default="src", help="Source directory")
 @click.option("--preview", is_flag=True)
 @click.option("--rosdep", is_flag=True)
@@ -600,7 +644,12 @@ def check(
 @click.argument("package")
 @click.argument("launcher")
 @click.argument("args", nargs=-1)
-@click.option("-l", "--lockfile", default="manifest.lock.repos", help="Lockfile path")
+@click.option(
+    "-l",
+    "--lockfile",
+    default="manifest.lock.repos",
+    help="Lockfile path (ignored in --dirty mode; src/ is scanned instead)",
+)
 @click.option("--src", default="src", help="Source directory")
 @click.option("-c", "--clean", is_flag=True)
 @click.option("-d", "--dirty", is_flag=True)
@@ -668,7 +717,12 @@ def build(
 
 @main.command("build-pkg")
 @click.argument("packages", nargs=-1, required=True)
-@click.option("-l", "--lockfile", default="manifest.lock.repos", help="Lockfile path")
+@click.option(
+    "-l",
+    "--lockfile",
+    default="manifest.lock.repos",
+    help="Lockfile path (ignored in --dirty mode; src/ is scanned instead)",
+)
 @click.option("--src", default="src", help="Source directory")
 @click.option("-c", "--clean", is_flag=True)
 @click.option("-d", "--dirty", is_flag=True)
@@ -872,7 +926,7 @@ def _cmd_resolve(
     from roscope.orchestrator import resolve_launch_recursive
     from roscope.renderer import render_resolved_xml
 
-    parsed_lockfile = _read_lockfile(lockfile_path)
+    parsed_lockfile = _load_lockfile(lockfile_path, src_dir, workspace_state)
     fetch_path = Path(src_dir)
     options = FetchOptions(
         recurse_submodules=True,
@@ -987,7 +1041,7 @@ def _run_build(
     from roscope.orchestrator import resolve_launch_recursive
     from roscope.rosdep import rosdep_install
 
-    parsed_lockfile = _read_lockfile(lockfile_path)
+    parsed_lockfile = _load_lockfile(lockfile_path, src_dir, workspace_state)
     fetch_path = Path(src_dir)
     fetch_options = FetchOptions(
         recurse_submodules=True,

--- a/roscope/cli.py
+++ b/roscope/cli.py
@@ -780,7 +780,7 @@ def build_pkg(
 ) -> None:
     """Build package(s) by name with automatic transitive dependency fetching."""
     from roscope.builder import BuildOptions, execute_build, plan_build_from_packages
-    from roscope.fetcher import FetchOptions, fetch_packages
+    from roscope.fetcher import FetchOptions, WorkspaceState, fetch_packages
     from roscope.rosdep import rosdep_install
 
     src_path = Path(src)
@@ -796,10 +796,11 @@ def build_pkg(
         workspace_state=workspace_state,
     )
 
-    # Fetch the seed packages first
-    to_fetch = [p for p in packages if p in parsed_lockfile.packages]
-    if to_fetch:
-        fetch_packages(to_fetch, parsed_lockfile, src_path, fetch_options)
+    # Fetch the seed packages first (skipped in dirty mode — src/ is authoritative)
+    if workspace_state != WorkspaceState.DIRTY:
+        to_fetch = [p for p in packages if p in parsed_lockfile.packages]
+        if to_fetch:
+            fetch_packages(to_fetch, parsed_lockfile, src_path, fetch_options)
 
     seed = set(packages)
     plan = plan_build_from_packages(

--- a/roscope/cli.py
+++ b/roscope/cli.py
@@ -539,10 +539,18 @@ def resolve(
     viz_id: str,
 ) -> None:
     """Resolve launch file (no build)."""
+    from click.core import ParameterSource  # type: ignore[attr-defined]
+
     from roscope.orchestrator import ResolveWorkflowOptions
 
     initial_args = _parse_launch_args(args)
     workspace_state = _parse_workspace_state(clean, dirty)
+
+    if dirty and ctx.get_parameter_source("lockfile") == ParameterSource.COMMANDLINE:  # type: ignore[attr-defined,union-attr]
+        click.echo(
+            "warning: --lockfile is ignored in --dirty mode (src/ is scanned instead)",
+            err=True,
+        )
 
     workflow_options = ResolveWorkflowOptions(
         preview=preview,
@@ -608,10 +616,18 @@ def check(
     shallow: bool,
 ) -> None:
     """Validate launch file without running."""
+    from click.core import ParameterSource  # type: ignore[attr-defined]
+
     from roscope.orchestrator import ResolveWorkflowOptions
 
     initial_args = _parse_launch_args(args)
     workspace_state = _parse_workspace_state(clean, dirty)
+
+    if dirty and ctx.get_parameter_source("lockfile") == ParameterSource.COMMANDLINE:  # type: ignore[attr-defined,union-attr]
+        click.echo(
+            "warning: --lockfile is ignored in --dirty mode (src/ is scanned instead)",
+            err=True,
+        )
 
     workflow_options = ResolveWorkflowOptions(
         preview=preview,
@@ -679,10 +695,18 @@ def build(
     dry_run: bool,
 ) -> None:
     """Fetch and build packages for a launcher."""
+    from click.core import ParameterSource  # type: ignore[attr-defined]
+
     from roscope.orchestrator import ResolveWorkflowOptions
 
     initial_args = _parse_launch_args(args)
     workspace_state = _parse_workspace_state(clean, dirty)
+
+    if dirty and ctx.get_parameter_source("lockfile") == ParameterSource.COMMANDLINE:  # type: ignore[attr-defined,union-attr]
+        click.echo(
+            "warning: --lockfile is ignored in --dirty mode (src/ is scanned instead)",
+            err=True,
+        )
 
     workflow_options = ResolveWorkflowOptions(
         preview=True,  # always resolve from source for build

--- a/roscope/cli.py
+++ b/roscope/cli.py
@@ -548,7 +548,8 @@ def resolve(
 
     if dirty and ctx.get_parameter_source("lockfile") == ParameterSource.COMMANDLINE:  # type: ignore[attr-defined,union-attr]
         click.echo(
-            "warning: --lockfile is ignored in --dirty mode (src/ is scanned instead)",
+            f"warning: --lockfile is ignored in --dirty mode"
+            f" ({src.rstrip('/')}/ is scanned instead)",
             err=True,
         )
 
@@ -625,7 +626,8 @@ def check(
 
     if dirty and ctx.get_parameter_source("lockfile") == ParameterSource.COMMANDLINE:  # type: ignore[attr-defined,union-attr]
         click.echo(
-            "warning: --lockfile is ignored in --dirty mode (src/ is scanned instead)",
+            f"warning: --lockfile is ignored in --dirty mode"
+            f" ({src.rstrip('/')}/ is scanned instead)",
             err=True,
         )
 
@@ -704,7 +706,8 @@ def build(
 
     if dirty and ctx.get_parameter_source("lockfile") == ParameterSource.COMMANDLINE:  # type: ignore[attr-defined,union-attr]
         click.echo(
-            "warning: --lockfile is ignored in --dirty mode (src/ is scanned instead)",
+            f"warning: --lockfile is ignored in --dirty mode"
+            f" ({src.rstrip('/')}/ is scanned instead)",
             err=True,
         )
 

--- a/roscope/cli.py
+++ b/roscope/cli.py
@@ -128,6 +128,33 @@ def _load_lockfile(
     return _read_lockfile(lockfile_path)
 
 
+def _warn_if_lockfile_ignored(
+    ctx: click.Context,
+    workspace_state: WorkspaceState,
+    src: str,
+) -> None:
+    """Emit a warning when --lockfile is explicitly passed with --dirty.
+
+    In dirty mode the lockfile is ignored entirely (src/ is scanned instead),
+    so passing --lockfile alongside --dirty is likely a mistake.
+    """
+    from click.core import ParameterSource  # type: ignore[attr-defined]
+
+    from roscope.fetcher import WorkspaceState
+
+    if workspace_state != WorkspaceState.DIRTY:
+        return
+    lockfile_explicit = (
+        ctx.get_parameter_source("lockfile") == ParameterSource.COMMANDLINE  # type: ignore[attr-defined]
+    )
+    if lockfile_explicit:
+        click.echo(
+            f"warning: --lockfile is ignored in --dirty mode"
+            f" ({src.rstrip('/')}/ is scanned instead)",
+            err=True,
+        )
+
+
 def _contains_git_dir(path: Path) -> bool:
     """Check if a directory contains a .git directory (recursively)."""
     if (path / ".git").exists():
@@ -535,23 +562,12 @@ def resolve(
     viz_id: str,
 ) -> None:
     """Resolve launch file (no build)."""
-    from click.core import ParameterSource  # type: ignore[attr-defined]
-
-    from roscope.fetcher import WorkspaceState
     from roscope.orchestrator import ResolveWorkflowOptions
 
     initial_args = _parse_launch_args(args)
     workspace_state = _parse_workspace_state(clean, dirty)
 
-    lockfile_explicit = (
-        ctx.get_parameter_source("lockfile") == ParameterSource.COMMANDLINE  # type: ignore[attr-defined]
-    )
-    if workspace_state == WorkspaceState.DIRTY and lockfile_explicit:
-        click.echo(
-            f"warning: --lockfile is ignored in --dirty mode"
-            f" ({src.rstrip('/')}/ is scanned instead)",
-            err=True,
-        )
+    _warn_if_lockfile_ignored(ctx, workspace_state, src)
 
     workflow_options = ResolveWorkflowOptions(
         preview=preview,
@@ -617,23 +633,12 @@ def check(
     shallow: bool,
 ) -> None:
     """Validate launch file without running."""
-    from click.core import ParameterSource  # type: ignore[attr-defined]
-
-    from roscope.fetcher import WorkspaceState
     from roscope.orchestrator import ResolveWorkflowOptions
 
     initial_args = _parse_launch_args(args)
     workspace_state = _parse_workspace_state(clean, dirty)
 
-    lockfile_explicit = (
-        ctx.get_parameter_source("lockfile") == ParameterSource.COMMANDLINE  # type: ignore[attr-defined]
-    )
-    if workspace_state == WorkspaceState.DIRTY and lockfile_explicit:
-        click.echo(
-            f"warning: --lockfile is ignored in --dirty mode"
-            f" ({src.rstrip('/')}/ is scanned instead)",
-            err=True,
-        )
+    _warn_if_lockfile_ignored(ctx, workspace_state, src)
 
     workflow_options = ResolveWorkflowOptions(
         preview=preview,
@@ -701,23 +706,12 @@ def build(
     dry_run: bool,
 ) -> None:
     """Fetch and build packages for a launcher."""
-    from click.core import ParameterSource  # type: ignore[attr-defined]
-
-    from roscope.fetcher import WorkspaceState
     from roscope.orchestrator import ResolveWorkflowOptions
 
     initial_args = _parse_launch_args(args)
     workspace_state = _parse_workspace_state(clean, dirty)
 
-    lockfile_explicit = (
-        ctx.get_parameter_source("lockfile") == ParameterSource.COMMANDLINE  # type: ignore[attr-defined]
-    )
-    if workspace_state == WorkspaceState.DIRTY and lockfile_explicit:
-        click.echo(
-            f"warning: --lockfile is ignored in --dirty mode"
-            f" ({src.rstrip('/')}/ is scanned instead)",
-            err=True,
-        )
+    _warn_if_lockfile_ignored(ctx, workspace_state, src)
 
     workflow_options = ResolveWorkflowOptions(
         preview=True,  # always resolve from source for build
@@ -785,24 +779,14 @@ def build_pkg(
     dry_run: bool,
 ) -> None:
     """Build package(s) by name with automatic transitive dependency fetching."""
-    from click.core import ParameterSource  # type: ignore[attr-defined]
-
     from roscope.builder import BuildOptions, execute_build, plan_build_from_packages
-    from roscope.fetcher import FetchOptions, WorkspaceState, fetch_packages
+    from roscope.fetcher import FetchOptions, fetch_packages
     from roscope.rosdep import rosdep_install
 
     src_path = Path(src)
     workspace_state = _parse_workspace_state(clean, dirty)
 
-    lockfile_explicit = (
-        ctx.get_parameter_source("lockfile") == ParameterSource.COMMANDLINE  # type: ignore[attr-defined]
-    )
-    if workspace_state == WorkspaceState.DIRTY and lockfile_explicit:
-        click.echo(
-            f"warning: --lockfile is ignored in --dirty mode"
-            f" ({src.rstrip('/')}/ is scanned instead)",
-            err=True,
-        )
+    _warn_if_lockfile_ignored(ctx, workspace_state, src)
 
     parsed_lockfile = _load_lockfile(lockfile, src, workspace_state)
 
@@ -892,23 +876,12 @@ def test_cmd(
     dry_run: bool,
 ) -> None:
     """Fetch, build, and run tests (includes test_depend packages)."""
-    from click.core import ParameterSource  # type: ignore[attr-defined]
-
-    from roscope.fetcher import WorkspaceState
     from roscope.orchestrator import ResolveWorkflowOptions
 
     initial_args = _parse_launch_args(args)
     workspace_state = _parse_workspace_state(clean, dirty)
 
-    lockfile_explicit = (
-        ctx.get_parameter_source("lockfile") == ParameterSource.COMMANDLINE  # type: ignore[attr-defined]
-    )
-    if workspace_state == WorkspaceState.DIRTY and lockfile_explicit:
-        click.echo(
-            f"warning: --lockfile is ignored in --dirty mode"
-            f" ({src.rstrip('/')}/ is scanned instead)",
-            err=True,
-        )
+    _warn_if_lockfile_ignored(ctx, workspace_state, src)
 
     workflow_options = ResolveWorkflowOptions(
         preview=True,

--- a/roscope/fetcher.py
+++ b/roscope/fetcher.py
@@ -409,14 +409,21 @@ def fetch_repo_sparse(
     options: FetchOptions,
 ) -> None:
     """Fetch a repository with sparse-checkout for specific paths."""
+    if options.workspace_state == WorkspaceState.DIRTY:
+        # Dirty mode: trust whatever is on disk, never perform git operations.
+        # The repo may or may not have a .git directory (e.g. plain vcs import).
+        if repo_dir.exists():
+            logger.debug("Skipping git operations for %s (--dirty)", repo_dir)
+        else:
+            logger.warning(
+                "Dirty mode: repository directory %s does not exist; "
+                "package may be missing from src/",
+                repo_dir,
+            )
+        return
+
     if repo_dir.exists() and (repo_dir / ".git").exists():
-        if options.workspace_state == WorkspaceState.DIRTY:
-            desc = _describe_repo_state(repo_dir, sha)
-            if desc:
-                logger.info("Using as-is (--dirty) %s :\n  %s", repo_dir, desc)
-            else:
-                logger.debug("Skipping git operations for %s (--dirty)", repo_dir)
-        elif options.workspace_state == WorkspaceState.DEFAULT:
+        if options.workspace_state == WorkspaceState.DEFAULT:
             _ensure_remote_url(repo_dir, url)
             if not (repo_dir / ".git" / "index").exists():
                 logger.info("Initializing sparse-checkout for no-checkout clone at %s", repo_dir)

--- a/roscope/indexer.py
+++ b/roscope/indexer.py
@@ -842,7 +842,8 @@ def scan_source_dir(src_dir: Path) -> Lockfile:
 
         try:
             entries = sorted(directory.iterdir())
-        except OSError:
+        except OSError as e:
+            logger.warning("scan_source_dir: cannot read %s: %s", directory, e)
             return
         for entry in entries:
             if not entry.is_dir() or entry.name == ".git":

--- a/roscope/indexer.py
+++ b/roscope/indexer.py
@@ -794,6 +794,51 @@ def scan_source_dir(src_dir: Path) -> Lockfile:
     src_dir = src_dir.resolve()
 
     def _walk(directory: Path) -> None:
+        xml = directory / "package.xml"
+        if xml.exists():
+            try:
+                info = parse_package_xml(xml.read_text(), str(xml))
+            except RoscopeError as e:
+                logger.warning("scan_source_dir: skipping %s: %s", xml, e)
+                return  # don't recurse into a broken package
+
+            if info.name in seen:
+                logger.warning(
+                    "scan_source_dir: duplicate package '%s' at %s and %s; keeping first",
+                    info.name,
+                    seen[info.name],
+                    directory,
+                )
+                return
+
+            seen[info.name] = directory
+
+            # repo  = immediate child of src_dir that contains this package
+            # path  = relative path from that child to the package dir
+            # fetch_dir / repo / path  must equal directory.resolve()
+            try:
+                rel = directory.relative_to(src_dir)
+            except ValueError:
+                logger.warning("scan_source_dir: %s outside src_dir; skipping", directory)
+                return
+            if rel.parts:
+                repo_key = rel.parts[0]  # immediate child of src_dir
+                path_in_repo = str(Path(*rel.parts[1:])) if len(rel.parts) > 1 else "."
+            else:
+                # directory IS src_dir itself
+                repo_key = directory.name
+                path_in_repo = "."
+
+            if repo_key not in lockfile.repositories:
+                lockfile.repositories[repo_key] = RepoLock(url="", version="")
+
+            lockfile.packages[info.name] = PackageLock(
+                repo=repo_key,
+                path=path_in_repo,
+            )
+            # Do not recurse: ROS packages don't contain other packages
+            return
+
         try:
             entries = sorted(directory.iterdir())
         except OSError:
@@ -801,46 +846,7 @@ def scan_source_dir(src_dir: Path) -> Lockfile:
         for entry in entries:
             if not entry.is_dir() or entry.name == ".git":
                 continue
-            xml = entry / "package.xml"
-            if xml.exists():
-                try:
-                    info = parse_package_xml(xml.read_text(), str(xml))
-                except RoscopeError as e:
-                    logger.warning("scan_source_dir: skipping %s: %s", xml, e)
-                    continue
-
-                if info.name in seen:
-                    logger.warning(
-                        "scan_source_dir: duplicate package '%s' at %s and %s; keeping first",
-                        info.name,
-                        seen[info.name],
-                        entry,
-                    )
-                    continue
-
-                seen[info.name] = entry
-
-                # repo  = immediate child of src_dir that contains this package
-                # path  = relative path from that child to the package dir
-                # fetch_dir / repo / path  must equal entry.resolve()
-                try:
-                    rel = entry.relative_to(src_dir)
-                except ValueError:
-                    logger.warning("scan_source_dir: %s outside src_dir; skipping", entry)
-                    continue
-                repo_key = rel.parts[0]  # immediate child of src_dir
-                path_in_repo = str(Path(*rel.parts[1:])) if len(rel.parts) > 1 else "."
-
-                if repo_key not in lockfile.repositories:
-                    lockfile.repositories[repo_key] = RepoLock(url="", version="")
-
-                lockfile.packages[info.name] = PackageLock(
-                    repo=repo_key,
-                    path=path_in_repo,
-                )
-                # Do not recurse: ROS packages don't contain other packages
-            else:
-                _walk(entry)
+            _walk(entry)
 
     _walk(src_dir)
     logger.info(

--- a/roscope/indexer.py
+++ b/roscope/indexer.py
@@ -798,6 +798,9 @@ def scan_source_dir(src_dir: Path) -> Lockfile:
         if xml.exists():
             try:
                 info = parse_package_xml(xml.read_text(), str(xml))
+            except (OSError, UnicodeDecodeError) as e:
+                logger.warning("scan_source_dir: cannot read %s: %s", xml, e)
+                return  # don't recurse into an unreadable package
             except RoscopeError as e:
                 logger.warning("scan_source_dir: skipping %s: %s", xml, e)
                 return  # don't recurse into a broken package

--- a/roscope/indexer.py
+++ b/roscope/indexer.py
@@ -767,6 +767,92 @@ def generate_lockfile(
 
 
 # ---------------------------------------------------------------------------
+# Source directory scanning (dirty mode)
+# ---------------------------------------------------------------------------
+
+
+def scan_source_dir(src_dir: Path) -> Lockfile:
+    """Build a synthetic Lockfile by scanning a source directory for packages.
+
+    Walks ``src_dir`` recursively, finds every ``package.xml``, and maps each
+    package to a ``PackageLock``.  The resulting ``Lockfile`` has empty
+    ``url`` / ``version`` fields (sufficient for dirty-mode resolution, where
+    git operations are never performed).
+
+    Intended for ``--dirty`` mode: lets users work without a lockfile after
+    a plain ``vcs import src < some.repos``.  Works equally well when there is
+    no remote, or when the directory is not a git repository at all.
+
+    Traversal rules:
+    - Recurse into every subdirectory except ``.git/``.
+    - When ``package.xml`` is found at a node, record the package and stop
+      recursing into that directory (ROS packages don't nest inside each other).
+    - Duplicate package names: warn and keep the first occurrence.
+    """
+    lockfile = Lockfile()
+    seen: dict[str, Path] = {}  # pkg_name -> first absolute path
+    src_dir = src_dir.resolve()
+
+    def _walk(directory: Path) -> None:
+        try:
+            entries = sorted(directory.iterdir())
+        except OSError:
+            return
+        for entry in entries:
+            if not entry.is_dir() or entry.name == ".git":
+                continue
+            xml = entry / "package.xml"
+            if xml.exists():
+                try:
+                    info = parse_package_xml(xml.read_text(), str(xml))
+                except RoscopeError as e:
+                    logger.warning("scan_source_dir: skipping %s: %s", xml, e)
+                    continue
+
+                if info.name in seen:
+                    logger.warning(
+                        "scan_source_dir: duplicate package '%s' at %s and %s; keeping first",
+                        info.name,
+                        seen[info.name],
+                        entry,
+                    )
+                    continue
+
+                seen[info.name] = entry
+
+                # repo  = immediate child of src_dir that contains this package
+                # path  = relative path from that child to the package dir
+                # fetch_dir / repo / path  must equal entry.resolve()
+                try:
+                    rel = entry.relative_to(src_dir)
+                except ValueError:
+                    logger.warning("scan_source_dir: %s outside src_dir; skipping", entry)
+                    continue
+                repo_key = rel.parts[0]  # immediate child of src_dir
+                path_in_repo = str(Path(*rel.parts[1:])) if len(rel.parts) > 1 else "."
+
+                if repo_key not in lockfile.repositories:
+                    lockfile.repositories[repo_key] = RepoLock(url="", version="")
+
+                lockfile.packages[info.name] = PackageLock(
+                    repo=repo_key,
+                    path=path_in_repo,
+                )
+                # Do not recurse: ROS packages don't contain other packages
+            else:
+                _walk(entry)
+
+    _walk(src_dir)
+    logger.info(
+        "scan_source_dir: found %d packages in %d repos under %s",
+        len(lockfile.packages),
+        len(lockfile.repositories),
+        src_dir,
+    )
+    return lockfile
+
+
+# ---------------------------------------------------------------------------
 # Dependency resolution
 # ---------------------------------------------------------------------------
 

--- a/roscope/indexer.py
+++ b/roscope/indexer.py
@@ -825,8 +825,9 @@ def scan_source_dir(src_dir: Path) -> Lockfile:
                 repo_key = rel.parts[0]  # immediate child of src_dir
                 path_in_repo = str(Path(*rel.parts[1:])) if len(rel.parts) > 1 else "."
             else:
-                # directory IS src_dir itself
-                repo_key = directory.name
+                # directory IS src_dir itself; use "." so that
+                # src_dir / repo_key / path resolves back to src_dir
+                repo_key = "."
                 path_in_repo = "."
 
             if repo_key not in lockfile.repositories:


### PR DESCRIPTION
## Summary

- In `--dirty` mode, roscope no longer reads a lockfile. Instead, it walks the source directory (`src/` by default) for `package.xml` files and builds a synthetic lockfile on the fly, enabling workflows where `src/` is populated via `vcs import` without generating a lockfile first.
- If `--lockfile` is explicitly passed alongside `--dirty`, a CLI warning is emitted (in each command handler using `ctx.get_parameter_source`) and the lockfile is ignored.
- Documentation updated in `README.md`, `docs/concepts.md`, and `docs/getting-started.md` to describe the lockfile-free workflow and reorder workspace state descriptions to default → clean → dirty.

## Test plan

- [ ] `roscope resolve -d <pkg> <launcher>` works with `src/` populated by `vcs import` and no lockfile present
- [ ] `roscope resolve -d --lockfile manifest.lock.repos <pkg> <launcher>` emits a warning to stderr and proceeds using `src/` scan
- [ ] `roscope resolve` (no flags) and `roscope resolve -c` still require and use the lockfile as before
- [ ] Packages absent from `src/` and not rosdep-installable produce an error in dirty mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)