### PR TITLE
Search whole package share dir for top-level launch file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - run: pip install ruff
+      - run: pip install "ruff>=0.4,<0.16"
       - run: ruff check
       - run: ruff format --check
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
 dev = [
     "pytest>=7.0",
     "pytest-cov>=4.0",
-    "ruff>=0.4",
+    "ruff>=0.4,<0.16",
     "mypy>=1.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "roscope"
-version = "0.3.0"
+version = "0.3.1"
 description = "ROS 2 launch resolver and build orchestrator"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/roscope/locator.py
+++ b/roscope/locator.py
@@ -16,6 +16,41 @@ from roscope.types import Lockfile, PackageLock
 logger = logging.getLogger(__name__)
 
 
+class MultipleLaunchFilesError(LookupError):
+    """Raised when a file name matches more than one file in a share directory."""
+
+    def __init__(self, msg: str, paths: list[Path]) -> None:
+        super().__init__(msg)
+        self.paths = paths
+
+
+def find_share_file(share_dir: Path, file_name: str) -> Path:
+    """Search every directory under ``share_dir`` for a file named exactly ``file_name``.
+
+    Mirrors upstream ``ros2launch``'s ``get_share_file_path_from_package``.
+
+    :raises FileNotFoundError: if no file named ``file_name`` exists under ``share_dir``.
+    :raises MultipleLaunchFilesError: if more than one file matches.
+    """
+    matches = [
+        Path(root) / name
+        for root, _dirs, files in os.walk(share_dir)
+        for name in files
+        if name == file_name
+    ]
+    if not matches:
+        raise FileNotFoundError(
+            f"file '{file_name}' was not found in the share directory '{share_dir}'"
+        )
+    if len(matches) > 1:
+        raise MultipleLaunchFilesError(
+            f"file '{file_name}' was found more than once in the share directory "
+            f"'{share_dir}': {[str(p) for p in matches]}",
+            matches,
+        )
+    return matches[0]
+
+
 class PackageLocator:
     """Resolves package names to file system paths."""
 
@@ -198,19 +233,26 @@ class PackageLocator:
         return None
 
     def locate_launch_file(self, package: str, launcher: str) -> Path | None:
-        """Search filesystem for an existing launch file."""
+        """Search the package's share directory for a file named ``launcher``.
+
+        Returns ``None`` if the package itself cannot be located.
+
+        :raises MultipleLaunchFilesError: if ``launcher`` matches more than one file.
+        """
         pkg_share = self.locate_package_share(package)
         if pkg_share is None:
             return None
-        launch_path = pkg_share / "launch" / launcher
-        return launch_path if launch_path.exists() else None
+        try:
+            return find_share_file(pkg_share, launcher)
+        except FileNotFoundError:
+            return None
 
     def locate_launch_file_or_err(self, package: str, launcher: str) -> Path:
         """Like :meth:`locate_launch_file` but raises on failure."""
         result = self.locate_launch_file(package, launcher)
         if result is not None:
             return result
-        raise LookupError(f"launch file not found: {package}/launch/{launcher}")
+        raise FileNotFoundError(f"launch file '{launcher}' not found in package '{package}'")
 
     # ========================================================================
     # Bulk lookups

--- a/roscope/orchestrator.py
+++ b/roscope/orchestrator.py
@@ -13,7 +13,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 from roscope.fetcher import FetchOptions
-from roscope.locator import PackageLocator
+from roscope.locator import MultipleLaunchFilesError, PackageLocator, find_share_file
 from roscope.types import (
     DependencyKind,
     FileDependency,
@@ -292,7 +292,42 @@ def resolve_launch_recursive(
             "Packages not in the lockfile will not be found via AMENT_PREFIX_PATH."
         )
 
-    share_path = Path("launch") / launcher
+    if workflow_options.preview:
+        if lockfile.packages.get(package) is not None:
+            if not _ensure_package_fetched(
+                lockfile, package, fetch_dir, options, result, fetched_packages, failed_repos
+            ):
+                return result
+            pkg_share = locator.resolve_package_share(package)
+        else:
+            from roscope.fetcher import ensure_package_available
+
+            pkg_share = ensure_package_available(
+                package, None, None, rosdep_fallback=workflow_options.rosdep_fallback
+            )
+        if pkg_share is None:
+            logger.error("package '%s' not found in lockfile or AMENT_PREFIX_PATH", package)
+            return result
+    else:
+        pkg_share = locator.locate_install_share(package)
+        if pkg_share is None:
+            logger.error(
+                "package '%s' not found in AMENT_PREFIX_PATH; "
+                "run 'colcon build' first, or use --preview to resolve from source workspace",
+                package,
+            )
+            return result
+
+    try:
+        file_path = find_share_file(pkg_share, launcher)
+    except FileNotFoundError:
+        logger.error("launch file '%s' not found in package '%s'", launcher, package)
+        return result
+    except MultipleLaunchFilesError as e:
+        logger.error(str(e))
+        return result
+
+    share_path = file_path.relative_to(pkg_share)
     _resolve_python_file_recursive(
         lockfile,
         locator,

--- a/tests/test_locator.py
+++ b/tests/test_locator.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import tempfile
 from pathlib import Path
 
-from roscope.locator import PackageLocator
+import pytest
+
+from roscope.locator import MultipleLaunchFilesError, PackageLocator, find_share_file
 from roscope.types import Lockfile, PackageLock, RepoLock
 
 
@@ -142,3 +144,36 @@ def test_locate_launch_file_not_found() -> None:
     with tempfile.TemporaryDirectory() as tmp:
         locator = PackageLocator.with_workspace(tmp)
         assert locator.locate_launch_file("nonexistent", "test.launch.xml") is None
+
+
+def test_locate_launch_file_in_subdirectory() -> None:
+    """A launch file nested under a subdirectory of launch/ is still found.
+
+    Matches upstream ros2launch, which searches the whole package share
+    directory rather than only ``launch/`` directly.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        pkg_dir = Path(tmp) / "my_pkg"
+        nested_dir = pkg_dir / "launch" / "components"
+        nested_dir.mkdir(parents=True)
+        (pkg_dir / "package.xml").write_text("<package></package>")
+        (nested_dir / "test.launch.xml").write_text("<launch></launch>")
+        locator = PackageLocator.with_workspace(tmp)
+        result = locator.locate_launch_file("my_pkg", "test.launch.xml")
+        assert result == nested_dir / "test.launch.xml"
+
+
+def test_find_share_file_multiple_matches_raises() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        share_dir = Path(tmp)
+        (share_dir / "a").mkdir()
+        (share_dir / "b").mkdir()
+        (share_dir / "a" / "dup.launch.xml").write_text("<launch></launch>")
+        (share_dir / "b" / "dup.launch.xml").write_text("<launch></launch>")
+        with pytest.raises(MultipleLaunchFilesError):
+            find_share_file(share_dir, "dup.launch.xml")
+
+
+def test_find_share_file_not_found_raises() -> None:
+    with tempfile.TemporaryDirectory() as tmp, pytest.raises(FileNotFoundError):
+        find_share_file(Path(tmp), "missing.launch.xml")


### PR DESCRIPTION
## Summary
- `roscope resolve <package> <launcher>` only looked for the file directly under `<package>/launch/<launcher>`, so files nested in subdirectories (e.g. autoware_launch's `launch/components/tier4_perception_component.launch.xml`) were never found, even though `ros2 launch autoware_launch tier4_perception_component.launch.xml` resolves them fine.
- Matches upstream `ros2launch`'s `get_share_file_path_from_package`: walk the entire package share directory looking for a file with the given name, raising if it's not found or if it matches more than one file.
- Applies to both preview mode (source workspace) and install mode (AMENT_PREFIX_PATH).

## Test plan
- [x] `python3 -m pytest tests/ -v`
- [x] `ruff check && ruff format --check`
- [x] Manually reproduced the original failure and confirmed the fix against the autoware_launch example (`roscope resolve -d autoware_launch tier4_perception_component.launch.xml --preview`)