### PR TITLE
improve(traceability): file context in diagnostics, env serialization fixes, node name fallback

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "roscope"
-version = "0.2.1"
+version = "0.2.2"
 description = "ROS 2 launch resolver and build orchestrator"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/roscope/entities/actions/arg.py
+++ b/roscope/entities/actions/arg.py
@@ -24,6 +24,7 @@ import logging
 
 from roscope.entities.action import Action
 from roscope.entities.expose import expose_action
+from roscope.entities.helpers import _current_file
 from roscope.entities.parsing import _ActionParser
 from roscope.parsers.entity import Entity
 
@@ -101,7 +102,7 @@ class DeclareLaunchArgument(Action):
         # Not set — apply default immediately (matching official: no deferred resolution).
         if self.default_value is None:
             # No default and not set: at runtime this raises InvalidLaunchArgument.
-            logger.error("arg '%s' is required but not set", name)
+            logger.error("%s: arg '%s' is required but not set", _current_file(context), name)
             _track_arg_default(name, "", state)
             return None
 
@@ -141,8 +142,9 @@ def _apply_declared_arg(arg: DeclareLaunchArgument, context) -> None:
                 return
         except Exception as e:
             logger.warning(
-                "condition on DeclareLaunchArgument '%s' failed to evaluate: %s; "
+                "%s: condition on DeclareLaunchArgument '%s' failed to evaluate: %s; "
                 "assuming condition is satisfied",
+                _current_file(context),
                 arg.name,
                 e,
             )
@@ -153,7 +155,7 @@ def _apply_declared_arg(arg: DeclareLaunchArgument, context) -> None:
 
     if arg.default_value is None:
         if arg.name not in context._launch_configurations:
-            logger.error("arg '%s' is required but not set", arg.name)
+            logger.error("%s: arg '%s' is required but not set", _current_file(context), arg.name)
         _track_arg_default(arg.name, "", context._state)
         return
 

--- a/roscope/entities/actions/env.py
+++ b/roscope/entities/actions/env.py
@@ -31,6 +31,7 @@ import os
 
 from roscope.entities.action import Action
 from roscope.entities.expose import expose_action
+from roscope.entities.helpers import _current_file
 from roscope.entities.parsing import _ActionParser
 from roscope.parsers.entity import Entity
 
@@ -58,7 +59,10 @@ class SetEnvironmentVariable(Action):
 
         name = resolve_value(self._name, context)
         if not name:
-            logger.error("SetEnvironmentVariable: resolved name is empty or None — skipping")
+            logger.error(
+                "%s: SetEnvironmentVariable: resolved name is empty or None — skipping",
+                _current_file(context),
+            )
             return None
         value = resolve_value(self._value, context) or ""
         context.environment[name] = value
@@ -84,20 +88,26 @@ class UnsetEnvironmentVariable(Action):
 
         name = resolve_value(self._name, context)
         if not name:
-            logger.error("UnsetEnvironmentVariable: resolved name is empty or None — skipping")
+            logger.error(
+                "%s: UnsetEnvironmentVariable: resolved name is empty or None — skipping",
+                _current_file(context),
+            )
             return None
         if name in os.environ:
             logger.error(
-                "unset_env: '%s' exists in the process env and cannot be unset. "
+                "%s: unset_env: '%s' exists in the process env and cannot be unset. "
                 'Use SetEnvironmentVariable(name="%s", value="") '
                 "or a scoped group instead",
+                _current_file(context),
                 name,
                 name,
             )
         elif name in context.environment:
             del context.environment[name]
         else:
-            logger.error("unset_env: environment variable '%s' is not set", name)
+            logger.error(
+                "%s: unset_env: environment variable '%s' is not set", _current_file(context), name
+            )
         return None
 
 

--- a/roscope/entities/actions/env.py
+++ b/roscope/entities/actions/env.py
@@ -106,7 +106,9 @@ class UnsetEnvironmentVariable(Action):
             del context.environment[name]
         else:
             logger.error(
-                "%s: unset_env: environment variable '%s' is not set", _current_file(context), name
+                "%s: unset_env: environment variable '%s' is not set",
+                _current_file(context),
+                name,
             )
         return None
 

--- a/roscope/entities/actions/event_handler.py
+++ b/roscope/entities/actions/event_handler.py
@@ -34,6 +34,7 @@ import xml.etree.ElementTree as ET
 
 from roscope.entities.action import Action
 from roscope.entities.expose import expose_action
+from roscope.entities.helpers import _current_file
 from roscope.entities.parsing import _ActionParser
 from roscope.parsers.entity import Entity
 
@@ -280,8 +281,9 @@ class RegisterEventHandler(Action):
 
     def execute(self, context) -> list:
         logger.warning(
-            "RegisterEventHandler encountered — event-handler-driven topology "
+            "%s: RegisterEventHandler encountered — event-handler-driven topology "
             "is not resolved; nodes or actions triggered by events will not "
-            "appear in the resolved output"
+            "appear in the resolved output",
+            _current_file(context),
         )
         return []

--- a/roscope/entities/actions/executable.py
+++ b/roscope/entities/actions/executable.py
@@ -139,22 +139,16 @@ class ExecuteProcess(Action):
             if isinstance(self.cmd, list)
             else [self.cmd]
         )
-        name = (
-            perform_substitutions(context, self.name)
-            if self.name is not None and not isinstance(self.name, str)
-            else self.name
-        )
+        name = context.perform_substitution(self.name) if self.name is not None else None
 
-        resolved = ExecuteProcess(cmd=" ".join(cmd_parts), name=name)
-        resolved.env = self._resolve_env(context)
-        return [resolved]
-
-    def _resolve_env(self, context) -> dict:
         env = env_overrides(context)
         if self.additional_env is not None:
             for k_tokens, v_tokens in self.additional_env.items():
                 env[resolve_value(k_tokens, context) or ""] = resolve_value(v_tokens, context) or ""
-        return env
+        resolved = ExecuteProcess(cmd=" ".join(cmd_parts), name=name)
+        resolved.name = name  # keep as resolved string; __init__ normalizes to list
+        resolved.env = env
+        return [resolved]
 
     def serialize_resolved(self) -> list[ET.Element]:
         if not self.cmd:

--- a/roscope/entities/actions/executable.py
+++ b/roscope/entities/actions/executable.py
@@ -124,7 +124,7 @@ class ExecuteProcess(Action):
         for e in items:
             name_raw = e.get_attr("name", optional=True) or ""
             if not name_raw.strip():
-                logger.error("skipping <env> child with missing or empty name attribute")
+                logger.error("%s: skipping <env> child with missing or empty name attribute", _current_file(parser.ctx))
                 continue
             result[tuple(parser.parse_substitution(name_raw))] = parser.parse_substitution(
                 e.get_attr("value", optional=True) or ""

--- a/roscope/entities/actions/executable.py
+++ b/roscope/entities/actions/executable.py
@@ -157,7 +157,7 @@ class ExecuteProcess(Action):
         elem.set("cmd", self.cmd if isinstance(self.cmd, str) else "")
         if self.name:
             elem.set("name", self.name if isinstance(self.name, str) else "")
-        for k, v in (self.env or {}).items():
+        for k, v in sorted((self.env or {}).items()):
             e = ET.SubElement(elem, "env")
             e.set("name", k)
             e.set("value", v)

--- a/roscope/entities/actions/executable.py
+++ b/roscope/entities/actions/executable.py
@@ -108,18 +108,17 @@ class ExecuteProcess(Action):
         return result_args
 
     @staticmethod
-    def parse_envs(entity: Entity, parser: _ActionParser) -> list:
-        """Extract <env> children as unresolved token pairs."""
+    def parse_envs(entity: Entity, parser: _ActionParser) -> dict:
+        """Extract <env> children as a dict of unresolved token lists."""
         items = entity.get_attr("env", data_type=list, optional=True)
         if not items:
-            return []
-        return [
-            (
-                parser.parse_substitution(e.get_attr("name", optional=True) or ""),
-                parser.parse_substitution(e.get_attr("value", optional=True) or ""),
+            return {}
+        return {
+            tuple(parser.parse_substitution(e.get_attr("name", optional=True) or "")): (
+                parser.parse_substitution(e.get_attr("value", optional=True) or "")
             )
             for e in items
-        ]
+        }
 
     @classmethod
     def parse(cls, entity: Entity, parser: _ActionParser, ignore: list | None = None):
@@ -151,10 +150,9 @@ class ExecuteProcess(Action):
         return [resolved]
 
     def _resolve_env(self, context) -> dict:
-        """Resolve additional_env into a flat env dict, starting from context overrides."""
         env = env_overrides(context)
         if self.additional_env is not None:
-            for k_tokens, v_tokens in self.additional_env:
+            for k_tokens, v_tokens in self.additional_env.items():
                 env[resolve_value(k_tokens, context) or ""] = resolve_value(v_tokens, context) or ""
         return env
 

--- a/roscope/entities/actions/executable.py
+++ b/roscope/entities/actions/executable.py
@@ -157,4 +157,8 @@ class ExecuteProcess(Action):
         elem.set("cmd", self.cmd if isinstance(self.cmd, str) else "")
         if self.name:
             elem.set("name", self.name if isinstance(self.name, str) else "")
+        for k, v in (self.env or {}).items():
+            e = ET.SubElement(elem, "env")
+            e.set("name", k)
+            e.set("value", v)
         return [elem]

--- a/roscope/entities/actions/executable.py
+++ b/roscope/entities/actions/executable.py
@@ -29,16 +29,19 @@ Method definition order follows the official implementation.
 
 from __future__ import annotations
 
+import logging
 import shlex
 import xml.etree.ElementTree as ET
 
 from roscope.entities.action import Action
 from roscope.entities.expose import expose_action
-from roscope.entities.helpers import env_overrides, resolve_value
+from roscope.entities.helpers import _current_file, env_overrides, resolve_value
 from roscope.entities.parsing import _ActionParser
 from roscope.entities.substitution import Substitution, TextSubstitution
 from roscope.entities.utilities import normalize_to_list_of_substitutions, perform_substitutions
 from roscope.parsers.entity import Entity
+
+logger = logging.getLogger("roscope")
 
 
 @expose_action("executable")
@@ -63,7 +66,11 @@ class ExecuteProcess(Action):
         else:
             # From Python shim: list of mixed str/Substitution items
             self.cmd = [normalize_to_list_of_substitutions(x) for x in cmd]
-        self.name = normalize_to_list_of_substitutions(name) if name is not None else name
+        # str → already resolved; anything else → normalize to list[Substitution]
+        if name is None or isinstance(name, str):
+            self.name = name
+        else:
+            self.name = normalize_to_list_of_substitutions(name)
         self.additional_env = kwargs.pop("additional_env", None)
         self.env: dict = {}
 
@@ -113,12 +120,16 @@ class ExecuteProcess(Action):
         items = entity.get_attr("env", data_type=list, optional=True)
         if not items:
             return {}
-        return {
-            tuple(parser.parse_substitution(e.get_attr("name", optional=True) or "")): (
-                parser.parse_substitution(e.get_attr("value", optional=True) or "")
+        result = {}
+        for e in items:
+            name_raw = e.get_attr("name", optional=True) or ""
+            if not name_raw.strip():
+                logger.error("skipping <env> child with missing or empty name attribute")
+                continue
+            result[tuple(parser.parse_substitution(name_raw))] = parser.parse_substitution(
+                e.get_attr("value", optional=True) or ""
             )
-            for e in items
-        }
+        return result
 
     @classmethod
     def parse(cls, entity: Entity, parser: _ActionParser, ignore: list | None = None):
@@ -144,9 +155,15 @@ class ExecuteProcess(Action):
         env = env_overrides(context)
         if self.additional_env is not None:
             for k_tokens, v_tokens in self.additional_env.items():
-                env[resolve_value(k_tokens, context) or ""] = resolve_value(v_tokens, context) or ""
+                k = resolve_value(k_tokens, context) or ""
+                if not k:
+                    logger.error(
+                        "%s: additional_env entry has an empty variable name; skipping",
+                        _current_file(context),
+                    )
+                    continue
+                env[k] = resolve_value(v_tokens, context) or ""
         resolved = ExecuteProcess(cmd=" ".join(cmd_parts), name=name)
-        resolved.name = name  # keep as resolved string; __init__ normalizes to list
         resolved.env = env
         return [resolved]
 

--- a/roscope/entities/actions/executable.py
+++ b/roscope/entities/actions/executable.py
@@ -124,7 +124,10 @@ class ExecuteProcess(Action):
         for e in items:
             name_raw = e.get_attr("name", optional=True) or ""
             if not name_raw.strip():
-                logger.error("%s: skipping <env> child with missing or empty name attribute", _current_file(parser.ctx))
+                logger.error(
+                    "%s: skipping <env> child with missing or empty name attribute",
+                    _current_file(parser.ctx),
+                )
                 continue
             result[tuple(parser.parse_substitution(name_raw))] = parser.parse_substitution(
                 e.get_attr("value", optional=True) or ""

--- a/roscope/entities/actions/group.py
+++ b/roscope/entities/actions/group.py
@@ -83,7 +83,11 @@ class GroupAction(Action):
                     if children:
                         results.extend(children)
                 else:
-                    logger.error("expected Action or Entity, got %s", type(child).__name__)
+                    logger.error(
+                        "%s: expected Action or Entity, got %s",
+                        _current_file(context),
+                        type(child).__name__,
+                    )
         finally:
             if self.scoped:
                 context._pop_environment()

--- a/roscope/entities/actions/group.py
+++ b/roscope/entities/actions/group.py
@@ -25,6 +25,7 @@ import xml.etree.ElementTree as ET
 
 from roscope.entities.action import Action
 from roscope.entities.expose import expose_action
+from roscope.entities.helpers import _current_file
 from roscope.entities.parsing import _ActionParser
 from roscope.parsers.entity import Entity
 
@@ -118,7 +119,12 @@ class OpaqueFunction(Action):
 
                     return _execute_actions(result, context)
             except Exception as e:
-                logger.error("OpaqueFunction failed: %s", e)
+                logger.error(
+                    "OpaqueFunction failed in %s: %s",
+                    _current_file(context),
+                    e,
+                    exc_info=True,
+                )
         return []
 
 
@@ -135,6 +141,8 @@ class TimerAction(Action):
 
     def execute(self, context) -> list:
         logger.error(
-            "TimerAction cannot be statically resolved: context execution timing is not sequential"
+            "%s: TimerAction cannot be statically resolved: "
+            "context execution timing is not sequential",
+            _current_file(context),
         )
         return []

--- a/roscope/entities/actions/include.py
+++ b/roscope/entities/actions/include.py
@@ -27,6 +27,7 @@ from roscope.entities.action import Action
 from roscope.entities.actions.group import GroupAction
 from roscope.entities.actions.marker import ArgComment, SourceMarker
 from roscope.entities.expose import expose_action
+from roscope.entities.helpers import _current_file
 from roscope.entities.parsing import _ActionParser
 from roscope.entities.substitution import Substitution
 from roscope.parsers.entity import Entity
@@ -81,15 +82,19 @@ class IncludeLaunchDescription(Action):
         # Step 1: Resolve file path
         file_path = self._resolve_file_path(context)
         if not file_path:
-            logger.error("include: 'file' attribute resolved to empty string")
+            logger.error(
+                "%s: include: 'file' attribute resolved to empty string", _current_file(context)
+            )
             return []
 
         # Step 2: Validate
         if file_path in self.include_stack:
-            logger.error("circular include detected: %s", file_path)
+            logger.error("%s: circular include detected: %s", _current_file(context), file_path)
             return []
         if len(self.include_stack) > 20:
-            logger.warning("max include depth exceeded for %s", file_path)
+            logger.warning(
+                "%s: max include depth exceeded for %s", _current_file(context), file_path
+            )
             return []
 
         # Step 3: Track include
@@ -103,7 +108,9 @@ class IncludeLaunchDescription(Action):
 
         # Step 5: Check file exists
         if not os.path.isfile(file_path):
-            logger.error("included launch file not found: %s", file_path)
+            logger.error(
+                "%s: included launch file not found: %s", _current_file(context), file_path
+            )
             return []
 
         # Step 6: Resolve children
@@ -140,7 +147,11 @@ class IncludeLaunchDescription(Action):
                 try:
                     self.path = src.perform(context)
                 except Exception as e:
-                    logger.warning("failed to resolve IncludeLaunchDescription source: %s", e)
+                    logger.warning(
+                        "%s: failed to resolve IncludeLaunchDescription source: %s",
+                        _current_file(context),
+                        e,
+                    )
 
         return self.path
 

--- a/roscope/entities/actions/node.py
+++ b/roscope/entities/actions/node.py
@@ -173,13 +173,14 @@ class Node(ExecuteProcess):
         exe = context.perform_substitution(self.executable) or ""
         name = base.name if base else (context.perform_substitution(self.name) or "")
         ns = context.perform_substitution(self.namespace) if self.namespace else None
-        if not name:
+        if not name and exe:
             logger.warning(
-                "%s: node (pkg=%r exec=%r) has no name set; FQN cannot be fully resolved",
+                "%s: node (pkg=%r exec=%r) has no name set; FQN is guessed from executable name",
                 _current_file(context),
                 pkg,
                 exe,
             )
+            name = exe
         if pkg:
             state.track_package(pkg)
 

--- a/roscope/entities/actions/node.py
+++ b/roscope/entities/actions/node.py
@@ -294,6 +294,11 @@ class Node(ExecuteProcess):
             r.set("from", from_)
             r.set("to", to)
 
+        for k, v in (self.env or {}).items():
+            e = ET.SubElement(parent, "env")
+            e.set("name", k)
+            e.set("value", v)
+
         if isinstance(self.env, dict):
             for ename, value in sorted(self.env.items()):
                 e = ET.SubElement(parent, "env")

--- a/roscope/entities/actions/node.py
+++ b/roscope/entities/actions/node.py
@@ -160,6 +160,7 @@ class Node(ExecuteProcess):
         self.respawn_delay = kwargs.get("respawn_delay")
         self.ros_namespace: str | None = None
         self.explicit_namespace: str | None = None
+        self.name_guessed: bool = False
 
     def execute(self, context) -> list:
         """Resolve substitutions and return a clean resolved Node."""
@@ -173,7 +174,8 @@ class Node(ExecuteProcess):
         exe = context.perform_substitution(self.executable) or ""
         name = base.name if base else (context.perform_substitution(self.name) or "")
         ns = context.perform_substitution(self.namespace) if self.namespace else None
-        if not name and exe:
+        name_guessed = not name and bool(exe)
+        if name_guessed:
             logger.warning(
                 "%s: node (pkg=%r exec=%r) has no name set; FQN is guessed from executable name",
                 _current_file(context),
@@ -235,6 +237,7 @@ class Node(ExecuteProcess):
             return context.perform_substitution(raw) or None
 
         resolved = type(self)(package=pkg, executable=exe, name=name or None)
+        resolved.name_guessed = name_guessed
         resolved.ros_namespace = ros_ns
         resolved.explicit_namespace = ns
         resolved.namespace = _ros2_namespace_join(ros_ns, ns) if ns else ros_ns
@@ -259,7 +262,7 @@ class Node(ExecuteProcess):
         elem = ET.Element(self._tag_name)
         elem.set("pkg", self.package)
         elem.set("exec", self.executable or "")
-        if self.name:
+        if self.name and not self.name_guessed:
             elem.set("name", self.name)
         if self.namespace:
             elem.set("namespace", self.namespace)

--- a/roscope/entities/actions/node.py
+++ b/roscope/entities/actions/node.py
@@ -24,14 +24,17 @@ Matching official ``launch_ros.actions.Node`` and ``LifecycleNode``.
 
 from __future__ import annotations
 
+import logging
 import xml.etree.ElementTree as ET
 
 from roscope.entities.actions.executable import ExecuteProcess
 from roscope.entities.expose import expose_action
-from roscope.entities.helpers import _ros2_namespace_join
+from roscope.entities.helpers import _current_file, _ros2_namespace_join
 from roscope.entities.parameter_descriptions import Parameter, ParameterFile
 from roscope.entities.parsing import _ActionParser
 from roscope.parsers.entity import Entity
+
+logger = logging.getLogger("roscope")
 
 
 def _parse_optional(parser: _ActionParser, text: str | None) -> list | None:
@@ -170,6 +173,13 @@ class Node(ExecuteProcess):
         exe = context.perform_substitution(self.executable) or ""
         name = base.name if base else (context.perform_substitution(self.name) or "")
         ns = context.perform_substitution(self.namespace) if self.namespace else None
+        if not name:
+            logger.warning(
+                "%s: node (pkg=%r exec=%r) has no name set; FQN cannot be fully resolved",
+                _current_file(context),
+                pkg,
+                exe,
+            )
         if pkg:
             state.track_package(pkg)
 

--- a/roscope/entities/actions/node.py
+++ b/roscope/entities/actions/node.py
@@ -162,9 +162,13 @@ class Node(ExecuteProcess):
         """Resolve substitutions and return a clean resolved Node."""
         state = context._state
 
+        # Delegate cmd/name/env resolution to parent; cmd is ignored in Node.
+        parent_result = super().execute(context)
+        base = parent_result[0] if parent_result else None
+
         pkg = context.perform_substitution(self.package) or ""
         exe = context.perform_substitution(self.executable) or ""
-        name = context.perform_substitution(self.name) or ""
+        name = base.name if base else (context.perform_substitution(self.name) or "")
         ns = context.perform_substitution(self.namespace) if self.namespace else None
         if pkg:
             state.track_package(pkg)
@@ -211,7 +215,7 @@ class Node(ExecuteProcess):
                 dst = context.perform_substitution(r[1])
                 remaps.append([src or str(r[0]), dst or str(r[1])])
 
-        env = self._resolve_env(context)
+        env = base.env if base else {}
 
         def _resolve_opt(attr):
             raw = getattr(self, attr, None)

--- a/roscope/entities/actions/node.py
+++ b/roscope/entities/actions/node.py
@@ -294,11 +294,6 @@ class Node(ExecuteProcess):
             r.set("from", from_)
             r.set("to", to)
 
-        for k, v in (self.env or {}).items():
-            e = ET.SubElement(parent, "env")
-            e.set("name", k)
-            e.set("value", v)
-
         if isinstance(self.env, dict):
             for ename, value in sorted(self.env.items()):
                 e = ET.SubElement(parent, "env")

--- a/roscope/entities/helpers.py
+++ b/roscope/entities/helpers.py
@@ -17,6 +17,14 @@ from roscope.entities.state import LaunchContext
 logger = logging.getLogger("roscope")
 
 
+def _current_file(context) -> str:
+    """Return the current launch file path for diagnostic messages."""
+    try:
+        return str(context._state.current_source_key())
+    except Exception:
+        return "<unknown>"
+
+
 def env_overrides(context: LaunchContext) -> dict[str, str]:
     """Return env vars explicitly set via SetEnvironmentVariable (overrides only).
 
@@ -183,7 +191,7 @@ def _evaluate_condition(
     try:
         truthy = _is_truthy(resolved)
     except ValueError as e:
-        logger.error("%s", e)
+        logger.error("%s: %s", _current_file(ctx), e)
         return False
     if kind == "If":
         return truthy

--- a/roscope/entities/helpers.py
+++ b/roscope/entities/helpers.py
@@ -20,7 +20,8 @@ logger = logging.getLogger("roscope")
 def _current_file(context) -> str:
     """Return the current launch file path for diagnostic messages."""
     try:
-        return str(context._state.current_source_key())
+        key = context._state.current_source_key()
+        return str(key) if key else "<unknown>"
     except Exception:
         return "<unknown>"
 

--- a/roscope/entities/substitutions/command.py
+++ b/roscope/entities/substitutions/command.py
@@ -57,10 +57,13 @@ class CommandSubstitution(Substitution):
         return cls, {"arguments": arguments}
 
     def perform(self, ctx: LaunchContext) -> str:
+        from roscope.entities.helpers import _current_file
+
         logger.warning(
-            "$(command ...) substitution is not executed by roscope; "
+            "%s: $(command ...) substitution is not executed by roscope; "
             "the literal expression will appear in the resolved output — "
-            "topology depending on this value may be incorrect"
+            "topology depending on this value may be incorrect",
+            _current_file(ctx),
         )
         from roscope.entities.helpers import resolve_substitutions_from_tokens
 

--- a/roscope/entities/substitutions/env.py
+++ b/roscope/entities/substitutions/env.py
@@ -96,7 +96,13 @@ class EnvironmentVariable(Substitution):
         if value is None and self._default is not None:
             value = resolve_substitutions_from_tokens(self._default, ctx)
         if value is None:
-            logger.error("environment variable '%s' is not set; using empty string", name)
+            from roscope.entities.helpers import _current_file
+
+            logger.error(
+                "%s: environment variable '%s' is not set; using empty string",
+                _current_file(ctx),
+                name,
+            )
             return ""
         return str(value)
 

--- a/roscope/entities/substitutions/eval.py
+++ b/roscope/entities/substitutions/eval.py
@@ -68,7 +68,9 @@ class EvalSubstitution(Substitution):
             result = eval(expr)  # noqa: S307
             return str(result)
         except Exception as e:
-            logger.error("$(eval %s) failed: %s", expr, e)
+            from roscope.entities.helpers import _current_file
+
+            logger.error("%s: $(eval %s) failed: %s", _current_file(ctx), expr, e)
             if ctx.preview_mode:
                 return f"$(eval {expr})"
             return ""

--- a/roscope/entities/substitutions/executable_in_package.py
+++ b/roscope/entities/substitutions/executable_in_package.py
@@ -74,7 +74,7 @@ class ExecutableInPackage(Substitution):
         return cls, {"executable": exe_arg, "package": pkg_arg}
 
     def perform(self, ctx: LaunchContext) -> str:
-        from roscope.entities.helpers import resolve_substitutions_from_tokens
+        from roscope.entities.helpers import _current_file, resolve_substitutions_from_tokens
 
         exe = resolve_substitutions_from_tokens(self._executable, ctx)
         pkg = resolve_substitutions_from_tokens(self._package, ctx)
@@ -82,8 +82,9 @@ class ExecutableInPackage(Substitution):
 
         if ctx._state.preview_mode:
             logger.error(
-                "$(exec-in-pkg %s %s) requires a built install tree and cannot be "
+                "%s: $(exec-in-pkg %s %s) requires a built install tree and cannot be "
                 "resolved in preview mode; build the workspace first",
+                _current_file(ctx),
                 exe,
                 pkg,
             )
@@ -105,7 +106,8 @@ class ExecutableInPackage(Substitution):
 
         if package_prefix is None:
             logger.error(
-                "$(exec-in-pkg %s %s): package '%s' not found in AMENT_PREFIX_PATH",
+                "%s: $(exec-in-pkg %s %s): package '%s' not found in AMENT_PREFIX_PATH",
+                _current_file(ctx),
                 exe,
                 pkg,
                 pkg,
@@ -115,7 +117,8 @@ class ExecutableInPackage(Substitution):
         libexec_dir = os.path.join(package_prefix, "lib", pkg)
         if not os.path.isdir(libexec_dir):
             logger.error(
-                "$(exec-in-pkg %s %s): libexec directory '%s' does not exist",
+                "%s: $(exec-in-pkg %s %s): libexec directory '%s' does not exist",
+                _current_file(ctx),
                 exe,
                 pkg,
                 libexec_dir,
@@ -130,7 +133,8 @@ class ExecutableInPackage(Substitution):
             return candidate
 
         logger.error(
-            "$(exec-in-pkg %s %s): executable '%s' not found in '%s'",
+            "%s: $(exec-in-pkg %s %s): executable '%s' not found in '%s'",
+            _current_file(ctx),
             exe,
             pkg,
             exe,

--- a/roscope/entities/substitutions/find_pkg_prefix.py
+++ b/roscope/entities/substitutions/find_pkg_prefix.py
@@ -67,10 +67,13 @@ class FindPackagePrefixSubstitution(Substitution):
             # In preview mode, packages are resolved to source workspace directories
             # which have no install prefix structure.  $(find-pkg-prefix) requires a
             # built install tree — it cannot be resolved statically from source.
+            from roscope.entities.helpers import _current_file
+
             logger.error(
-                "$(find-pkg-prefix %s) is not supported in preview mode "
+                "%s: $(find-pkg-prefix %s) is not supported in preview mode "
                 "(source directories have no install prefix); "
                 "build the workspace first or avoid this substitution in preview",
+                _current_file(ctx),
                 pkg,
             )
             raise LookupError(f"$(find-pkg-prefix {pkg}) unavailable in preview mode")
@@ -89,9 +92,12 @@ class FindPackagePrefixSubstitution(Substitution):
             if marker.exists():
                 return prefix_str
 
+        from roscope.entities.helpers import _current_file
+
         logger.error(
-            "$(find-pkg-prefix %s): package not found in AMENT index "
+            "%s: $(find-pkg-prefix %s): package not found in AMENT index "
             "(AMENT_PREFIX_PATH=%r); source /opt/ros/<distro>/setup.bash",
+            _current_file(ctx),
             pkg,
             ament_prefix_path or "<unset>",
         )

--- a/roscope/entities/substitutions/launch_config.py
+++ b/roscope/entities/substitutions/launch_config.py
@@ -94,7 +94,9 @@ class LaunchConfiguration(Substitution):
         if self._default is not None:
             return str(self._default)
         # Not found
-        logger.error("undefined variable: %s", name)
+        from roscope.entities.helpers import _current_file
+
+        logger.error("%s: undefined variable: %s", _current_file(context), name)
         return f"$(var {name})"
 
     def __str__(self):

--- a/roscope/resolver.py
+++ b/roscope/resolver.py
@@ -53,6 +53,7 @@ from roscope.entities.conditions import (
     UnlessCondition,
 )
 from roscope.entities.descriptions import ComposableNode
+from roscope.entities.helpers import _current_file
 from roscope.entities.launch_description import LaunchDescription as _LaunchDescription
 from roscope.entities.launch_description_sources import (
     AnyLaunchDescriptionSource,
@@ -480,7 +481,7 @@ def _resolve_element(
         if isinstance(action, Action):
             return action.visit(ctx) or []
         return []
-    logger.warning("unknown element: <%s>", tag)
+    logger.warning("%s: unknown element: <%s>", _current_file(ctx), tag)
     return []
 
 
@@ -491,7 +492,9 @@ def _execute_actions(actions, context) -> list:
         if action is None:
             continue
         if not isinstance(action, Action):
-            logger.error("expected Action, got %s", type(action).__name__)
+            logger.error(
+                "%s: expected Action, got %s", _current_file(context), type(action).__name__
+            )
             continue
         children = action.visit(context)
         if children:

--- a/roscope/visualizer/graph.py
+++ b/roscope/visualizer/graph.py
@@ -153,14 +153,6 @@ class _GraphBuilder:
         ns = action.namespace or "/"
         # Fallback to executable is best-effort; users should set name= explicitly.
         name = action.name or action.executable or ""
-        if not action.name:
-            logger.warning(
-                "Node in package %r has no name set (executable=%r, namespace=%r); "
-                "FQN is best-effort.",
-                action.package,
-                action.executable,
-                ns,
-            )
         fqn = f"{ns.rstrip('/')}/{name}"
         nid = self._uid("node", action.package, fqn)
 

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -138,7 +138,11 @@ def test_node_env_children() -> None:
     resolved = node.execute(ctx)
     elems = resolved[0].serialize_resolved()
     assert len(elems) == 1
-    env_map = {e.get("name"): e.get("value") for e in elems[0].findall("env")}
+    env_elems = elems[0].findall("env")
+    # Regression: env must not appear twice (duplicate loop bug)
+    env_names = [e.get("name") for e in env_elems]
+    assert env_names.count("ROSCOPE_TEST_VAR") == 1
+    env_map = {e.get("name"): e.get("value") for e in env_elems}
     assert env_map.get("ROSCOPE_TEST_VAR") == "world"
 
 

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -122,6 +122,26 @@ def test_executable() -> None:
     assert "echo hello" in snippet
 
 
+def test_executable_env_children() -> None:
+    ctx = _make_ctx()
+    ep = ExecuteProcess(cmd=["echo"], additional_env={"ROSCOPE_TEST_VAR": "hello"})
+    resolved = ep.execute(ctx)
+    elems = resolved[0].serialize_resolved()
+    assert len(elems) == 1
+    env_map = {e.get("name"): e.get("value") for e in elems[0].findall("env")}
+    assert env_map.get("ROSCOPE_TEST_VAR") == "hello"
+
+
+def test_node_env_children() -> None:
+    ctx = _make_ctx()
+    node = Node(package="p", executable="e", additional_env={"ROSCOPE_TEST_VAR": "world"})
+    resolved = node.execute(ctx)
+    elems = resolved[0].serialize_resolved()
+    assert len(elems) == 1
+    env_map = {e.get("name"): e.get("value") for e in elems[0].findall("env")}
+    assert env_map.get("ROSCOPE_TEST_VAR") == "world"
+
+
 # ─── Source group nesting ────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

- All `logger.warning`/`logger.error` calls in `entities/` and `resolver.py` now prepend `_current_file(context)` so every diagnostic identifies the launch file it originates from
- `additional_env` aligned with the official dict-only API; `Node.execute()` delegates env/name resolution to `super().execute()` instead of calling `_resolve_env` directly
- `<env>` children are now emitted in `<executable>` and `<node>` serialization (removed a pre-existing duplicate loop that caused each env entry to appear twice)
- Node without an explicit name now falls back to the executable name for FQN computation, emits a warning, sets `name_guessed=True`, and omits the `name` attribute from serialized XML
- Version bumped to 0.2.2

## Test plan

- `python3 -m pytest tests/ -v` — all 235 tests pass
- `test_executable_env_children` and `test_node_env_children` added; `test_node_env_children` includes a regression assertion against the duplicate-env bug