### PR TITLE
Fix missing shims for launch_xml and launch description source modules

### DIFF
--- a/roscope/entities/launch_description_source.py
+++ b/roscope/entities/launch_description_source.py
@@ -19,6 +19,7 @@ class LaunchDescriptionSource:
         self,
         location=None,
         method: str = "unspecified mechanism from a script",
+        **_kwargs,
     ) -> None:
         self._method = method
         if location is None:

--- a/roscope/entities/launch_description_source.py
+++ b/roscope/entities/launch_description_source.py
@@ -1,6 +1,6 @@
-"""LaunchDescriptionSource — deferred location resolution.
+"""LaunchDescriptionSource — base class for launch description sources.
 
-Matches official ``launch.launch_description_sources.PythonLaunchDescriptionSource``.
+Matches official ``launch.launch_description_source.LaunchDescriptionSource``.
 """
 
 from __future__ import annotations
@@ -8,14 +8,19 @@ from __future__ import annotations
 from roscope.entities.substitution import Substitution
 
 
-class PythonLaunchDescriptionSource:
+class LaunchDescriptionSource:
     """Stores raw location substitutions, resolves lazily.
 
     Matching official: ``__init__`` does NOT resolve substitutions.
     Resolution is deferred to ``_resolve_location(context)``.
     """
 
-    def __init__(self, location=None, **kwargs):
+    def __init__(
+        self,
+        location=None,
+        method: str = "unspecified mechanism from a script",
+    ) -> None:
+        self._method = method
         if location is None:
             self._location_subs = None
             self._location: str | None = None
@@ -54,8 +59,7 @@ class PythonLaunchDescriptionSource:
             return None
         return " + ".join(str(sub) for sub in self._location_subs)
 
-
-class AnyLaunchDescriptionSource(PythonLaunchDescriptionSource):
-    """Matches official AnyLaunchDescriptionSource."""
-
-    pass
+    @property
+    def method(self) -> str:
+        """Getter for method."""
+        return self._method

--- a/roscope/entities/launch_description_sources/__init__.py
+++ b/roscope/entities/launch_description_sources/__init__.py
@@ -1,0 +1,21 @@
+"""Launch description source implementations."""
+
+from roscope.entities.launch_description_sources.any_launch_description_source import (
+    AnyLaunchDescriptionSource,
+)
+from roscope.entities.launch_description_sources.frontend_launch_description_source import (
+    FrontendLaunchDescriptionSource,
+)
+from roscope.entities.launch_description_sources.python_launch_description_source import (
+    PythonLaunchDescriptionSource,
+)
+from roscope.entities.launch_description_sources.xml_launch_description_source import (
+    XMLLaunchDescriptionSource,
+)
+
+__all__ = [
+    "AnyLaunchDescriptionSource",
+    "FrontendLaunchDescriptionSource",
+    "PythonLaunchDescriptionSource",
+    "XMLLaunchDescriptionSource",
+]

--- a/roscope/entities/launch_description_sources/any_launch_description_source.py
+++ b/roscope/entities/launch_description_sources/any_launch_description_source.py
@@ -1,0 +1,24 @@
+"""AnyLaunchDescriptionSource — deferred launch file location resolution (any format).
+
+Matches official ``launch.launch_description_sources.AnyLaunchDescriptionSource``.
+"""
+
+from __future__ import annotations
+
+from roscope.entities.launch_description_source import LaunchDescriptionSource
+
+
+class AnyLaunchDescriptionSource(LaunchDescriptionSource):
+    """Encapsulation of a launch file of any supported format, which can be loaded during launch."""
+
+    def __init__(
+        self,
+        launch_file_path,
+    ) -> None:
+        """
+        Create an AnyLaunchDescriptionSource.
+
+        :param launch_file_path: the path to the launch file. It can be made up of Substitution
+            instances which are expanded when the location is resolved.
+        """
+        super().__init__(launch_file_path, "interpreted launch file")

--- a/roscope/entities/launch_description_sources/frontend_launch_description_source.py
+++ b/roscope/entities/launch_description_sources/frontend_launch_description_source.py
@@ -1,0 +1,30 @@
+"""FrontendLaunchDescriptionSource — deferred declarative launch file location resolution.
+
+Matches official ``launch.launch_description_sources.FrontendLaunchDescriptionSource``.
+"""
+
+from __future__ import annotations
+
+from roscope.entities.launch_description_source import LaunchDescriptionSource
+
+
+class FrontendLaunchDescriptionSource(LaunchDescriptionSource):
+    """Encapsulation of a declarative (markup-based) launch file."""
+
+    def __init__(
+        self,
+        launch_file_path,
+        *,
+        method: str = "interpreted frontend launch file",
+        parser=None,
+    ) -> None:
+        """
+        Create a FrontendLaunchDescriptionSource.
+
+        :param launch_file_path: the path to the launch file. It can be made up of Substitution
+            instances which are expanded when the location is resolved.
+        :param method: human-readable description of how the launch description is generated.
+        :param parser: the parser implementation to use for loading the file.
+        """
+        super().__init__(launch_file_path, method)
+        self._parser = parser

--- a/roscope/entities/launch_description_sources/frontend_launch_description_source.py
+++ b/roscope/entities/launch_description_sources/frontend_launch_description_source.py
@@ -24,7 +24,9 @@ class FrontendLaunchDescriptionSource(LaunchDescriptionSource):
         :param launch_file_path: the path to the launch file. It can be made up of Substitution
             instances which are expanded when the location is resolved.
         :param method: human-readable description of how the launch description is generated.
-        :param parser: the parser implementation to use for loading the file.
+        :param parser: stored for API compatibility with the official
+            ``FrontendLaunchDescriptionSource``. Not used for dispatch — the
+            resolver selects a parser by file extension instead.
         """
         super().__init__(launch_file_path, method)
         self._parser = parser

--- a/roscope/entities/launch_description_sources/python_launch_description_source.py
+++ b/roscope/entities/launch_description_sources/python_launch_description_source.py
@@ -1,0 +1,26 @@
+"""PythonLaunchDescriptionSource — deferred Python launch file location resolution.
+
+Matches official ``launch.launch_description_sources.PythonLaunchDescriptionSource``.
+"""
+
+from __future__ import annotations
+
+from roscope.entities.launch_description_source import LaunchDescriptionSource
+
+
+class PythonLaunchDescriptionSource(LaunchDescriptionSource):
+    """Encapsulation of a Python launch file, which can be loaded during launch."""
+
+    def __init__(
+        self,
+        launch_file_path,
+    ) -> None:
+        """
+        Create a PythonLaunchDescriptionSource.
+
+        The given file path should be to a ``.launch.py`` style file.
+
+        :param launch_file_path: the path to the launch file. It can be made up of Substitution
+            instances which are expanded when the location is resolved.
+        """
+        super().__init__(launch_file_path, "interpreted python launch file")

--- a/roscope/entities/launch_description_sources/xml_launch_description_source.py
+++ b/roscope/entities/launch_description_sources/xml_launch_description_source.py
@@ -1,0 +1,33 @@
+"""XMLLaunchDescriptionSource — deferred XML launch file location resolution.
+
+Matches official ``launch_xml.launch_description_sources.XMLLaunchDescriptionSource``.
+"""
+
+from __future__ import annotations
+
+from roscope.entities.launch_description_sources.frontend_launch_description_source import (
+    FrontendLaunchDescriptionSource,
+)
+from roscope.parsers.xml_parser import parse_xml_launch
+
+
+class XMLLaunchDescriptionSource(FrontendLaunchDescriptionSource):
+    """Encapsulation of an XML launch file, which can be loaded during launch."""
+
+    def __init__(
+        self,
+        launch_file_path,
+    ) -> None:
+        """
+        Create an XMLLaunchDescriptionSource.
+
+        The given file path should be to a ``.launch.xml`` style file.
+
+        :param launch_file_path: the path to the launch file. It can be made up of Substitution
+            instances which are expanded when the location is resolved.
+        """
+        super().__init__(
+            launch_file_path,
+            method="interpreted XML launch file",
+            parser=parse_xml_launch,
+        )

--- a/roscope/resolver.py
+++ b/roscope/resolver.py
@@ -271,6 +271,14 @@ def _build_patched_launch_conditions():
     return mod
 
 
+def _build_patched_launch_launch_description_source():
+    from roscope.entities.launch_description_source import LaunchDescriptionSource
+
+    mod = types.ModuleType("launch.launch_description_source")
+    mod.LaunchDescriptionSource = LaunchDescriptionSource
+    return mod
+
+
 def _build_patched_launch_launch_description_sources():
     from roscope.entities.launch_description_sources import FrontendLaunchDescriptionSource
 
@@ -351,6 +359,7 @@ class _PatchingFinder(importlib.abc.MetaPathFinder):
         "launch.events": _build_patched_launch_events,
         "launch.event_handlers": _build_patched_launch_event_handlers,
         "launch.conditions": _build_patched_launch_conditions,
+        "launch.launch_description_source": _build_patched_launch_launch_description_source,
         "launch.launch_description_sources": _build_patched_launch_launch_description_sources,
         "launch_xml": _build_patched_launch_xml,
         "launch_xml.launch_description_sources": _build_patched_launch_xml_launch_description_sources,

--- a/roscope/resolver.py
+++ b/roscope/resolver.py
@@ -54,9 +54,10 @@ from roscope.entities.conditions import (
 )
 from roscope.entities.descriptions import ComposableNode
 from roscope.entities.launch_description import LaunchDescription as _LaunchDescription
-from roscope.entities.launch_description_source import (
+from roscope.entities.launch_description_sources import (
     AnyLaunchDescriptionSource,
     PythonLaunchDescriptionSource,
+    XMLLaunchDescriptionSource,
 )
 from roscope.entities.parsing import _ActionParser
 from roscope.entities.state import LaunchContext, ResolverState
@@ -277,6 +278,19 @@ def _build_patched_launch_launch_description_sources():
     return mod
 
 
+def _build_patched_launch_xml():
+    mod = types.ModuleType("launch_xml")
+    mod.__path__ = []
+    mod.__package__ = "launch_xml"
+    return mod
+
+
+def _build_patched_launch_xml_launch_description_sources():
+    mod = types.ModuleType("launch_xml.launch_description_sources")
+    mod.XMLLaunchDescriptionSource = XMLLaunchDescriptionSource
+    return mod
+
+
 def _build_patched_launch_ros_substitutions():
     from roscope.entities.substitutions.executable_in_package import ExecutableInPackage
 
@@ -335,6 +349,8 @@ class _PatchingFinder(importlib.abc.MetaPathFinder):
         "launch.event_handlers": _build_patched_launch_event_handlers,
         "launch.conditions": _build_patched_launch_conditions,
         "launch.launch_description_sources": _build_patched_launch_launch_description_sources,
+        "launch_xml": _build_patched_launch_xml,
+        "launch_xml.launch_description_sources": _build_patched_launch_xml_launch_description_sources,
         "launch_ros.events": _build_patched_launch_ros_events,
         "launch_ros.events.lifecycle": _build_patched_launch_ros_events_lifecycle,
         "launch_ros.event_handlers": _build_patched_launch_ros_event_handlers,

--- a/roscope/resolver.py
+++ b/roscope/resolver.py
@@ -272,9 +272,12 @@ def _build_patched_launch_conditions():
 
 
 def _build_patched_launch_launch_description_sources():
+    from roscope.entities.launch_description_sources import FrontendLaunchDescriptionSource
+
     mod = types.ModuleType("launch.launch_description_sources")
     mod.PythonLaunchDescriptionSource = PythonLaunchDescriptionSource
     mod.AnyLaunchDescriptionSource = AnyLaunchDescriptionSource
+    mod.FrontendLaunchDescriptionSource = FrontendLaunchDescriptionSource
     return mod
 
 

--- a/roscope/resolver.py
+++ b/roscope/resolver.py
@@ -302,6 +302,42 @@ def _build_patched_launch_xml_launch_description_sources():
     return mod
 
 
+# ── Per-class submodule shims ─────────────────────────────────────────────────
+# Upstream code may import via the per-class submodule path, e.g.:
+#   from launch.launch_description_sources.python_launch_description_source \
+#       import PythonLaunchDescriptionSource
+
+
+def _build_patched_launch_lds_python():
+    mod_name = "launch.launch_description_sources.python_launch_description_source"
+    mod = types.ModuleType(mod_name)
+    mod.PythonLaunchDescriptionSource = PythonLaunchDescriptionSource
+    return mod
+
+
+def _build_patched_launch_lds_any():
+    mod_name = "launch.launch_description_sources.any_launch_description_source"
+    mod = types.ModuleType(mod_name)
+    mod.AnyLaunchDescriptionSource = AnyLaunchDescriptionSource
+    return mod
+
+
+def _build_patched_launch_lds_frontend():
+    from roscope.entities.launch_description_sources import FrontendLaunchDescriptionSource
+
+    mod_name = "launch.launch_description_sources.frontend_launch_description_source"
+    mod = types.ModuleType(mod_name)
+    mod.FrontendLaunchDescriptionSource = FrontendLaunchDescriptionSource
+    return mod
+
+
+def _build_patched_launch_xml_lds_xml():
+    mod_name = "launch_xml.launch_description_sources.xml_launch_description_source"
+    mod = types.ModuleType(mod_name)
+    mod.XMLLaunchDescriptionSource = XMLLaunchDescriptionSource
+    return mod
+
+
 def _build_patched_launch_ros_substitutions():
     from roscope.entities.substitutions.executable_in_package import ExecutableInPackage
 
@@ -363,6 +399,10 @@ class _PatchingFinder(importlib.abc.MetaPathFinder):
         "launch.launch_description_sources": _build_patched_launch_launch_description_sources,
         "launch_xml": _build_patched_launch_xml,
         "launch_xml.launch_description_sources": _build_patched_launch_xml_launch_description_sources,
+        "launch_xml.launch_description_sources.xml_launch_description_source": _build_patched_launch_xml_lds_xml,
+        "launch.launch_description_sources.python_launch_description_source": _build_patched_launch_lds_python,
+        "launch.launch_description_sources.any_launch_description_source": _build_patched_launch_lds_any,
+        "launch.launch_description_sources.frontend_launch_description_source": _build_patched_launch_lds_frontend,
         "launch_ros.events": _build_patched_launch_ros_events,
         "launch_ros.events.lifecycle": _build_patched_launch_ros_events_lifecycle,
         "launch_ros.event_handlers": _build_patched_launch_ros_event_handlers,

--- a/roscope/resolver.py
+++ b/roscope/resolver.py
@@ -283,6 +283,8 @@ def _build_patched_launch_launch_description_sources():
     from roscope.entities.launch_description_sources import FrontendLaunchDescriptionSource
 
     mod = types.ModuleType("launch.launch_description_sources")
+    mod.__path__ = []
+    mod.__package__ = "launch.launch_description_sources"
     mod.PythonLaunchDescriptionSource = PythonLaunchDescriptionSource
     mod.AnyLaunchDescriptionSource = AnyLaunchDescriptionSource
     mod.FrontendLaunchDescriptionSource = FrontendLaunchDescriptionSource
@@ -298,6 +300,8 @@ def _build_patched_launch_xml():
 
 def _build_patched_launch_xml_launch_description_sources():
     mod = types.ModuleType("launch_xml.launch_description_sources")
+    mod.__path__ = []
+    mod.__package__ = "launch_xml.launch_description_sources"
     mod.XMLLaunchDescriptionSource = XMLLaunchDescriptionSource
     return mod
 

--- a/roscope/resolver.py
+++ b/roscope/resolver.py
@@ -382,6 +382,11 @@ class _PatchingFinder(importlib.abc.MetaPathFinder):
             _PATCHED_MODULES[fullname] = self.PATCHED[fullname]()
         mod = _PATCHED_MODULES[fullname]
         sys.modules[fullname] = mod
+        if "." in fullname:
+            parent_name, _, child_name = fullname.rpartition(".")
+            parent = sys.modules.get(parent_name)
+            if parent is not None:
+                setattr(parent, child_name, mod)
         return mod
 
 
@@ -542,6 +547,11 @@ def resolve_file(
         if mod_name not in _PATCHED_MODULES:
             _PATCHED_MODULES[mod_name] = builder()
         sys.modules[mod_name] = _PATCHED_MODULES[mod_name]
+        if "." in mod_name:
+            parent_name, _, child_name = mod_name.rpartition(".")
+            parent = sys.modules.get(parent_name)
+            if parent is not None:
+                setattr(parent, child_name, sys.modules[mod_name])
 
     # ── Resolve by file type ─────────────────────────────────────────────
     if launch_file_str.endswith((".launch.xml", ".xml", ".yaml", ".yml")):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,13 @@ def _install_import_patching():
     for mod_name, builder in _PatchingFinder.PATCHED.items():
         if mod_name not in _PATCHED_MODULES:
             _PATCHED_MODULES[mod_name] = builder()
-        sys.modules[mod_name] = _PATCHED_MODULES[mod_name]
+        mod = _PATCHED_MODULES[mod_name]
+        sys.modules[mod_name] = mod
+        if "." in mod_name:
+            parent_name, _, child_name = mod_name.rpartition(".")
+            parent = sys.modules.get(parent_name)
+            if parent is not None:
+                setattr(parent, child_name, mod)
 
 
 _install_import_patching()

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -1973,12 +1973,20 @@ class TestLaunchXmlShim:
         import sys
 
         from roscope.entities.launch_description_sources import (
+            AnyLaunchDescriptionSource,
             FrontendLaunchDescriptionSource,
             PythonLaunchDescriptionSource,
             XMLLaunchDescriptionSource,
         )
 
         self._install_shims()
+
+        assert "launch.launch_description_sources.any_launch_description_source" in sys.modules
+        from launch.launch_description_sources.any_launch_description_source import (
+            AnyLaunchDescriptionSource as ShimmedAny,
+        )
+
+        assert ShimmedAny is AnyLaunchDescriptionSource
 
         assert "launch.launch_description_sources.python_launch_description_source" in sys.modules
         from launch.launch_description_sources.python_launch_description_source import (

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -1949,3 +1949,15 @@ class TestLaunchXmlShim:
         )
 
         assert Shimmed is FrontendLaunchDescriptionSource
+
+    def test_launch_description_source_base_module_shim(self):
+        """LaunchDescriptionSource base-module shim resolves to the roscope implementation."""
+        import sys
+
+        from roscope.entities.launch_description_source import LaunchDescriptionSource
+
+        self._install_shims()
+        assert "launch.launch_description_source" in sys.modules
+        from launch.launch_description_source import LaunchDescriptionSource as Shimmed
+
+        assert Shimmed is LaunchDescriptionSource

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -1905,3 +1905,47 @@ class TestExecutableInPackage:
         )
         result = shim.perform(ctx)
         assert result == str(exe_path)
+
+
+class TestLaunchXmlShim:
+    """launch_xml.launch_description_sources shim resolves to roscope implementation."""
+
+    def _install_shims(self):
+        import sys
+
+        from roscope.resolver import _PATCHED_MODULES, _PatchingFinder
+
+        if not any(isinstance(f, _PatchingFinder) for f in sys.meta_path):
+            sys.meta_path.insert(0, _PatchingFinder())
+        for mod_name, builder in _PatchingFinder.PATCHED.items():
+            if mod_name not in _PATCHED_MODULES:
+                _PATCHED_MODULES[mod_name] = builder()
+            sys.modules[mod_name] = _PATCHED_MODULES[mod_name]
+
+    def test_xml_launch_description_source_shim(self):
+        """XMLLaunchDescriptionSource shim resolves to the roscope implementation."""
+        import sys
+
+        from roscope.entities.launch_description_sources import XMLLaunchDescriptionSource
+
+        self._install_shims()
+        assert "launch_xml.launch_description_sources" in sys.modules
+        from launch_xml.launch_description_sources import (
+            XMLLaunchDescriptionSource as Shimmed,
+        )
+
+        assert Shimmed is XMLLaunchDescriptionSource
+
+    def test_frontend_launch_description_source_in_launch_shim(self):
+        """FrontendLaunchDescriptionSource shim resolves to the roscope implementation."""
+        import sys
+
+        from roscope.entities.launch_description_sources import FrontendLaunchDescriptionSource
+
+        self._install_shims()
+        assert "launch.launch_description_sources" in sys.modules
+        from launch.launch_description_sources import (
+            FrontendLaunchDescriptionSource as Shimmed,
+        )
+
+        assert Shimmed is FrontendLaunchDescriptionSource

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -1911,22 +1911,9 @@ class TestLaunchXmlShim:
     """launch_xml.launch_description_sources shim resolves to roscope implementation."""
 
     def _install_shims(self):
-        import sys
+        from conftest import _install_import_patching
 
-        from roscope.resolver import _PATCHED_MODULES, _PatchingFinder
-
-        if not any(isinstance(f, _PatchingFinder) for f in sys.meta_path):
-            sys.meta_path.insert(0, _PatchingFinder())
-        for mod_name, builder in _PatchingFinder.PATCHED.items():
-            if mod_name not in _PATCHED_MODULES:
-                _PATCHED_MODULES[mod_name] = builder()
-            mod = _PATCHED_MODULES[mod_name]
-            sys.modules[mod_name] = mod
-            if "." in mod_name:
-                parent_name, _, child_name = mod_name.rpartition(".")
-                parent = sys.modules.get(parent_name)
-                if parent is not None:
-                    setattr(parent, child_name, mod)
+        _install_import_patching()
 
     def test_xml_launch_description_source_shim(self):
         """XMLLaunchDescriptionSource shim resolves to the roscope implementation."""

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -1961,3 +1961,36 @@ class TestLaunchXmlShim:
         from launch.launch_description_source import LaunchDescriptionSource as Shimmed
 
         assert Shimmed is LaunchDescriptionSource
+
+    def test_per_class_submodule_shims(self):
+        """Per-class submodule import paths resolve to the roscope implementations."""
+        import sys
+
+        from roscope.entities.launch_description_sources import (
+            FrontendLaunchDescriptionSource,
+            PythonLaunchDescriptionSource,
+            XMLLaunchDescriptionSource,
+        )
+
+        self._install_shims()
+
+        assert "launch.launch_description_sources.python_launch_description_source" in sys.modules
+        from launch.launch_description_sources.python_launch_description_source import (
+            PythonLaunchDescriptionSource as ShimmedPython,
+        )
+
+        assert ShimmedPython is PythonLaunchDescriptionSource
+
+        assert "launch.launch_description_sources.frontend_launch_description_source" in sys.modules
+        from launch.launch_description_sources.frontend_launch_description_source import (
+            FrontendLaunchDescriptionSource as ShimmedFrontend,
+        )
+
+        assert ShimmedFrontend is FrontendLaunchDescriptionSource
+
+        assert "launch_xml.launch_description_sources.xml_launch_description_source" in sys.modules
+        from launch_xml.launch_description_sources.xml_launch_description_source import (
+            XMLLaunchDescriptionSource as ShimmedXML,
+        )
+
+        assert ShimmedXML is XMLLaunchDescriptionSource

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -3,8 +3,13 @@ and inline Python include resolution."""
 
 import logging
 import os
+import sys
 import tempfile
 import textwrap
+import uuid
+
+import pytest
+from conftest import _install_import_patching
 
 from roscope.entities.actions.arg import DeclareLaunchArgument, _apply_declared_arg
 from roscope.entities.actions.composable_node_container import (
@@ -463,7 +468,6 @@ class TestEnvStack:
 
     def test_unset_env_nonexistent_errors(self, caplog):
         """UnsetEnvironmentVariable on a var that doesn't exist → 'not set' error."""
-        import uuid
 
         name = f"NONEXISTENT_VAR_{uuid.uuid4().hex[:8]}"
         assert name not in os.environ, f"precondition: {name} must not be in process env"
@@ -474,7 +478,6 @@ class TestEnvStack:
 
     def test_unset_env_override_only_accepted(self):
         """UnsetEnv on an override-only var (not in process env) → accepted."""
-        import uuid
 
         name = f"OVERRIDE_ONLY_{uuid.uuid4().hex[:8]}"
         assert name not in os.environ, f"precondition: {name} must not be in process env"
@@ -514,7 +517,6 @@ class TestEnvStack:
         overrides = env_overrides(ctx)
         assert overrides["NEW_VAR"] == "new_val"
         # Process env vars must NOT appear in overrides.
-        import os
 
         assert "PATH" in os.environ, "PATH should exist in process env for this test"
         assert "PATH" not in overrides
@@ -911,7 +913,6 @@ class TestResolveSubstitutions:
         assert "my_pkg" in ctx._state.packages
 
     def test_resolve_find_pkg_prefix_preview_errors(self):
-        import pytest
 
         ctx = _fresh_subst_ctx(preview_mode=True)
         ctx._state.package_shares["my_pkg"] = "/ws/src/my_pkg"
@@ -1216,7 +1217,6 @@ class TestResolveXmlElements:
         assert _is_truthy("false") is False
         assert _is_truthy("0") is False
         # Invalid values raise ValueError
-        import pytest
 
         for invalid in ("yes", "on", "no", ""):
             with pytest.raises(ValueError, match="invalid condition expression"):
@@ -1269,7 +1269,6 @@ class TestActionRegistry:
 
 
 # ─── rosdep resolve parser tests ─────────────────────────────────────────────
-# Mirror the Rust-side tests in rosdep.rs.
 
 
 # ─── _apply_declared_arg ─────────────────────────────────────────────────────
@@ -1331,7 +1330,6 @@ class TestResolvePkgShare:
     def test_preview_unknown_pkg_raises(self):
         state = ResolverState()
         state.preview_mode = True
-        import pytest
 
         with pytest.raises(LookupError, match="not found"):
             state.resolve_pkg_share("unknown_pkg")
@@ -1345,7 +1343,6 @@ class TestResolvePkgShare:
     def test_postbuild_unknown_pkg_raises(self):
         state = ResolverState()
         state.preview_mode = False
-        import pytest
 
         with pytest.raises(LookupError, match="not found"):
             state.resolve_pkg_share("unknown_pkg")
@@ -1362,7 +1359,6 @@ class TestResolvePkgShare:
                 "version": "abc123",
             }
         }
-        import pytest
 
         # Should raise, not attempt to fetch
         with pytest.raises(LookupError, match="not found"):
@@ -1478,7 +1474,6 @@ class TestTrackedFindPackageShare:
         ctx = LaunchContext()
         ctx._state.preview_mode = True
         fps = FindPackageShare("unknown_pkg")
-        import pytest
 
         with pytest.raises(LookupError, match="not found"):
             fps.perform(ctx)
@@ -1496,7 +1491,6 @@ class TestTrackedFindPackageShare:
         ctx = LaunchContext()
         ctx._state.preview_mode = False
         fps = FindPackageShare("missing_pkg")
-        import pytest
 
         with pytest.raises(LookupError, match="not found"):
             fps.perform(ctx)
@@ -1731,17 +1725,7 @@ class TestShimUnknownAction:
 
     def test_unknown_launch_action_warns_not_crashes(self, caplog):
         """from launch.actions import UnknownFutureAction must not crash."""
-        import sys
-
-        from roscope.resolver import _PATCHED_MODULES, _PatchingFinder
-
-        # Re-install patcher (may already be present from other tests)
-        if not any(isinstance(f, _PatchingFinder) for f in sys.meta_path):
-            sys.meta_path.insert(0, _PatchingFinder())
-        for mod_name, builder in _PatchingFinder.PATCHED.items():
-            if mod_name not in _PATCHED_MODULES:
-                _PATCHED_MODULES[mod_name] = builder()
-            sys.modules[mod_name] = _PATCHED_MODULES[mod_name]
+        _install_import_patching()
 
         launch_actions = sys.modules["launch.actions"]
         with caplog.at_level(logging.WARNING):
@@ -1751,17 +1735,10 @@ class TestShimUnknownAction:
 
     def test_unknown_shim_returns_action_subclass(self):
         """The stub class must be an Action subclass usable by _execute_actions."""
-        import sys
 
         from roscope.entities.action import Action
-        from roscope.resolver import _PATCHED_MODULES, _PatchingFinder
 
-        if not any(isinstance(f, _PatchingFinder) for f in sys.meta_path):
-            sys.meta_path.insert(0, _PatchingFinder())
-        for mod_name, builder in _PatchingFinder.PATCHED.items():
-            if mod_name not in _PATCHED_MODULES:
-                _PATCHED_MODULES[mod_name] = builder()
-            sys.modules[mod_name] = _PATCHED_MODULES[mod_name]
+        _install_import_patching()
 
         launch_actions = sys.modules["launch.actions"]
         stub_cls = getattr(launch_actions, "AnotherUnknownAction_ABC", None)
@@ -1774,19 +1751,9 @@ class TestShimUnknownAction:
 
     def test_dunder_attr_raises_attribute_error(self):
         """__dunder__ attribute access on shim action modules must raise AttributeError."""
-        import sys
-
-        from roscope.resolver import _PATCHED_MODULES, _PatchingFinder
-
-        if not any(isinstance(f, _PatchingFinder) for f in sys.meta_path):
-            sys.meta_path.insert(0, _PatchingFinder())
-        for mod_name, builder in _PatchingFinder.PATCHED.items():
-            if mod_name not in _PATCHED_MODULES:
-                _PATCHED_MODULES[mod_name] = builder()
-            sys.modules[mod_name] = _PATCHED_MODULES[mod_name]
+        _install_import_patching()
 
         launch_actions = sys.modules["launch.actions"]
-        import pytest
 
         with pytest.raises(AttributeError):
             _ = launch_actions.__some_dunder__
@@ -1797,17 +1764,10 @@ class TestShimUnknownSubstitution:
 
     def test_unknown_substitution_shim_returns_substitution_subclass(self):
         """Unknown attributes on substitution shim modules must return a Substitution subclass."""
-        import sys
 
         from roscope.entities.substitution import Substitution
-        from roscope.resolver import _PATCHED_MODULES, _PatchingFinder
 
-        if not any(isinstance(f, _PatchingFinder) for f in sys.meta_path):
-            sys.meta_path.insert(0, _PatchingFinder())
-        for mod_name, builder in _PatchingFinder.PATCHED.items():
-            if mod_name not in _PATCHED_MODULES:
-                _PATCHED_MODULES[mod_name] = builder()
-            sys.modules[mod_name] = _PATCHED_MODULES[mod_name]
+        _install_import_patching()
 
         launch_subs = sys.modules["launch.substitutions"]
         stub_cls = getattr(launch_subs, "SomeUnknownSubstitution_XYZ", None)
@@ -1818,18 +1778,7 @@ class TestShimUnknownSubstitution:
 
     def test_dunder_attr_raises_attribute_error(self):
         """__dunder__ attribute access on shim substitution modules must raise AttributeError."""
-        import sys
-
-        from roscope.resolver import _PATCHED_MODULES, _PatchingFinder
-
-        if not any(isinstance(f, _PatchingFinder) for f in sys.meta_path):
-            sys.meta_path.insert(0, _PatchingFinder())
-        for mod_name, builder in _PatchingFinder.PATCHED.items():
-            if mod_name not in _PATCHED_MODULES:
-                _PATCHED_MODULES[mod_name] = builder()
-            sys.modules[mod_name] = _PATCHED_MODULES[mod_name]
-
-        import pytest
+        _install_import_patching()
 
         launch_subs = sys.modules["launch.substitutions"]
         with pytest.raises(AttributeError):
@@ -1841,7 +1790,6 @@ class TestExecutableInPackage:
 
     def test_raises_in_preview(self):
         """ExecutableInPackage must raise LookupError in preview mode."""
-        import pytest
 
         from roscope.entities.substitution import TextSubstitution
         from roscope.entities.substitutions.executable_in_package import ExecutableInPackage
@@ -1863,17 +1811,10 @@ class TestExecutableInPackage:
 
     def test_launch_ros_substitutions_exposes_class(self):
         """launch_ros.substitutions shim must expose ExecutableInPackage."""
-        import sys
 
         from roscope.entities.substitutions.executable_in_package import ExecutableInPackage
-        from roscope.resolver import _PATCHED_MODULES, _PatchingFinder
 
-        if not any(isinstance(f, _PatchingFinder) for f in sys.meta_path):
-            sys.meta_path.insert(0, _PatchingFinder())
-        for mod_name, builder in _PatchingFinder.PATCHED.items():
-            if mod_name not in _PATCHED_MODULES:
-                _PATCHED_MODULES[mod_name] = builder()
-            sys.modules[mod_name] = _PATCHED_MODULES[mod_name]
+        _install_import_patching()
 
         lr_subs = sys.modules["launch_ros.substitutions"]
         assert hasattr(lr_subs, "ExecutableInPackage")
@@ -1910,18 +1851,12 @@ class TestExecutableInPackage:
 class TestLaunchXmlShim:
     """launch_xml.launch_description_sources shim resolves to roscope implementation."""
 
-    def _install_shims(self):
-        from conftest import _install_import_patching
-
-        _install_import_patching()
-
     def test_xml_launch_description_source_shim(self):
         """XMLLaunchDescriptionSource shim resolves to the roscope implementation."""
-        import sys
 
         from roscope.entities.launch_description_sources import XMLLaunchDescriptionSource
 
-        self._install_shims()
+        _install_import_patching()
         assert "launch_xml.launch_description_sources" in sys.modules
         from launch_xml.launch_description_sources import (
             XMLLaunchDescriptionSource as Shimmed,
@@ -1931,11 +1866,10 @@ class TestLaunchXmlShim:
 
     def test_frontend_launch_description_source_in_launch_shim(self):
         """FrontendLaunchDescriptionSource shim resolves to the roscope implementation."""
-        import sys
 
         from roscope.entities.launch_description_sources import FrontendLaunchDescriptionSource
 
-        self._install_shims()
+        _install_import_patching()
         assert "launch.launch_description_sources" in sys.modules
         from launch.launch_description_sources import (
             FrontendLaunchDescriptionSource as Shimmed,
@@ -1945,11 +1879,10 @@ class TestLaunchXmlShim:
 
     def test_launch_description_source_base_module_shim(self):
         """LaunchDescriptionSource base-module shim resolves to the roscope implementation."""
-        import sys
 
         from roscope.entities.launch_description_source import LaunchDescriptionSource
 
-        self._install_shims()
+        _install_import_patching()
         assert "launch.launch_description_source" in sys.modules
         from launch.launch_description_source import LaunchDescriptionSource as Shimmed
 
@@ -1957,7 +1890,6 @@ class TestLaunchXmlShim:
 
     def test_per_class_submodule_shims(self):
         """Per-class submodule import paths resolve to the roscope implementations."""
-        import sys
 
         from roscope.entities.launch_description_sources import (
             AnyLaunchDescriptionSource,
@@ -1966,7 +1898,7 @@ class TestLaunchXmlShim:
             XMLLaunchDescriptionSource,
         )
 
-        self._install_shims()
+        _install_import_patching()
 
         assert "launch.launch_description_sources.any_launch_description_source" in sys.modules
         from launch.launch_description_sources.any_launch_description_source import (
@@ -2000,7 +1932,7 @@ class TestLaunchXmlShim:
         """Submodule shims must be accessible as attributes on the parent shim."""
         from roscope.entities.parameter_descriptions import ParameterFile
 
-        self._install_shims()
+        _install_import_patching()
 
         import launch_ros
 

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -1920,7 +1920,13 @@ class TestLaunchXmlShim:
         for mod_name, builder in _PatchingFinder.PATCHED.items():
             if mod_name not in _PATCHED_MODULES:
                 _PATCHED_MODULES[mod_name] = builder()
-            sys.modules[mod_name] = _PATCHED_MODULES[mod_name]
+            mod = _PATCHED_MODULES[mod_name]
+            sys.modules[mod_name] = mod
+            if "." in mod_name:
+                parent_name, _, child_name = mod_name.rpartition(".")
+                parent = sys.modules.get(parent_name)
+                if parent is not None:
+                    setattr(parent, child_name, mod)
 
     def test_xml_launch_description_source_shim(self):
         """XMLLaunchDescriptionSource shim resolves to the roscope implementation."""
@@ -1994,3 +2000,14 @@ class TestLaunchXmlShim:
         )
 
         assert ShimmedXML is XMLLaunchDescriptionSource
+
+    def test_launch_ros_submodule_is_exposed_as_parent_attribute(self):
+        """Submodule shims must be accessible as attributes on the parent shim."""
+        from roscope.entities.parameter_descriptions import ParameterFile
+
+        self._install_shims()
+
+        import launch_ros
+
+        assert hasattr(launch_ros, "parameter_descriptions")
+        assert launch_ros.parameter_descriptions.ParameterFile is ParameterFile


### PR DESCRIPTION
## Summary

Several import paths used by real-world Python launch files were not shimmed, causing `ImportError` or `AttributeError` at resolve time:

- `from launch_xml.launch_description_sources import XMLLaunchDescriptionSource` — `launch_xml` was entirely absent from `_PatchingFinder`
- `from launch.launch_description_source import LaunchDescriptionSource` — the singular base module was not shimmed
- `from launch.launch_description_sources import FrontendLaunchDescriptionSource` — missing from the `launch.launch_description_sources` shim
- `import launch_ros; launch_ros.parameter_descriptions.ParameterFile(...)` — submodule attribute access failed because shim registration never called `setattr(parent, child_name, mod)`, which the real Python import machinery does automatically

To support the new shims cleanly, the `*LaunchDescriptionSource` entity model is also restructured to match the official `launch` hierarchy:
- `LaunchDescriptionSource` base in `launch_description_source.py`
- `Python~`, `Any~`, `Frontend~`, `XML~` in `entities/launch_description_sources/`, with `XML → Frontend → Base`

## Test plan

- [ ] `python3 -m pytest tests/ -v` — all tests pass, including new `TestLaunchXmlShim`
- [ ] `import launch_ros; launch_ros.parameter_descriptions.ParameterFile` resolves without `AttributeError`
- [ ] `from launch_xml.launch_description_sources import XMLLaunchDescriptionSource` resolves to the roscope class
- [ ] `from launch.launch_description_source import LaunchDescriptionSource` resolves to the roscope class

🤖 Generated with [Claude Code](https://claude.com/claude-code)